### PR TITLE
Update Cloud API with new manifest generation process

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -124,10 +124,10 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 	options := distro.ImageOptions{Size: 0}
 	if cr.OSTree != nil {
 		options.OSTree = &ostree.ImageOptions{
-			URL:           cr.OSTree.URL,
-			ImageRef:      cr.OSTree.Ref,
-			FetchChecksum: cr.OSTree.Parent,
-			RHSM:          cr.OSTree.RHSM,
+			URL:       cr.OSTree.URL,
+			ImageRef:  cr.OSTree.Ref,
+			ParentRef: cr.OSTree.Parent,
+			RHSM:      cr.OSTree.RHSM,
 		}
 	} else {
 		// use default OSTreeRef for image type

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -192,7 +193,7 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 			Blueprint:    cr.Blueprint,
 			OSTree:       cr.OSTree,
 		}
-		err = save(mf, packageSpecs, containerSpecs, request, path, filename)
+		err = save(mf, packageSpecs, containerSpecs, commitSpecs, request, path, filename)
 		return
 	}
 	return job
@@ -276,17 +277,23 @@ func resolvePipelineContainers(containerSources map[string][]container.SourceSpe
 	return containerSpecs, nil
 }
 
+func resolveCommit(commitSource ostree.SourceSpec) ostree.CommitSpec {
+	// "resolve" ostree commits by hashing the URL + ref to create a
+	// realistic-looking commit ID in a deterministic way
+	checksum := fmt.Sprintf("%x", sha256.Sum256([]byte(commitSource.URL+commitSource.Ref)))
+	return ostree.CommitSpec{
+		Ref:      commitSource.Ref,
+		URL:      commitSource.URL,
+		Checksum: checksum,
+	}
+}
+
 func resolvePipelineCommits(commitSources map[string][]ostree.SourceSpec) map[string][]ostree.CommitSpec {
-	// "resolve" ostree commits by copying the source specs into commit specs
 	commits := make(map[string][]ostree.CommitSpec, len(commitSources))
 	for name, commitSources := range commitSources {
 		commitSpecs := make([]ostree.CommitSpec, len(commitSources))
 		for idx, commitSource := range commitSources {
-			commitSpecs[idx] = ostree.CommitSpec{
-				Ref:      commitSource.Ref,
-				URL:      commitSource.URL,
-				Checksum: commitSource.Parent,
-			}
+			commitSpecs[idx] = resolveCommit(commitSource)
 		}
 		commits[name] = commitSpecs
 	}
@@ -307,15 +314,16 @@ func depsolve(cacheDir string, packageSets map[string][]rpmmd.PackageSet, d dist
 	return depsolvedSets, nil
 }
 
-func save(ms manifest.OSBuildManifest, pkgs map[string][]rpmmd.PackageSpec, containers map[string][]container.Spec, cr composeRequest, path, filename string) error {
+func save(ms manifest.OSBuildManifest, pkgs map[string][]rpmmd.PackageSpec, containers map[string][]container.Spec, commits map[string][]ostree.CommitSpec, cr composeRequest, path, filename string) error {
 	data := struct {
 		ComposeRequest composeRequest                 `json:"compose-request"`
 		Manifest       manifest.OSBuildManifest       `json:"manifest"`
 		RPMMD          map[string][]rpmmd.PackageSpec `json:"rpmmd"`
 		Containers     map[string][]container.Spec    `json:"containers,omitempty"`
+		OSTreeCommits  map[string][]ostree.CommitSpec `json:"ostree-commits,omitempty"`
 		NoImageInfo    bool                           `json:"no-image-info"`
 	}{
-		cr, ms, pkgs, containers, true,
+		cr, ms, pkgs, containers, commits, true,
 	}
 	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -129,11 +129,6 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 			ParentRef: cr.OSTree.Parent,
 			RHSM:      cr.OSTree.RHSM,
 		}
-	} else {
-		// use default OSTreeRef for image type
-		options.OSTree = &ostree.ImageOptions{
-			ImageRef: imgType.OSTreeRef(),
-		}
 	}
 
 	// add RHSM fact to detect changes

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -158,7 +158,7 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 			return
 		}
 
-		packageSpecs, err := depsolve(cacheDir, manifest.Content.PackageSets, distribution, archName)
+		packageSpecs, err := depsolve(cacheDir, manifest.GetPackageSetChains(), distribution, archName)
 		if err != nil {
 			err = fmt.Errorf("[%s] depsolve failed: %s", filename, err.Error())
 			return
@@ -172,12 +172,12 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 			bp = blueprint.Blueprint(*cr.Blueprint)
 		}
 
-		containerSpecs, err := resolvePipelineContainers(manifest.Content.Containers, archName)
+		containerSpecs, err := resolvePipelineContainers(manifest.GetContainerSourceSpecs(), archName)
 		if err != nil {
 			return fmt.Errorf("[%s] container resolution failed: %s", filename, err.Error())
 		}
 
-		commitSpecs := resolvePipelineCommits(manifest.Content.OSTreeCommits)
+		commitSpecs := resolvePipelineCommits(manifest.GetOSTreeSourceSpecs())
 
 		mf, err := manifest.Serialize(packageSpecs, containerSpecs, commitSpecs)
 		if err != nil {

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -64,7 +64,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 						repos[archStr], 0)
 					assert.NoError(t, err)
 
-					for _, set := range manifest.Content.PackageSets {
+					for _, set := range manifest.GetPackageSetChains() {
 						_, err = solver.Depsolve(set)
 						assert.NoError(t, err)
 					}
@@ -101,7 +101,7 @@ func TestDepsolvePackageSets(t *testing.T) {
 
 	manifestSource, _, err := qcow2Image.Manifest(&blueprint.Blueprint{Packages: []blueprint.Package{{Name: "bind"}}}, distro.ImageOptions{}, x86Repos, 0)
 	require.Nilf(t, err, "failed to initialise manifest for %q image type of %q/%q distro/arch", qcow2ImageTypeName, cs9.Name(), platform.ARCH_X86_64.String())
-	imagePkgSets := manifestSource.Content.PackageSets
+	imagePkgSets := manifestSource.GetPackageSetChains()
 
 	gotPackageSpecsSets := make(map[string][]rpmmd.PackageSpec, len(imagePkgSets))
 	for name, pkgSet := range imagePkgSets {

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -58,9 +58,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 						},
 						distro.ImageOptions{
 							OSTree: &ostree.ImageOptions{
-								URL:           "foo",
-								ImageRef:      "bar",
-								FetchChecksum: "baz",
+								URL: "https://example.com", // required by some image types
 							},
 						},
 						repos[archStr], 0)

--- a/cmd/osbuild-package-sets/main.go
+++ b/cmd/osbuild-package-sets/main.go
@@ -57,5 +57,5 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	_ = encoder.Encode(manifest.Content.PackageSets)
+	_ = encoder.Encode(manifest.GetPackageSetChains())
 }

--- a/cmd/osbuild-package-sets/main.go
+++ b/cmd/osbuild-package-sets/main.go
@@ -50,9 +50,9 @@ func main() {
 	encoder.SetIndent("", "  ")
 	options := distro.ImageOptions{
 		OSTree: &ostree.ImageOptions{
-			URL:           "foo",
-			ImageRef:      "bar",
-			FetchChecksum: "baz",
+			URL:       "foo",
+			ImageRef:  "bar",
+			ParentRef: "baz",
 		},
 	}
 	manifest, _, err := image.Manifest(&blueprint.Blueprint{}, options, nil, 0)

--- a/cmd/osbuild-package-sets/main.go
+++ b/cmd/osbuild-package-sets/main.go
@@ -50,9 +50,7 @@ func main() {
 	encoder.SetIndent("", "  ")
 	options := distro.ImageOptions{
 		OSTree: &ostree.ImageOptions{
-			URL:       "foo",
-			ImageRef:  "bar",
-			ParentRef: "baz",
+			URL: "https://example.com", // required by some image types
 		},
 	}
 	manifest, _, err := image.Manifest(&blueprint.Blueprint{}, options, nil, 0)

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -201,7 +201,7 @@ func main() {
 	}
 
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
-	for name, pkgSet := range manifest.Content.PackageSets {
+	for name, pkgSet := range manifest.GetPackageSetChains() {
 		res, err := solver.Depsolve(pkgSet)
 		if err != nil {
 			panic("Could not depsolve: " + err.Error())
@@ -209,8 +209,9 @@ func main() {
 		depsolvedSets[name] = res
 	}
 
-	containers := make(map[string][]container.Spec, len(manifest.Content.Containers))
-	for name, sourceSpecs := range manifest.Content.Containers {
+	containerSources := manifest.GetContainerSourceSpecs()
+	containers := make(map[string][]container.Spec, len(containerSources))
+	for name, sourceSpecs := range containerSources {
 		containerSpecs, err := resolveContainers(sourceSpecs, arch.Name())
 		if err != nil {
 			panic("Could not resolve containers: " + err.Error())
@@ -219,8 +220,9 @@ func main() {
 	}
 
 	// "resolve" ostree commits by copying the source specs into commit specs
-	commits := make(map[string][]ostree.CommitSpec, len(manifest.Content.OSTreeCommits))
-	for name, commitSources := range manifest.Content.OSTreeCommits {
+	commitSources := manifest.GetOSTreeSourceSpecs()
+	commits := make(map[string][]ostree.CommitSpec, len(commitSources))
+	for name, commitSources := range commitSources {
 		commitSpecs := make([]ostree.CommitSpec, len(commitSources))
 		for idx, commitSource := range commitSources {
 			commitSpecs[idx] = ostree.CommitSpec{

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -173,11 +173,6 @@ func main() {
 		}
 	}
 
-	if composeRequest.OSTree.Ref == "" {
-		// use default OSTreeRef for image type
-		composeRequest.OSTree.Ref = imageType.OSTreeRef()
-	}
-
 	options := distro.ImageOptions{
 		Size: imageType.Size(0),
 		OSTree: &ostree.ImageOptions{

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -181,9 +181,9 @@ func main() {
 	options := distro.ImageOptions{
 		Size: imageType.Size(0),
 		OSTree: &ostree.ImageOptions{
-			ImageRef:      composeRequest.OSTree.Ref,
-			FetchChecksum: composeRequest.OSTree.Parent,
-			URL:           composeRequest.OSTree.URL,
+			ImageRef:  composeRequest.OSTree.Ref,
+			ParentRef: composeRequest.OSTree.Parent,
+			URL:       composeRequest.OSTree.URL,
 		},
 	}
 

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -48,7 +48,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 		fmt.Fprintf(os.Stderr, "could not clean dnf cache: %s", err.Error())
 	}
 
-	bytes, err := manifest.Serialize(packageSpecs, nil)
+	bytes, err := manifest.Serialize(packageSpecs, nil, nil)
 	if err != nil {
 		panic("failed to serialize manifest: " + err.Error())
 	}

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -28,7 +28,7 @@ func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d di
 	}
 	pkgSpecSets := make(map[string][]rpmmd.PackageSpec)
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), a.Name(), d.Name(), cacheDir)
-	for name, packages := range manifest.Content.PackageSets {
+	for name, packages := range manifest.GetPackageSetChains() {
 		res, err := solver.Depsolve(packages)
 		if err != nil {
 			panic(err)

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -36,7 +36,7 @@ func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d di
 		pkgSpecSets[name] = res
 	}
 
-	mf, err := manifest.Serialize(pkgSpecSets, nil)
+	mf, err := manifest.Serialize(pkgSpecSets, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -114,7 +114,7 @@ func (s *Server) enqueueCompose(distribution distro.Distro, bp blueprint.Bluepri
 	}
 
 	depsolveJobID, err := s.workers.EnqueueDepsolve(&worker.DepsolveJob{
-		PackageSets:      manifestSource.Content.PackageSets,
+		PackageSets:      manifestSource.GetPackageSetChains(),
 		ModulePlatformID: distribution.ModulePlatformID(),
 		Arch:             ir.arch.Name(),
 		Releasever:       distribution.Releasever(),
@@ -125,7 +125,7 @@ func (s *Server) enqueueCompose(distribution distro.Distro, bp blueprint.Bluepri
 	dependencies := []uuid.UUID{depsolveJobID}
 
 	var containerResolveJobID uuid.UUID
-	containerSources := manifestSource.Content.Containers
+	containerSources := manifestSource.GetContainerSourceSpecs()
 	if len(containerSources) > 1 {
 		// only one pipeline can embed containers
 		pipelines := make([]string, 0, len(containerSources))
@@ -161,7 +161,7 @@ func (s *Server) enqueueCompose(distribution distro.Distro, bp blueprint.Bluepri
 	}
 
 	var ostreeResolveJobID uuid.UUID
-	commitSources := manifestSource.Content.OSTreeCommits
+	commitSources := manifestSource.GetOSTreeSourceSpecs()
 	if len(commitSources) > 1 {
 		// only one pipeline can specify an ostree commit for content
 		pipelines := make([]string, 0, len(commitSources))
@@ -234,7 +234,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 		}
 
 		depsolveJobID, err := s.workers.EnqueueDepsolve(&worker.DepsolveJob{
-			PackageSets:      manifestSource.Content.PackageSets,
+			PackageSets:      manifestSource.GetPackageSetChains(),
 			ModulePlatformID: distribution.ModulePlatformID(),
 			Arch:             ir.arch.Name(),
 			Releasever:       distribution.Releasever(),
@@ -245,7 +245,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 		dependencies := []uuid.UUID{depsolveJobID}
 
 		var containerResolveJobID uuid.UUID
-		containerSources := manifestSource.Content.Containers
+		containerSources := manifestSource.GetContainerSourceSpecs()
 		if len(containerSources) > 1 {
 			// only one pipeline can embed containers
 			pipelines := make([]string, 0, len(containerSources))
@@ -281,7 +281,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 		}
 
 		var ostreeResolveJobID uuid.UUID
-		commitSources := manifestSource.Content.OSTreeCommits
+		commitSources := manifestSource.GetOSTreeSourceSpecs()
 		if len(commitSources) > 1 {
 			// only one pipeline can specify an ostree commit for content
 			pipelines := make([]string, 0, len(commitSources))
@@ -476,7 +476,7 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 		// the container embedding, so we need to get it from the manifest
 		// content field. There should be only one.
 		var containerEmbedPipeline string
-		for name := range manifestSource.Content.Containers {
+		for name := range manifestSource.GetContainerSourceSpecs() {
 			containerEmbedPipeline = name
 			break
 		}
@@ -519,7 +519,7 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 		// ostree commits, so we need to get it from the manifest content
 		// field. There should be only one.
 		var ostreeCommitPipeline string
-		for name := range manifestSource.Content.OSTreeCommits {
+		for name := range manifestSource.GetOSTreeSourceSpecs() {
 			ostreeCommitPipeline = name
 			break
 		}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -507,7 +507,8 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 	} else {
 		panic(fmt.Sprintf("ImageType %q does not define payload pipelines - this is a programming error", imageType.Name()))
 	}
-	ms, err := manifest.Serialize(depsolveResults.PackageSpecs, map[string][]container.Spec{payloadPipelineName: containerSpecs})
+	// TODO: resolve ostree source spec from manifest content and pass here.
+	ms, err := manifest.Serialize(depsolveResults.PackageSpecs, map[string][]container.Spec{payloadPipelineName: containerSpecs}, nil)
 
 	jobResult.Manifest = ms
 }

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -482,9 +482,9 @@ func generateManifest(ctx context.Context, workers *worker.Server, depsolveJobID
 		}
 
 		options.OSTree = &ostree.ImageOptions{
-			ImageRef:      result.Specs[0].Ref,
-			FetchChecksum: result.Specs[0].Checksum,
-			URL:           result.Specs[0].URL,
+			ImageRef:  result.Specs[0].Ref,
+			ParentRef: result.Specs[0].Checksum,
+			URL:       result.Specs[0].URL,
 		}
 	}
 

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -323,6 +323,8 @@ func TestKojiCompose(t *testing.T) {
 		},
 	}
 
+	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"":{"url":""}}}}}`
+	expectedManifests := `{"manifests":[` + emptyManifest + `,` + emptyManifest + `],"kind":"ComposeManifests"}`
 	for idx, c := range cases {
 		name, version, release := "foo", "1", "2"
 		t.Run(fmt.Sprintf("Test case #%d", idx), func(t *testing.T) {
@@ -459,7 +461,7 @@ func TestKojiCompose(t *testing.T) {
 			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v", finalizeID), ``, http.StatusOK, c.composeStatus, `href`, `id`)
 
 			// get the manifests
-			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v/manifests", finalizeID), ``, http.StatusOK, `{"manifests":[{"version":"2","pipelines":[],"sources":{}},{"version":"2","pipelines":[],"sources":{}}],"kind":"ComposeManifests"}`, `href`, `id`)
+			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v/manifests", finalizeID), ``, http.StatusOK, expectedManifests, `href`, `id`)
 
 			// get the logs
 			test.TestRoute(t, handler, false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v/logs", finalizeID), ``, http.StatusOK, `{"kind":"ComposeLogs"}`, `koji`, `image_builds`, `href`, `id`)

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -585,19 +585,16 @@ func TestComposeStatusSuccess(t *testing.T) {
 		]
 	}`, jobId, jobId))
 
+	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"":{"url":""}}}}}`
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v/manifests", jobId), ``, http.StatusOK, fmt.Sprintf(`
 	{
 		"href": "/api/image-builder-composer/v2/composes/%v/manifests",
 		"id": "%v",
 		"kind": "ComposeManifests",
 		"manifests": [
-			{
-				"version": "2",
-				"pipelines": [],
-				"sources": {}
-			}
+			%s
 		]
-	}`, jobId, jobId), "details")
+	}`, jobId, jobId, emptyManifest), "details")
 }
 
 func TestComposeStatusFailure(t *testing.T) {

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -56,9 +56,9 @@ func TestImageType_PackageSetsChains(t *testing.T) {
 					}
 					options := distro.ImageOptions{
 						OSTree: &ostree.ImageOptions{
-							URL:           "foo",
-							ImageRef:      "bar",
-							FetchChecksum: "baz",
+							URL:       "foo",
+							ImageRef:  "bar",
+							ParentRef: "baz",
 						},
 					}
 					manifest, _, err := imageType.Manifest(&bp, options, nil, 0)
@@ -147,9 +147,9 @@ func TestImageTypePipelineNames(t *testing.T) {
 
 					// Add ostree options for image types that require them
 					options.OSTree = &ostree.ImageOptions{
-						ImageRef:      imageType.OSTreeRef(),
-						URL:           "https://example.com/repo",
-						FetchChecksum: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+						ImageRef:  imageType.OSTreeRef(),
+						URL:       "https://example.com/repo",
+						ParentRef: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 					}
 
 					// Pipelines that require package sets will fail if none
@@ -461,9 +461,9 @@ func TestPipelineRepositories(t *testing.T) {
 
 							// Add ostree options for image types that require them
 							options.OSTree = &ostree.ImageOptions{
-								ImageRef:      imageType.OSTreeRef(),
-								URL:           "https://example.com/repo",
-								FetchChecksum: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+								ImageRef:  imageType.OSTreeRef(),
+								URL:       "https://example.com/repo",
+								ParentRef: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 							}
 
 							repos := tCase.repos

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -61,7 +61,7 @@ func TestImageType_PackageSetsChains(t *testing.T) {
 					}
 					manifest, _, err := imageType.Manifest(&bp, options, nil, 0)
 					require.NoError(t, err)
-					imagePkgSets := manifest.Content.PackageSets
+					imagePkgSets := manifest.GetPackageSetChains()
 					for packageSetName := range imageType.PackageSetsChains() {
 						_, ok := imagePkgSets[packageSetName]
 						if !ok {
@@ -168,8 +168,9 @@ func TestImageTypePipelineNames(t *testing.T) {
 
 					containers := make(map[string][]container.Spec, 0)
 					// "resolve" ostree commits by copying the source specs into commit specs
-					commits := make(map[string][]ostree.CommitSpec, len(m.Content.OSTreeCommits))
-					for name, commitSources := range m.Content.OSTreeCommits {
+					ostreeSources := m.GetOSTreeSourceSpecs()
+					commits := make(map[string][]ostree.CommitSpec, len(ostreeSources))
+					for name, commitSources := range ostreeSources {
 						commitSpecs := make([]ostree.CommitSpec, len(commitSources))
 						for idx, commitSource := range commitSources {
 							commitSpecs[idx] = ostree.CommitSpec{
@@ -463,7 +464,7 @@ func TestPipelineRepositories(t *testing.T) {
 							repos := tCase.repos
 							manifest, _, err := imageType.Manifest(&bp, options, repos, 0)
 							require.NoError(err)
-							packageSets := manifest.Content.PackageSets
+							packageSets := manifest.GetPackageSetChains()
 
 							var globals stringSet
 							if len(tCase.result["*"]) > 0 {

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -56,9 +56,7 @@ func TestImageType_PackageSetsChains(t *testing.T) {
 					}
 					options := distro.ImageOptions{
 						OSTree: &ostree.ImageOptions{
-							URL:       "foo",
-							ImageRef:  "bar",
-							ParentRef: "baz",
+							URL: "https://example.com", // required by some image types
 						},
 					}
 					manifest, _, err := imageType.Manifest(&bp, options, nil, 0)
@@ -147,9 +145,7 @@ func TestImageTypePipelineNames(t *testing.T) {
 
 					// Add ostree options for image types that require them
 					options.OSTree = &ostree.ImageOptions{
-						ImageRef:  imageType.OSTreeRef(),
-						URL:       "https://example.com/repo",
-						ParentRef: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+						URL: "https://example.com",
 					}
 
 					// Pipelines that require package sets will fail if none
@@ -461,9 +457,7 @@ func TestPipelineRepositories(t *testing.T) {
 
 							// Add ostree options for image types that require them
 							options.OSTree = &ostree.ImageOptions{
-								ImageRef:  imageType.OSTreeRef(),
-								URL:       "https://example.com/repo",
-								ParentRef: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+								URL: "https://example.com",
 							}
 
 							repos := tCase.repos

--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -171,7 +171,20 @@ func TestImageTypePipelineNames(t *testing.T) {
 					assert.NoError(err)
 
 					containers := make(map[string][]container.Spec, 0)
-					mf, err := m.Serialize(packageSets, containers)
+					// "resolve" ostree commits by copying the source specs into commit specs
+					commits := make(map[string][]ostree.CommitSpec, len(m.Content.OSTreeCommits))
+					for name, commitSources := range m.Content.OSTreeCommits {
+						commitSpecs := make([]ostree.CommitSpec, len(commitSources))
+						for idx, commitSource := range commitSources {
+							commitSpecs[idx] = ostree.CommitSpec{
+								Ref:      commitSource.Ref,
+								URL:      commitSource.URL,
+								Checksum: commitSource.Parent,
+							}
+						}
+						commits[name] = commitSpecs
+					}
+					mf, err := m.Serialize(packageSets, containers, commits)
 					assert.NoError(err)
 					pm := new(manifest)
 					err = json.Unmarshal(mf, pm)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -112,11 +112,6 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 					}
 				}
 			}
-			if ostreeOptions == nil { // set image type default if not specified in request
-				ostreeOptions = &ostree.ImageOptions{
-					ImageRef: imageType.OSTreeRef(),
-				}
-			}
 
 			options := distro.ImageOptions{
 				Size:   imageType.Size(0),
@@ -217,9 +212,7 @@ var knownKernels = []string{"kernel", "kernel-debug", "kernel-rt"}
 // Returns the number of known kernels in the package list
 func kernelCount(imgType distro.ImageType, bp blueprint.Blueprint) int {
 	ostreeOptions := &ostree.ImageOptions{
-		URL:       "foo",
-		ImageRef:  "bar",
-		ParentRef: "baz",
+		URL: "https://example.com", // required by some image types
 	}
 	manifest, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: ostreeOptions}, nil, 0)
 	if err != nil {

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -172,7 +172,7 @@ func getImageTypePkgSpecSets(imageType distro.ImageType, bp blueprint.Blueprint,
 	if err != nil {
 		panic("Could not generate manifest for package sets: " + err.Error())
 	}
-	imgPackageSets := manifest.Content.PackageSets
+	imgPackageSets := manifest.GetPackageSetChains()
 
 	solver := dnfjson.NewSolver(imageType.Arch().Distro().ModulePlatformID(),
 		imageType.Arch().Distro().Releasever(),
@@ -207,7 +207,7 @@ func kernelCount(imgType distro.ImageType, bp blueprint.Blueprint) int {
 	if err != nil {
 		panic(err)
 	}
-	sets := manifest.Content.PackageSets
+	sets := manifest.GetPackageSetChains()
 
 	// Use a map to count unique kernels in a package set. If the same kernel
 	// name appears twice, it will only be installed once, so we only count it

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -105,10 +105,10 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 			if ref := imageType.OSTreeRef(); ref != "" {
 				if tt.ComposeRequest.OSTree != nil {
 					ostreeOptions = &ostree.ImageOptions{
-						ImageRef:      tt.ComposeRequest.OSTree.Ref,
-						FetchChecksum: tt.ComposeRequest.OSTree.Parent,
-						URL:           tt.ComposeRequest.OSTree.URL,
-						RHSM:          tt.ComposeRequest.OSTree.RHSM,
+						ImageRef:  tt.ComposeRequest.OSTree.Ref,
+						ParentRef: tt.ComposeRequest.OSTree.Parent,
+						URL:       tt.ComposeRequest.OSTree.URL,
+						RHSM:      tt.ComposeRequest.OSTree.RHSM,
 					}
 				}
 			}
@@ -217,9 +217,9 @@ var knownKernels = []string{"kernel", "kernel-debug", "kernel-rt"}
 // Returns the number of known kernels in the package list
 func kernelCount(imgType distro.ImageType, bp blueprint.Blueprint) int {
 	ostreeOptions := &ostree.ImageOptions{
-		URL:           "foo",
-		ImageRef:      "bar",
-		FetchChecksum: "baz",
+		URL:       "foo",
+		ImageRef:  "bar",
+		ParentRef: "baz",
 	}
 	manifest, _, err := imgType.Manifest(&bp, distro.ImageOptions{OSTree: ostreeOptions}, nil, 0)
 	if err != nil {

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -256,7 +256,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, 0)
 					assert.NoError(t, err)
-					buildPkgs := manifest.Content.PackageSets["build"]
+					buildPkgs := manifest.GetPackageSetChains()["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -200,6 +200,7 @@ func liveImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewLiveImage()
@@ -225,6 +226,7 @@ func containerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 	img := image.NewBaseContainer()
 
@@ -244,6 +246,7 @@ func imageInstallerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewImageInstaller()
@@ -288,6 +291,7 @@ func iotCommitImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
@@ -318,6 +322,7 @@ func iotContainerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
@@ -350,7 +355,8 @@ func iotInstallerImage(workload workload.Workload,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
+	_ []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
@@ -391,8 +397,9 @@ func iotRawImage(workload workload.Workload,
 	t *imageType,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
-	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
+	_ map[string]rpmmd.PackageSet,
+	_ []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	commit := ostree.CommitSpec{

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -294,7 +294,12 @@ func iotCommitImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeArchive(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)
@@ -316,7 +321,12 @@ func iotContainerImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeContainer(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], containers, customizations)

--- a/internal/distro/fedora/imagetype.go
+++ b/internal/distro/fedora/imagetype.go
@@ -237,10 +237,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, err
 	}
 
-	manifest.Content.PackageSets = manifest.GetPackageSetChains()
-	manifest.Content.Containers = manifest.GetContainerSourceSpecs()
-	manifest.Content.OSTreeCommits = manifest.GetOSTreeSourceSpecs()
-
 	return &manifest, warnings, err
 }
 

--- a/internal/distro/fedora/imagetype.go
+++ b/internal/distro/fedora/imagetype.go
@@ -249,14 +249,14 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return nil, fmt.Errorf("embedding containers is not supported for %s on %s", t.name, t.arch.distro.name)
 	}
 
-	ostreeChecksum := ""
+	ostreeURL := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.ParentRef
+		ostreeURL = options.OSTree.URL
 	}
 
 	if t.bootISO && t.rpmOstree {
-		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-		if ostreeChecksum == "" {
+		// ostree-based ISOs require a URL from which to pull a payload commit
+		if ostreeURL == "" {
 			return nil, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 	}

--- a/internal/distro/fedora/imagetype.go
+++ b/internal/distro/fedora/imagetype.go
@@ -213,8 +213,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
-	// TODO: set commit ref when needed
 	var ostreeCommit *ostree.SourceSpec
+	if options.OSTree != nil {
+		ostreeCommit = &ostree.SourceSpec{
+			URL:    options.OSTree.URL,
+			Ref:    options.OSTree.ImageRef,
+			Parent: options.OSTree.ParentRef,
+		}
+	}
 
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case

--- a/internal/distro/fedora/imagetype.go
+++ b/internal/distro/fedora/imagetype.go
@@ -251,7 +251,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 	ostreeChecksum := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.FetchChecksum
+		ostreeChecksum = options.OSTree.ParentRef
 	}
 
 	if t.bootISO && t.rpmOstree {

--- a/internal/distro/rhel7/distro_test.go
+++ b/internal/distro/rhel7/distro_test.go
@@ -119,7 +119,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, 0)
 					assert.NoError(t, err)
-					buildPkgs := manifest.Content.PackageSets["build"]
+					buildPkgs := manifest.GetPackageSetChains()["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/internal/distro/rhel7/images.go
+++ b/internal/distro/rhel7/images.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/users"
@@ -222,6 +223,7 @@ func liveImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewLiveImage()

--- a/internal/distro/rhel7/imagetype.go
+++ b/internal/distro/rhel7/imagetype.go
@@ -220,10 +220,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, err
 	}
 
-	manifest.Content.PackageSets = overridePackageNamesInSets(manifest.GetPackageSetChains())
-	manifest.Content.Containers = manifest.GetContainerSourceSpecs()
-	manifest.Content.OSTreeCommits = manifest.GetOSTreeSourceSpecs()
-
 	return &manifest, warnings, err
 }
 

--- a/internal/distro/rhel7/imagetype.go
+++ b/internal/distro/rhel7/imagetype.go
@@ -11,6 +11,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/environment"
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/pathpolicy"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -20,7 +21,7 @@ import (
 
 type packageSetFunc func(t *imageType) rpmmd.PackageSet
 
-type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
+type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, ostreeCommit *ostree.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
 type imageType struct {
 	arch               *architecture
@@ -161,7 +162,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	// merge package sets that appear in the image type with the package sets
 	// of the same name from the distro and arch
 	staticPackageSets := make(map[string]rpmmd.PackageSet)
-
 	for name, getter := range t.packageSets {
 		staticPackageSets[name] = getter(t)
 	}
@@ -202,6 +202,9 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
+	// TODO: set commit ref when needed
+	var ostreeCommit *ostree.SourceSpec
+
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -210,7 +213,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	if t.image == nil {
 		return nil, nil, nil
 	}
-	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, rng)
+	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, ostreeCommit, rng)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/distro/rhel7/imagetype.go
+++ b/internal/distro/rhel7/imagetype.go
@@ -202,9 +202,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
-	// TODO: set commit ref when needed
-	var ostreeCommit *ostree.SourceSpec
-
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -213,7 +210,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	if t.image == nil {
 		return nil, nil, nil
 	}
-	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, ostreeCommit, rng)
+	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, nil, rng)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/distro/rhel7/imagetype.go
+++ b/internal/distro/rhel7/imagetype.go
@@ -215,6 +215,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, err
 	}
 	manifest := manifest.New()
+	manifest.PackageSelector = packageSelector
 	_, err = img.InstantiateManifest(&manifest, repos, t.arch.distro.runner, rng)
 	if err != nil {
 		return nil, nil, err
@@ -223,29 +224,19 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	return &manifest, warnings, err
 }
 
-// Runs overridePackageNames() on each package set's Include and Exclude list
-// and replaces package names.
-func overridePackageNamesInSets(chains map[string][]rpmmd.PackageSet) map[string][]rpmmd.PackageSet {
-	pkgSetChains := make(map[string][]rpmmd.PackageSet)
-	for name, chain := range chains {
-		cc := make([]rpmmd.PackageSet, len(chain))
-		for idx := range chain {
-			cc[idx] = rpmmd.PackageSet{
-				Include:      overridePackageNames(chain[idx].Include),
-				Exclude:      overridePackageNames(chain[idx].Exclude),
-				Repositories: chain[idx].Repositories,
-			}
+func packageSelector(chain []rpmmd.PackageSet) []rpmmd.PackageSet {
+	cc := make([]rpmmd.PackageSet, len(chain))
+	for idx := range chain {
+		cc[idx] = rpmmd.PackageSet{
+			Include:      pkgRename(chain[idx].Include),
+			Exclude:      pkgRename(chain[idx].Exclude),
+			Repositories: chain[idx].Repositories,
 		}
-		pkgSetChains[name] = cc
 	}
-	return pkgSetChains
+	return cc
 }
 
-// Resolve packages to their distro-specific name. This function is a temporary
-// workaround to the issue of having packages specified outside of distros (in
-// internal/manifest/os.go), which should be distro agnostic. In the future,
-// this should be handled more generally.
-func overridePackageNames(packages []string) []string {
+func pkgRename(packages []string) []string {
 	for idx := range packages {
 		switch packages[idx] {
 		case "python3-pyyaml":

--- a/internal/distro/rhel8/distro_test.go
+++ b/internal/distro/rhel8/distro_test.go
@@ -287,7 +287,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, 0)
 					assert.NoError(t, err)
-					buildPkgs := manifest.Content.PackageSets["build"]
+					buildPkgs := manifest.GetPackageSetChains()["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/internal/distro/rhel8/images.go
+++ b/internal/distro/rhel8/images.go
@@ -317,7 +317,12 @@ func edgeCommitImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeArchive(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], options, containers, customizations)
@@ -339,7 +344,12 @@ func edgeContainerImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeContainer(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], options, containers, customizations)

--- a/internal/distro/rhel8/images.go
+++ b/internal/distro/rhel8/images.go
@@ -227,6 +227,7 @@ func liveImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewLiveImage()
@@ -253,6 +254,7 @@ func imageInstallerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewImageInstaller()
@@ -291,6 +293,7 @@ func tarImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewArchive()
@@ -311,6 +314,7 @@ func edgeCommitImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
@@ -344,6 +348,7 @@ func edgeContainerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
@@ -379,7 +384,8 @@ func edgeInstallerImage(workload workload.Workload,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
+	_ []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
@@ -424,8 +430,9 @@ func edgeRawImage(workload workload.Workload,
 	t *imageType,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
-	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
+	_ map[string]rpmmd.PackageSet,
+	_ []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	commit := ostree.CommitSpec{
@@ -470,7 +477,8 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	customizations *blueprint.Customizations,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
-	containers []container.SourceSpec,
+	_ []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	commit := ostree.CommitSpec{

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -318,7 +318,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 	ostreeChecksum := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.FetchChecksum
+		ostreeChecksum = options.OSTree.ParentRef
 	}
 
 	if t.bootISO && t.rpmOstree {

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -316,14 +316,14 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, fmt.Errorf("embedding containers is not supported for %s on %s", t.name, t.arch.distro.name)
 	}
 
-	ostreeChecksum := ""
+	ostreeURL := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.ParentRef
+		ostreeURL = options.OSTree.URL
 	}
 
 	if t.bootISO && t.rpmOstree {
-		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-		if ostreeChecksum == "" {
+		// ostree-based ISOs require a URL from which to pull a payload commit
+		if ostreeURL == "" {
 			return warnings, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
@@ -363,8 +363,8 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	}
 
 	if t.name == "edge-raw-image" {
-		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-		if ostreeChecksum == "" {
+		// ostree-based bootable images require a URL from which to pull a payload commit
+		if ostreeURL == "" {
 			return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
 		}
 

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -235,8 +235,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
-	// TODO: set commit ref when needed
 	var ostreeCommit *ostree.SourceSpec
+	if options.OSTree != nil {
+		ostreeCommit = &ostree.SourceSpec{
+			URL:    options.OSTree.URL,
+			Ref:    options.OSTree.ImageRef,
+			Parent: options.OSTree.ParentRef,
+		}
+	}
 
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -262,10 +262,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, err
 	}
 
-	manifest.Content.PackageSets = overridePackageNamesInSets(manifest.GetPackageSetChains())
-	manifest.Content.Containers = manifest.GetContainerSourceSpecs()
-	manifest.Content.OSTreeCommits = manifest.GetOSTreeSourceSpecs()
-
 	return &manifest, warnings, err
 }
 

--- a/internal/distro/rhel8/imagetype.go
+++ b/internal/distro/rhel8/imagetype.go
@@ -17,6 +17,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/oscap"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/pathpolicy"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -39,7 +40,7 @@ const (
 	blueprintPkgsKey = "blueprint"
 )
 
-type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
+type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, ostreeCommit *ostree.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
 type packageSetFunc func(t *imageType) rpmmd.PackageSet
 
@@ -194,7 +195,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	// merge package sets that appear in the image type with the package sets
 	// of the same name from the distro and arch
 	staticPackageSets := make(map[string]rpmmd.PackageSet)
-
 	for name, getter := range t.packageSets {
 		staticPackageSets[name] = getter(t)
 	}
@@ -235,6 +235,9 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
+	// TODO: set commit ref when needed
+	var ostreeCommit *ostree.SourceSpec
+
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
@@ -243,7 +246,7 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	if t.image == nil {
 		return nil, nil, nil
 	}
-	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, rng)
+	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, ostreeCommit, rng)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/distro/rhel9/distro_test.go
+++ b/internal/distro/rhel9/distro_test.go
@@ -272,7 +272,7 @@ func TestImageType_BuildPackages(t *testing.T) {
 					}
 					manifest, _, err := itStruct.Manifest(&blueprint.Blueprint{}, distro.ImageOptions{}, nil, 0)
 					assert.NoError(t, err)
-					buildPkgs := manifest.Content.PackageSets["build"]
+					buildPkgs := manifest.GetPackageSetChains()["build"]
 					assert.NotNil(t, buildPkgs)
 					assert.Len(t, buildPkgs, 1)
 					assert.ElementsMatch(t, buildPackages[archLabel], buildPkgs[0].Include)

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -254,7 +254,12 @@ func edgeCommitImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeArchive(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], options, containers, customizations)
@@ -280,7 +285,12 @@ func edgeContainerImage(workload workload.Workload,
 	parent *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
-	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
+	commitRef := t.OSTreeRef()
+	if options.OSTree != nil && options.OSTree.ImageRef != "" {
+		// overridden by user options
+		commitRef = options.OSTree.ImageRef
+	}
+	img := image.NewOSTreeContainer(commitRef)
 
 	img.Platform = t.platform
 	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], options, containers, customizations)

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -224,6 +224,7 @@ func liveImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewLiveImage()
@@ -250,6 +251,7 @@ func edgeCommitImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeArchive(options.OSTree.ImageRef)
@@ -286,6 +288,7 @@ func edgeContainerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewOSTreeContainer(options.OSTree.ImageRef)
@@ -325,6 +328,7 @@ func edgeInstallerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	d := t.arch.distro
@@ -376,6 +380,7 @@ func edgeRawImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	commit := ostree.CommitSpec{
@@ -438,6 +443,7 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	commit := ostree.CommitSpec{
@@ -527,6 +533,7 @@ func imageInstallerImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewImageInstaller()
@@ -570,6 +577,7 @@ func tarImage(workload workload.Workload,
 	options distro.ImageOptions,
 	packageSets map[string]rpmmd.PackageSet,
 	containers []container.SourceSpec,
+	_ *ostree.SourceSpec,
 	rng *rand.Rand) (image.ImageKind, error) {
 
 	img := image.NewArchive()

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -238,8 +238,14 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
-	// TODO: set commit ref when needed
 	var ostreeCommit *ostree.SourceSpec
+	if options.OSTree != nil {
+		ostreeCommit = &ostree.SourceSpec{
+			URL:    options.OSTree.URL,
+			Ref:    options.OSTree.ImageRef,
+			Parent: options.OSTree.ParentRef,
+		}
+	}
 
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -287,14 +287,14 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 		return warnings, fmt.Errorf("embedding containers is not supported for %s on %s", t.name, t.arch.distro.name)
 	}
 
-	ostreeChecksum := ""
+	ostreeURL := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.ParentRef
+		ostreeURL = options.OSTree.URL
 	}
 
 	if t.bootISO && t.rpmOstree {
-		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-		if ostreeChecksum == "" {
+		// ostree-based ISOs require a URL from which to pull a payload commit
+		if ostreeURL == "" {
 			return warnings, fmt.Errorf("boot ISO image type %q requires specifying a URL from which to retrieve the OSTree commit", t.name)
 		}
 
@@ -345,8 +345,8 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 	}
 
 	if t.name == "edge-raw-image" {
-		// check the checksum instead of the URL, because the URL should have been used to resolve the checksum and we need both
-		if ostreeChecksum == "" {
+		// ostree-based bootable images require a URL from which to pull a payload commit
+		if ostreeURL == "" {
 			return warnings, fmt.Errorf("edge raw images require specifying a URL from which to retrieve the OSTree commit")
 		}
 

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -289,7 +289,7 @@ func (t *imageType) checkOptions(bp *blueprint.Blueprint, options distro.ImageOp
 
 	ostreeChecksum := ""
 	if options.OSTree != nil {
-		ostreeChecksum = options.OSTree.FetchChecksum
+		ostreeChecksum = options.OSTree.ParentRef
 	}
 
 	if t.bootISO && t.rpmOstree {

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -17,6 +17,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/oscap"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/pathpolicy"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -42,7 +43,7 @@ const (
 	blueprintPkgsKey = "blueprint"
 )
 
-type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
+type imageFunc func(workload workload.Workload, t *imageType, customizations *blueprint.Customizations, options distro.ImageOptions, packageSets map[string]rpmmd.PackageSet, containers []container.SourceSpec, ostreeCommit *ostree.SourceSpec, rng *rand.Rand) (image.ImageKind, error)
 
 type packageSetFunc func(t *imageType) rpmmd.PackageSet
 
@@ -197,7 +198,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 	// merge package sets that appear in the image type with the package sets
 	// of the same name from the distro and arch
 	staticPackageSets := make(map[string]rpmmd.PackageSet)
-
 	for name, getter := range t.packageSets {
 		staticPackageSets[name] = getter(t)
 	}
@@ -238,12 +238,15 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		containerSources[idx] = container.SourceSpec(bp.Containers[idx])
 	}
 
+	// TODO: set commit ref when needed
+	var ostreeCommit *ostree.SourceSpec
+
 	source := rand.NewSource(seed)
 	// math/rand is good enough in this case
 	/* #nosec G404 */
 	rng := rand.New(source)
 
-	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, rng)
+	img, err := t.image(w, t, bp.Customizations, options, staticPackageSets, containerSources, ostreeCommit, rng)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/distro/rhel9/imagetype.go
+++ b/internal/distro/rhel9/imagetype.go
@@ -262,10 +262,6 @@ func (t *imageType) Manifest(bp *blueprint.Blueprint,
 		return nil, nil, err
 	}
 
-	manifest.Content.PackageSets = manifest.GetPackageSetChains()
-	manifest.Content.Containers = manifest.GetContainerSourceSpecs()
-	manifest.Content.OSTreeCommits = manifest.GetOSTreeSourceSpecs()
-
 	return &manifest, warnings, err
 }
 

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -1,14 +1,17 @@
 package test_distro
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distroregistry"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
+	dnfjson_mock "github.com/osbuild/osbuild-composer/internal/mocks/dnfjson"
 	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
@@ -235,7 +238,7 @@ func (t *TestImageType) Manifest(b *blueprint.Blueprint, options distro.ImageOpt
 		bpPkgs = b.GetPackages()
 	}
 
-	var ostreeSources map[string][]ostree.SourceSpec
+	var ostreeSources []ostree.SourceSpec
 	if defaultRef := t.OSTreeRef(); defaultRef != "" {
 		// ostree image type
 		ostreeSource := ostree.SourceSpec{ // init with default
@@ -250,39 +253,42 @@ func (t *TestImageType) Manifest(b *blueprint.Blueprint, options distro.ImageOpt
 			ostreeSource.Parent = options.OSTree.ParentRef
 			ostreeSource.RHSM = options.OSTree.RHSM
 		}
-		ostreeSources = map[string][]ostree.SourceSpec{
-			osPkgsKey: {ostreeSource},
-		}
+		ostreeSources = []ostree.SourceSpec{ostreeSource}
 	}
 
-	ret := manifest.Manifest{
-		Content: manifest.Content{
-			OSTreeCommits: ostreeSources,
-			PackageSets: map[string][]rpmmd.PackageSet{
-				buildPkgsKey: {{
-					Include: []string{
-						"dep-package1",
-						"dep-package2",
-						"dep-package3",
-					},
-					Repositories: repos,
-				}},
-				blueprintPkgsKey: {{
-					Include:      bpPkgs,
-					Repositories: repos,
-				}},
-				osPkgsKey: {{
-					Include: []string{
-						"dep-package1",
-						"dep-package2",
-						"dep-package3",
-					},
-					Repositories: repos,
-				}},
+	buildPackages := []rpmmd.PackageSet{{
+		Include: []string{
+			"dep-package1",
+			"dep-package2",
+			"dep-package3",
+		},
+		Repositories: repos,
+	}}
+	osPackages := []rpmmd.PackageSet{
+		{
+			Include:      bpPkgs,
+			Repositories: repos,
+		},
+		{
+			Include: []string{
+				"dep-package1",
+				"dep-package2",
+				"dep-package3",
 			},
+			Repositories: repos,
 		},
 	}
-	return &ret, nil, nil
+
+	m := &manifest.Manifest{}
+
+	manifest.NewContentTest(m, buildPkgsKey, buildPackages, nil, nil)
+	manifest.NewContentTest(m, osPkgsKey, osPackages, nil, ostreeSources)
+
+	m.Content.PackageSets = m.GetPackageSetChains()
+	m.Content.Containers = m.GetContainerSourceSpecs()
+	m.Content.OSTreeCommits = m.GetOSTreeSourceSpecs()
+
+	return m, nil, nil
 }
 
 // newTestDistro returns a new instance of TestDistro with the
@@ -384,4 +390,43 @@ func NewRegistry() *distroregistry.Registry {
 // New2 returns new instance of TestDistro named "test-distro-2".
 func New2() *TestDistro {
 	return newTestDistro(TestDistro2Name, TestDistro2ModulePlatformID, TestDistro2Releasever)
+}
+
+// ResolveContent transforms content source specs into resolved specs for serialization.
+// For packages, it uses the dnfjson_mock.BaseDeps() every time, but retains
+// the map keys from the input.
+// For ostree commits it hashes the URL+Ref to create a checksum.
+func ResolveContent(pkgs map[string][]rpmmd.PackageSet, containers map[string][]container.SourceSpec, commits map[string][]ostree.SourceSpec) (map[string][]rpmmd.PackageSpec, map[string][]container.Spec, map[string][]ostree.CommitSpec) {
+
+	pkgSpecs := make(map[string][]rpmmd.PackageSpec, len(pkgs))
+	for name := range pkgs {
+		pkgSpecs[name] = dnfjson_mock.BaseDeps()
+	}
+
+	containerSpecs := make(map[string][]container.Spec, len(containers))
+	for name := range containers {
+		containerSpecs[name] = make([]container.Spec, len(containers[name]))
+		for idx := range containers[name] {
+			containerSpecs[name][idx] = container.Spec{
+				Source:    containers[name][idx].Source,
+				TLSVerify: containers[name][idx].TLSVerify,
+				LocalName: containers[name][idx].Name,
+			}
+		}
+	}
+
+	commitSpecs := make(map[string][]ostree.CommitSpec, len(commits))
+	for name := range commits {
+		commitSpecs[name] = make([]ostree.CommitSpec, len(commits[name]))
+		for idx := range commits[name] {
+			commitSpecs[name][idx] = ostree.CommitSpec{
+				Ref:      commits[name][idx].Ref,
+				URL:      commits[name][idx].URL,
+				Checksum: fmt.Sprintf("%x", sha256.Sum256([]byte(commits[name][idx].URL+commits[name][idx].Ref))),
+			}
+			fmt.Printf("Test distro spec: %+v\n", commitSpecs[name][idx])
+		}
+	}
+
+	return pkgSpecs, containerSpecs, commitSpecs
 }

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -284,10 +284,6 @@ func (t *TestImageType) Manifest(b *blueprint.Blueprint, options distro.ImageOpt
 	manifest.NewContentTest(m, buildPkgsKey, buildPackages, nil, nil)
 	manifest.NewContentTest(m, osPkgsKey, osPackages, nil, ostreeSources)
 
-	m.Content.PackageSets = m.GetPackageSetChains()
-	m.Content.Containers = m.GetContainerSourceSpecs()
-	m.Content.OSTreeCommits = m.GetOSTreeSourceSpecs()
-
 	return m, nil, nil
 }
 

--- a/internal/image/ostree_archive.go
+++ b/internal/image/ostree_archive.go
@@ -20,9 +20,9 @@ type OSTreeArchive struct {
 	Environment      environment.Environment
 	Workload         workload.Workload
 
-	// OSTreeParent specifies an optional parent commit for the new commit
-	// being built.
-	OSTreeParent *ostree.CommitSpec
+	// OSTreeParent specifies the source for an optional parent commit for the
+	// new commit being built.
+	OSTreeParent *ostree.SourceSpec
 
 	// OSTreeRef is the ref of the commit that will be built.
 	OSTreeRef string

--- a/internal/image/ostree_archive.go
+++ b/internal/image/ostree_archive.go
@@ -19,10 +19,16 @@ type OSTreeArchive struct {
 	OSCustomizations manifest.OSCustomizations
 	Environment      environment.Environment
 	Workload         workload.Workload
-	OSTreeParent     *ostree.CommitSpec
-	OSTreeRef        string
-	OSVersion        string
-	Filename         string
+
+	// OSTreeParent specifies an optional parent commit for the new commit
+	// being built.
+	OSTreeParent *ostree.CommitSpec
+
+	// OSTreeRef is the ref of the commit that will be built.
+	OSTreeRef string
+
+	OSVersion string
+	Filename  string
 }
 
 func NewOSTreeArchive(ref string) *OSTreeArchive {

--- a/internal/image/ostree_container.go
+++ b/internal/image/ostree_container.go
@@ -15,12 +15,18 @@ import (
 
 type OSTreeContainer struct {
 	Base
-	Platform               platform.Platform
-	OSCustomizations       manifest.OSCustomizations
-	Environment            environment.Environment
-	Workload               workload.Workload
-	OSTreeRef              string
-	OSTreeParent           *ostree.CommitSpec
+	Platform         platform.Platform
+	OSCustomizations manifest.OSCustomizations
+	Environment      environment.Environment
+	Workload         workload.Workload
+
+	// OSTreeParent specifies the source for an optional parent commit for the
+	// new commit being built.
+	OSTreeParent *ostree.SourceSpec
+
+	// OSTreeRef is the ref of the commit that will be built.
+	OSTreeRef string
+
 	OSVersion              string
 	ExtraContainerPackages rpmmd.PackageSet // FIXME: this is never read
 	ContainerLanguage      string

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -31,7 +31,7 @@ type OSTreeInstaller struct {
 	OSVersion     string
 	Release       string
 
-	Commit ostree.CommitSpec
+	Commit ostree.SourceSpec
 
 	Filename string
 
@@ -40,7 +40,7 @@ type OSTreeInstaller struct {
 	AdditionalDrivers         []string
 }
 
-func NewOSTreeInstaller(commit ostree.CommitSpec) *OSTreeInstaller {
+func NewOSTreeInstaller(commit ostree.SourceSpec) *OSTreeInstaller {
 	return &OSTreeInstaller{
 		Base:   NewBase("ostree-installer"),
 		Commit: commit,
@@ -120,7 +120,7 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KSPath = kspath
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 
-	isoTreePipeline.OSTree = &img.Commit
+	isoTreePipeline.OSTreeCommitSource = &img.Commit
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline, isoLabel)

--- a/internal/image/ostree_raw.go
+++ b/internal/image/ostree_raw.go
@@ -25,7 +25,7 @@ type OSTreeRawImage struct {
 	Users  []users.User
 	Groups []users.Group
 
-	Commit ostree.CommitSpec
+	CommitSource ostree.SourceSpec
 
 	SysrootReadOnly bool
 
@@ -44,15 +44,15 @@ type OSTreeRawImage struct {
 	Files       []*fsnode.File
 }
 
-func NewOSTreeRawImage(commit ostree.CommitSpec) *OSTreeRawImage {
+func NewOSTreeRawImage(commit ostree.SourceSpec) *OSTreeRawImage {
 	return &OSTreeRawImage{
-		Base:   NewBase("ostree-raw-image"),
-		Commit: commit,
+		Base:         NewBase("ostree-raw-image"),
+		CommitSource: commit,
 	}
 }
 
 func ostreeCompressedImagePipelines(img *OSTreeRawImage, m *manifest.Manifest, buildPipeline *manifest.Build) *manifest.XZ {
-	osPipeline := manifest.NewOSTreeDeployment(m, buildPipeline, img.Commit, img.OSName, img.Ignition, img.Platform)
+	osPipeline := manifest.NewOSTreeDeployment(m, buildPipeline, img.CommitSource, img.OSName, img.Ignition, img.Platform)
 	osPipeline.PartitionTable = img.PartitionTable
 	osPipeline.Remote = img.Remote
 	osPipeline.KernelOptionsAppend = img.KernelOptionsAppend

--- a/internal/manifest/anaconda.go
+++ b/internal/manifest/anaconda.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/users"
@@ -141,7 +142,7 @@ func (p *Anaconda) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *Anaconda) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec) {
+func (p *Anaconda) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/internal/manifest/build.go
+++ b/internal/manifest/build.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/runner"
 )
@@ -68,7 +69,7 @@ func (p *Build) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *Build) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec) {
+func (p *Build) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/internal/manifest/commit.go
+++ b/internal/manifest/commit.go
@@ -49,15 +49,21 @@ func (p *OSTreeCommit) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: "/repo"}))
 
-	var parent string
-	if p.treePipeline.OSTreeParent != nil {
-		parent = p.treePipeline.OSTreeParent.Checksum
+	var parentID string
+	treeCommits := p.treePipeline.getOSTreeCommits()
+	if len(treeCommits) > 0 {
+		if len(treeCommits) > 1 {
+			panic("multiple ostree commit specs found; this is a programming error")
+		}
+		parentCommit := &treeCommits[0]
+		parentID = parentCommit.Checksum
 	}
+
 	pipeline.AddStage(osbuild.NewOSTreeCommitStage(
 		&osbuild.OSTreeCommitStageOptions{
 			Ref:       p.ref,
 			OSVersion: p.OSVersion,
-			Parent:    parent,
+			Parent:    parentID,
 		},
 		p.treePipeline.Name()),
 	)

--- a/internal/manifest/commit_server_tree.go
+++ b/internal/manifest/commit_server_tree.go
@@ -6,6 +6,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
@@ -83,7 +84,7 @@ func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec) {
+func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/internal/manifest/coreos_installer.go
+++ b/internal/manifest/coreos_installer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/fdo"
 	"github.com/osbuild/osbuild-composer/internal/ignition"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
@@ -122,7 +123,7 @@ func (p *CoreOSInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec) {
+func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/internal/manifest/empty.go
+++ b/internal/manifest/empty.go
@@ -1,0 +1,98 @@
+package manifest
+
+import (
+	"github.com/osbuild/osbuild-composer/internal/container"
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/ostree"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+)
+
+// A ContentTest can be used to define content sources without generating
+// pipelines. It is useful for testing but not much else.
+type ContentTest struct {
+	Base
+
+	// content sources
+	packageSets []rpmmd.PackageSet
+	containers  []container.SourceSpec
+	commits     []ostree.SourceSpec
+
+	// resolved content
+	packageSpecs   []rpmmd.PackageSpec
+	containerSpecs []container.Spec
+	commitSpecs    []ostree.CommitSpec
+
+	// serialization flag
+	serializing bool
+}
+
+// NewContentTest creates a new ContentTest pipeline with a given name and
+// content sources.
+func NewContentTest(m *Manifest, name string, packageSets []rpmmd.PackageSet, containers []container.SourceSpec, commits []ostree.SourceSpec) *ContentTest {
+	pipeline := &ContentTest{
+		Base:        NewBase(m, name, nil),
+		packageSets: packageSets,
+		containers:  containers,
+		commits:     commits,
+	}
+	m.addPipeline(pipeline)
+	return pipeline
+}
+
+func (p *ContentTest) getPackageSetChain() []rpmmd.PackageSet {
+	return p.packageSets
+}
+
+func (p *ContentTest) getContainerSources() []container.SourceSpec {
+	return p.containers
+}
+
+func (p *ContentTest) getOSTreeCommitSources() []ostree.SourceSpec {
+	return p.commits
+}
+
+func (p *ContentTest) getPackageSpecs() []rpmmd.PackageSpec {
+	return p.packageSpecs
+}
+
+func (p *ContentTest) getContainerSpecs() []container.Spec {
+	return p.containerSpecs
+}
+
+func (p *ContentTest) getOSTreeCommits() []ostree.CommitSpec {
+	return p.commitSpecs
+}
+
+func (p *ContentTest) serializeStart(pkgs []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
+	if p.serializing {
+		panic("double call to serializeStart()")
+	}
+	p.packageSpecs = pkgs
+	p.containerSpecs = containers
+	p.commitSpecs = commits
+
+	p.serializing = true
+}
+
+func (p *ContentTest) serializeEnd() {
+	if !p.serializing {
+		panic("serializeEnd() call when serialization not in progress")
+	}
+	p.packageSpecs = nil
+	p.containerSpecs = nil
+	p.commitSpecs = nil
+
+	p.serializing = false
+}
+
+func (p *ContentTest) serialize() osbuild.Pipeline {
+	if !p.serializing {
+		panic("serialization not started")
+	}
+
+	// no stages
+
+	return osbuild.Pipeline{
+		Name: p.name,
+	}
+}

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -44,8 +44,10 @@ type AnacondaISOTree struct {
 
 	SquashfsCompression string
 
-	OSPipeline *OS
-	OSTree     *ostree.CommitSpec
+	OSPipeline         *OS
+	OSTreeCommitSource *ostree.SourceSpec
+
+	ostreeCommitSpec *ostree.CommitSpec
 
 	KernelOpts []string
 
@@ -75,14 +77,21 @@ func NewAnacondaISOTree(m *Manifest,
 	return p
 }
 
-func (p *AnacondaISOTree) getOSTreeCommits() []ostree.CommitSpec {
-	if p.OSTree == nil {
+func (p *AnacondaISOTree) getOSTreeCommitSources() []ostree.SourceSpec {
+	if p.OSTreeCommitSource == nil {
 		return nil
 	}
 
-	return []ostree.CommitSpec{
-		*p.OSTree,
+	return []ostree.SourceSpec{
+		*p.OSTreeCommitSource,
 	}
+}
+
+func (p *AnacondaISOTree) getOSTreeCommits() []ostree.CommitSpec {
+	if p.ostreeCommitSpec == nil {
+		return nil
+	}
+	return []ostree.CommitSpec{*p.ostreeCommitSpec}
 }
 
 func (p *AnacondaISOTree) getBuildPackages() []string {
@@ -90,7 +99,7 @@ func (p *AnacondaISOTree) getBuildPackages() []string {
 		"squashfs-tools",
 	}
 
-	if p.OSTree != nil {
+	if p.OSTreeCommitSource != nil {
 		packages = append(packages, "rpm-ostree")
 	}
 
@@ -111,21 +120,21 @@ func (p *AnacondaISOTree) serializeStart(_ []rpmmd.PackageSpec, _ []container.Sp
 		panic("pipeline supports at most one ostree commit")
 	}
 
-	p.OSTree = &commits[0]
+	p.ostreeCommitSpec = &commits[0]
 }
 
 func (p *AnacondaISOTree) serializeEnd() {
-	p.OSTree = nil
+	p.ostreeCommitSpec = nil
 }
 
 func (p *AnacondaISOTree) serialize() osbuild.Pipeline {
 	// We need one of two payloads
-	if p.OSTree == nil && p.OSPipeline == nil {
+	if p.ostreeCommitSpec == nil && p.OSPipeline == nil {
 		panic("missing ostree or ospipeline parameters in ISO tree pipeline")
 	}
 
 	// But not both payloads
-	if p.OSTree != nil && p.OSPipeline != nil {
+	if p.ostreeCommitSpec != nil && p.OSPipeline != nil {
 		panic("got both ostree and ospipeline parameters in ISO tree pipeline")
 	}
 
@@ -235,16 +244,16 @@ func (p *AnacondaISOTree) serialize() osbuild.Pipeline {
 		copyInputs,
 	))
 
-	if p.OSTree != nil {
+	if p.ostreeCommitSpec != nil {
 		// Set up the payload ostree repo
 		pipeline.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: p.PayloadPath}))
 		pipeline.AddStage(osbuild.NewOSTreePullStage(
 			&osbuild.OSTreePullStageOptions{Repo: p.PayloadPath},
-			osbuild.NewOstreePullStageInputs("org.osbuild.source", p.OSTree.Checksum, p.OSTree.Ref),
+			osbuild.NewOstreePullStageInputs("org.osbuild.source", p.ostreeCommitSpec.Checksum, p.ostreeCommitSpec.Ref),
 		))
 
 		// Configure the kickstart file with the payload and any user options
-		kickstartOptions, err := osbuild.NewKickstartStageOptions(p.KSPath, "", p.Users, p.Groups, makeISORootPath(p.PayloadPath), p.OSTree.Ref, p.OSName)
+		kickstartOptions, err := osbuild.NewKickstartStageOptions(p.KSPath, "", p.Users, p.Groups, makeISORootPath(p.PayloadPath), p.ostreeCommitSpec.Ref, p.OSName)
 
 		if err != nil {
 			panic("failed to create kickstartstage options")

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/ostree"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/users"
 )
 
@@ -73,7 +75,6 @@ func NewAnacondaISOTree(m *Manifest,
 	return p
 }
 
-// Return the ostree commit URL and checksum that will be included in this
 func (p *AnacondaISOTree) getOSTreeCommits() []ostree.CommitSpec {
 	if p.OSTree == nil {
 		return nil
@@ -98,6 +99,23 @@ func (p *AnacondaISOTree) getBuildPackages() []string {
 	}
 
 	return packages
+}
+
+func (p *AnacondaISOTree) serializeStart(_ []rpmmd.PackageSpec, _ []container.Spec, commits []ostree.CommitSpec) {
+	if len(commits) == 0 {
+		// nothing to do
+		return
+	}
+
+	if len(commits) > 1 {
+		panic("pipeline supports at most one ostree commit")
+	}
+
+	p.OSTree = &commits[0]
+}
+
+func (p *AnacondaISOTree) serializeEnd() {
+	p.OSTree = nil
 }
 
 func (p *AnacondaISOTree) serialize() osbuild.Pipeline {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -48,34 +48,14 @@ func (m *OSBuildManifest) UnmarshalJSON(payload []byte) error {
 }
 
 // Manifest represents a manifest initialised with all the information required
-// to generate the pipelines but no content. The content included in the
-// Content field must be resolved before serializing.
+// to generate the pipelines but no content. The content type sources
+// (PackageSetChains, ContainerSourceSpecs, OSTreeSourceSpecs) must be
+// retrieved through their corresponding Getters and resolved before
+// serializing.
 type Manifest struct {
 
 	// pipelines describe the build process for an image.
 	pipelines []Pipeline
-
-	// Content for the image that will be built by the Manifest. Each content
-	// type should be resolved before passing to the Serialize method.
-	Content Content
-}
-
-// Content for the image that will be built by the Manifest. Each content type
-// should be resolved before passing to the Serialize method.
-type Content struct {
-	// PackageSets are sequences of package sets, each set consisting of a list
-	// of package names to include and exclude and a set of repositories to use
-	// for resolving. Package set sequences (chains) should be depsolved in
-	// separately and the result combined. Package set sequences (chains) are
-	// keyed by the name of the Pipeline that will install them.
-	PackageSets map[string][]rpmmd.PackageSet
-
-	// Containers are source specifications for containers to embed in the image.
-	Containers map[string][]container.SourceSpec
-
-	// OSTreeCommits are source specifications for ostree commits to embed in
-	// the image or use as parent commits when building a new one.
-	OSTreeCommits map[string][]ostree.SourceSpec
 }
 
 func New() Manifest {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -131,14 +131,14 @@ func (m Manifest) GetOSTreeSourceSpecs() map[string][]ostree.SourceSpec {
 	return ostreeSpecs
 }
 
-func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec) (OSBuildManifest, error) {
+func (m Manifest) Serialize(packageSets map[string][]rpmmd.PackageSpec, containerSpecs map[string][]container.Spec, ostreeCommits map[string][]ostree.CommitSpec) (OSBuildManifest, error) {
 	pipelines := make([]osbuild.Pipeline, 0)
 	packages := make([]rpmmd.PackageSpec, 0)
 	commits := make([]ostree.CommitSpec, 0)
 	inline := make([]string, 0)
 	containers := make([]container.Spec, 0)
 	for _, pipeline := range m.pipelines {
-		pipeline.serializeStart(packageSets[pipeline.Name()], containerSpecs[pipeline.Name()])
+		pipeline.serializeStart(packageSets[pipeline.Name()], containerSpecs[pipeline.Name()], ostreeCommits[pipeline.Name()])
 	}
 	for _, pipeline := range m.pipelines {
 		commits = append(commits, pipeline.getOSTreeCommits()...)

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -291,7 +291,7 @@ func (p *OS) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec) {
+func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -147,11 +147,14 @@ type OS struct {
 	// Partition table, if nil the tree cannot be put on a partitioned disk
 	PartitionTable *disk.PartitionTable
 
+	// content-related fields
 	repos          []rpmmd.RepoConfig
 	packageSpecs   []rpmmd.PackageSpec
 	containerSpecs []container.Spec
-	platform       platform.Platform
-	kernelVer      string
+	ostreeSpecs    []ostree.CommitSpec
+
+	platform  platform.Platform
+	kernelVer string
 
 	// NoBLS configures the image bootloader with traditional menu entries
 	// instead of BLS. Required for legacy systems like RHEL 7.
@@ -298,6 +301,7 @@ func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container
 
 	p.packageSpecs = packages
 	p.containerSpecs = containers
+	p.ostreeSpecs = commits
 
 	if p.KernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
@@ -311,6 +315,7 @@ func (p *OS) serializeEnd() {
 	p.kernelVer = ""
 	p.packageSpecs = nil
 	p.containerSpecs = nil
+	p.ostreeSpecs = nil
 }
 
 func (p *OS) serialize() osbuild.Pipeline {

--- a/internal/manifest/os_test.go
+++ b/internal/manifest/os_test.go
@@ -30,7 +30,7 @@ func NewTestOS() *OS {
 	packages := []rpmmd.PackageSpec{
 		rpmmd.PackageSpec{Name: "pkg1"},
 	}
-	os.serializeStart(packages, nil)
+	os.serializeStart(packages, nil, nil)
 
 	return os
 }

--- a/internal/manifest/pipeline.go
+++ b/internal/manifest/pipeline.go
@@ -44,7 +44,7 @@ type Pipeline interface {
 	// its full Spec. See the ostree package for more details.
 	getOSTreeCommitSources() []ostree.SourceSpec
 
-	serializeStart([]rpmmd.PackageSpec, []container.Spec)
+	serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec)
 	serializeEnd()
 	serialize() osbuild.Pipeline
 
@@ -155,7 +155,7 @@ func NewBase(m *Manifest, name string, build *Build) Base {
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec) {
+func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec) {
 }
 
 // serializeEnd must be called exactly once after each call to

--- a/internal/manifest/raw_ostree.go
+++ b/internal/manifest/raw_ostree.go
@@ -74,7 +74,8 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 		_, bootCopyDevices, bootCopyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
 		bootCopyOptions := &osbuild.CopyStageOptions{}
 
-		commitChecksum := p.treePipeline.commit.Checksum
+		commit := p.treePipeline.ostreeSpecs[0]
+		commitChecksum := commit.Checksum
 
 		bootCopyInputs := osbuild.OSTreeCheckoutInputs{
 			"ostree-tree": *osbuild.NewOSTreeCheckoutInput("org.osbuild.source", commitChecksum),

--- a/internal/ostree/ostree.go
+++ b/internal/ostree/ostree.go
@@ -56,11 +56,10 @@ type ImageOptions struct {
 	// embedded in the installer or deployed in the image.
 	ImageRef string
 
-	// For ostree commit and container types: The FetchChecksum specifies the parent
+	// For ostree commit and container types: The ParentRef specifies the parent
 	// ostree commit that the new commit will be based on.
-	// For ostree installers and raw images: The FetchChecksum specifies the commit
-	// ID that will be embedded in the installer or deployed in the image.
-	FetchChecksum string
+	// For ostree installers and raw images: The ParentRef does not apply.
+	ParentRef string
 
 	// The URL from which to fetch the commit specified by the checksum.
 	URL string

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -56,7 +56,7 @@ func FixtureBase() *Store {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}
 
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}
@@ -198,7 +198,7 @@ func FixtureFinished() *Store {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}
 
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -53,7 +53,7 @@ func (suite *storeTest) SetupSuite() {
 	suite.myArch, _ = suite.myDistro.GetArch(test_distro.TestArchName)
 	suite.myImageType, _ = suite.myArch.GetImageType(test_distro.TestImageTypeName)
 	manifest, _, _ := suite.myImageType.Manifest(&suite.myBP, suite.myImageOptions, suite.myRepoConfig, 0)
-	suite.myManifest, _ = manifest.Serialize(nil, nil)
+	suite.myManifest, _ = manifest.Serialize(nil, nil, nil)
 	suite.mySourceConfig = SourceConfig{
 		Name: "testSourceConfig",
 	}

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2466,7 +2466,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			return
 		}
 		ostreeOptions.ImageRef = ref
-		ostreeOptions.FetchChecksum = checksum
+		ostreeOptions.ParentRef = checksum
 	}
 
 	var size uint64

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2450,6 +2450,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		// Fake a parent commit for test requests
 		cr.OSTree.Parent = "02604b2da6e954bd34b8b82a835e5a77d2b60ffa"
 	} else if imageType.OSTreeRef() != "" {
+		// TODO: don't read image ref from image type directly; instead get it from the manifest after initialising.
 		// If the image type has a default ostree ref, assume this is an OSTree image
 		reqParams := cr.OSTree
 		if reqParams.Ref == "" {
@@ -2533,7 +2534,8 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	mf, err := manifest.Serialize(packageSets, containerSpecs)
+	// TODO: resolve ostree source spec from manifest content and pass here.
+	mf, err := manifest.Serialize(packageSets, containerSpecs, nil)
 	if err != nil {
 		errors := responseError{
 			ID:  "ManifestCreationFailed",

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	errors_package "errors"
@@ -2342,7 +2343,7 @@ func (api *API) resolveOSTreeCommits(sourceSpecs map[string][]ostree.SourceSpec,
 		for idx, source := range sources {
 			var ref, checksum string
 			if test {
-				checksum = "02604b2da6e954bd34b8b82a835e5a77d2b60ffa"
+				checksum = fmt.Sprintf("%x", sha256.Sum256([]byte(source.URL+source.Ref)))
 				ref = source.Ref
 			} else {
 				var err error

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2521,7 +2521,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	packageSets, err := api.depsolve(manifest.Content.PackageSets, imageType.Arch().Distro())
+	packageSets, err := api.depsolve(manifest.GetPackageSetChains(), imageType.Arch().Distro())
 	if err != nil {
 		errors := responseError{
 			ID:  "DepsolveError",
@@ -2531,7 +2531,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	containerSpecs, err := api.resolveContainers(manifest.Content.Containers)
+	containerSpecs, err := api.resolveContainers(manifest.GetContainerSourceSpecs())
 	if err != nil {
 		errors := responseError{
 			ID:  "ContainerResolveError",
@@ -2543,7 +2543,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	testMode := q.Get("test")
 
-	ostreeCommitSpecs, err := api.resolveOSTreeCommits(manifest.Content.OSTreeCommits, testMode == "1" || testMode == "2")
+	ostreeCommitSpecs, err := api.resolveOSTreeCommits(manifest.GetOSTreeSourceSpecs(), testMode == "1" || testMode == "2")
 	if err != nil {
 		errors := responseError{
 			ID:  "OSTreeOptionsError",

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -894,7 +894,7 @@ func TestCompose(t *testing.T) {
 	manifest, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	rPkgs, rContainers, rCommits := test_distro.ResolveContent(manifest.Content.PackageSets, manifest.Content.Containers, manifest.Content.OSTreeCommits)
+	rPkgs, rContainers, rCommits := test_distro.ResolveContent(manifest.GetPackageSetChains(), manifest.GetContainerSourceSpecs(), manifest.GetOSTreeSourceSpecs())
 
 	mf, err := manifest.Serialize(rPkgs, rContainers, rCommits)
 	require.NoError(t, err)
@@ -905,7 +905,7 @@ func TestCompose(t *testing.T) {
 	ostreeManifest, _, err := ostreeImgType.Manifest(nil, distro.ImageOptions{OSTree: &ostreeOptions}, nil, 0)
 	require.NoError(t, err)
 
-	rPkgs, rContainers, rCommits = test_distro.ResolveContent(ostreeManifest.Content.PackageSets, ostreeManifest.Content.Containers, ostreeManifest.Content.OSTreeCommits)
+	rPkgs, rContainers, rCommits = test_distro.ResolveContent(ostreeManifest.GetPackageSetChains(), ostreeManifest.GetContainerSourceSpecs(), ostreeManifest.GetOSTreeSourceSpecs())
 
 	omf, err := ostreeManifest.Serialize(rPkgs, rContainers, rCommits)
 	require.NoError(t, err)
@@ -1013,7 +1013,7 @@ func TestCompose(t *testing.T) {
 	ostreeManifestOther, _, err := ostreeImgType.Manifest(nil, distro.ImageOptions{OSTree: &ostreeOptionsOther}, nil, 0)
 	require.NoError(t, err)
 
-	rPkgs, rContainers, rCommits = test_distro.ResolveContent(ostreeManifestOther.Content.PackageSets, ostreeManifestOther.Content.Containers, ostreeManifestOther.Content.OSTreeCommits)
+	rPkgs, rContainers, rCommits = test_distro.ResolveContent(ostreeManifestOther.GetPackageSetChains(), ostreeManifestOther.GetContainerSourceSpecs(), ostreeManifestOther.GetOSTreeSourceSpecs())
 
 	omfo, err := ostreeManifest.Serialize(rPkgs, rContainers, rCommits)
 	require.NoError(t, err)
@@ -1053,7 +1053,7 @@ func TestCompose(t *testing.T) {
 	manifest2, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	rPkgs, rContainers, rCommits = test_distro.ResolveContent(manifest2.Content.PackageSets, manifest2.Content.Containers, manifest2.Content.OSTreeCommits)
+	rPkgs, rContainers, rCommits = test_distro.ResolveContent(manifest2.GetPackageSetChains(), manifest2.GetContainerSourceSpecs(), manifest2.GetOSTreeSourceSpecs())
 	mf2, err := manifest2.Serialize(rPkgs, rContainers, rCommits)
 	require.NoError(t, err)
 
@@ -2043,7 +2043,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 	manifest, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	rPkgs, rContainers, rCommits := test_distro.ResolveContent(manifest.Content.PackageSets, manifest.Content.Containers, manifest.Content.OSTreeCommits)
+	rPkgs, rContainers, rCommits := test_distro.ResolveContent(manifest.GetPackageSetChains(), manifest.GetContainerSourceSpecs(), manifest.GetOSTreeSourceSpecs())
 	mf, err := manifest.Serialize(rPkgs, rContainers, rCommits)
 	require.NoError(t, err)
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -886,7 +886,7 @@ func TestCompose(t *testing.T) {
 	manifest, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	require.NoError(t, err)
 
 	ostreeImgType, err := arch.GetImageType(test_distro.TestImageTypeOSTree)
@@ -894,7 +894,7 @@ func TestCompose(t *testing.T) {
 	ostreeManifest, _, err := ostreeImgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	omf, err := ostreeManifest.Serialize(nil, nil)
+	omf, err := ostreeManifest.Serialize(nil, nil, nil)
 	require.NoError(t, err)
 
 	expectedComposeLocal := &store.Compose{
@@ -1004,7 +1004,7 @@ func TestCompose(t *testing.T) {
 	manifest2, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	mf2, err := manifest2.Serialize(nil, nil)
+	mf2, err := manifest2.Serialize(nil, nil, nil)
 	require.NoError(t, err)
 
 	expectedComposeGoodDistro := &store.Compose{
@@ -1998,7 +1998,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 	manifest, _, err := imgType.Manifest(nil, distro.ImageOptions{}, nil, 0)
 	require.NoError(t, err)
 
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	require.NoError(t, err)
 
 	expectedComposeLocal := &store.Compose{

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -36,7 +36,7 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error serializing osbuild manifest: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestComposeStatusFromJobError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error serializing osbuild manifest: %v", err)
 	}

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -145,9 +145,10 @@ func TestCreate(t *testing.T) {
 	_, err = server.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: mf}, "")
 	require.NoError(t, err)
 
+	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{}}`
 	test.TestRoute(t, handler, false, "POST", "/api/worker/v1/jobs",
 		fmt.Sprintf(`{"types":["%s"],"arch":"%s"}`, worker.JobTypeOSBuild, test_distro.TestArchName), http.StatusCreated,
-		fmt.Sprintf(`{"kind":"RequestJob","href":"/api/worker/v1/jobs","type":"%s","args":{"manifest":{"version":"2","pipelines":[],"sources":{}}}}`, worker.JobTypeOSBuild), "id", "location", "artifact_location")
+		fmt.Sprintf(`{"kind":"RequestJob","href":"/api/worker/v1/jobs","type":"%s","args":{"manifest":`+emptyManifest+`}}`, worker.JobTypeOSBuild), "id", "location", "artifact_location")
 }
 
 func TestCancel(t *testing.T) {

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -135,7 +135,7 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestCancel(t *testing.T) {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
 	server := newTestServer(t, t.TempDir(), time.Duration(0), "/api/worker/v1", false)
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestUpdate(t *testing.T) {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
 	server := newTestServer(t, t.TempDir(), time.Duration(0), "/api/worker/v1", false)
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestArgs(t *testing.T) {
 	manifest, _, err := imageType.Manifest(nil, distro.ImageOptions{Size: imageType.Size(0)}, nil, 0)
 	require.NoError(t, err)
 
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	require.NoError(t, err)
 
 	job := worker.OSBuildJob{
@@ -289,7 +289,7 @@ func TestUpload(t *testing.T) {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
 	server := newTestServer(t, t.TempDir(), time.Duration(0), "/api/worker/v1", true)
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestUploadNotAcceptingArtifacts(t *testing.T) {
 	}
 	server := newTestServer(t, t.TempDir(), time.Duration(0), "/api/worker/v1", false)
 	handler := server.Handler()
-	mf, _ := manifest.Serialize(nil, nil)
+	mf, _ := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestUploadAlteredBasePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}
-	mf, err := manifest.Serialize(nil, nil)
+	mf, err := manifest.Serialize(nil, nil, nil)
 	if err != nil {
 		t.Fatalf("error creating osbuild manifest: %v", err)
 	}

--- a/test/data/manifests/centos_8-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9014,7 +9014,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -11499,12 +11499,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -22204,6 +22201,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:4280064ab658525b486d7b8c2ca5f87aeef90002361a0925f2819fd7a7909500",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9044,7 +9044,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -11551,7 +11551,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -22253,6 +22253,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:4280064ab658525b486d7b8c2ca5f87aeef90002361a0925f2819fd7a7909500",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2059,7 +2059,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3320,7 +3320,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -5810,6 +5810,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2411,7 +2411,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7212,7 +7212,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -13644,6 +13644,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-aarch64-appstream-20220208/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9216,7 +9216,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -11754,12 +11754,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -22679,6 +22676,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:3a232d848da1ace286efef6c8c9cf0fcfab2c47dd58968ddb6a24718629a6220",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9246,7 +9246,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -11806,7 +11806,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -22728,6 +22728,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:3a232d848da1ace286efef6c8c9cf0fcfab2c47dd58968ddb6a24718629a6220",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2171,7 +2171,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3501,7 +3501,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6131,6 +6131,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2459,7 +2459,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7403,7 +7403,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -13985,6 +13985,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el8/cs8-x86_64-appstream-20220208/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:a2aeabb3962859069a78acc288bc3bffb35485428e162caafec8134f5ce6ca67",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9604,7 +9604,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12287,12 +12287,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -23722,6 +23719,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/zlib-1.2.11-35.el9.aarch64.rpm",
         "checksum": "sha256:d3ab7a72a9b19e0240df96502d6ddc4b3f5817da89cd884c8783bf09f89f1873",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9634,7 +9634,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12339,7 +12339,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -23771,6 +23771,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/zlib-1.2.11-35.el9.aarch64.rpm",
         "checksum": "sha256:d3ab7a72a9b19e0240df96502d6ddc4b3f5817da89cd884c8783bf09f89f1873",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2123,7 +2123,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3489,7 +3489,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6059,6 +6059,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/zlib-1.2.11-35.el9.aarch64.rpm",
         "checksum": "sha256:d3ab7a72a9b19e0240df96502d6ddc4b3f5817da89cd884c8783bf09f89f1873",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2507,7 +2507,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7415,7 +7415,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -13977,6 +13977,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-aarch64-baseos-20230101/Packages/zlib-1.2.11-35.el9.aarch64.rpm",
         "checksum": "sha256:d3ab7a72a9b19e0240df96502d6ddc4b3f5817da89cd884c8783bf09f89f1873",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -27,7 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9790,7 +9790,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12517,12 +12517,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24142,6 +24139,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/zlib-1.2.11-35.el9.x86_64.rpm",
         "checksum": "sha256:80df42ac4be2c057e332647ca98d65b1548d4e4adf52beb75d79e79fc8e48aa7",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -27,7 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9820,7 +9820,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12569,7 +12569,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24191,6 +24191,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/zlib-1.2.11-35.el9.x86_64.rpm",
         "checksum": "sha256:80df42ac4be2c057e332647ca98d65b1548d4e4adf52beb75d79e79fc8e48aa7",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
@@ -27,7 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2250,7 +2250,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3688,7 +3688,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6408,6 +6408,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/zlib-1.2.11-35.el9.x86_64.rpm",
         "checksum": "sha256:80df42ac4be2c057e332647ca98d65b1548d4e4adf52beb75d79e79fc8e48aa7",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -27,7 +27,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2562,7 +2562,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7603,7 +7603,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14305,6 +14305,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-x86_64-baseos-20230101/Packages/zlib-1.2.11-35.el9.x86_64.rpm",
         "checksum": "sha256:80df42ac4be2c057e332647ca98d65b1548d4e4adf52beb75d79e79fc8e48aa7",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -35,7 +35,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10775,7 +10775,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13857,7 +13857,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26739,6 +26739,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
         "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -35,7 +35,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10804,7 +10804,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13908,7 +13908,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26790,6 +26790,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
         "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
@@ -2028,7 +2028,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2446,130 +2446,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3380,7 +3380,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5810,6 +5810,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
         "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_raw_image_customizations-boot.json
@@ -2103,7 +2103,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2810,130 +2810,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3764,7 +3764,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -6194,6 +6194,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
         "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
@@ -35,7 +35,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10985,7 +10985,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14123,7 +14123,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27235,6 +27235,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
         "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
@@ -35,7 +35,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -11014,7 +11014,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14174,7 +14174,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27286,6 +27286,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
         "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
@@ -2036,7 +2036,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3211,7 +3211,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5651,6 +5651,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
         "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_36-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_raw_image_customizations-boot.json
@@ -2111,7 +2111,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3595,7 +3595,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -6035,6 +6035,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
         "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10901,7 +10901,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14022,7 +14022,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27084,6 +27084,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
         "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10930,7 +10930,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14073,7 +14073,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27135,6 +27135,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
         "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
@@ -2044,7 +2044,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2462,130 +2462,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3408,7 +3408,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5878,6 +5878,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
         "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_raw_image_customizations-boot.json
@@ -2119,7 +2119,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2826,130 +2826,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3792,7 +3792,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -6262,6 +6262,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
         "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -11119,7 +11119,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14299,7 +14299,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27601,6 +27601,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
         "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -11148,7 +11148,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14350,7 +14350,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27652,6 +27652,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
         "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
@@ -2052,7 +2052,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3239,7 +3239,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5719,6 +5719,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
         "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_37-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_raw_image_customizations-boot.json
@@ -2127,7 +2127,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3623,7 +3623,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -6103,6 +6103,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20221025/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
         "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10540,7 +10540,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13598,7 +13598,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26210,6 +26210,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
         "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10569,7 +10569,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13649,7 +13649,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26261,6 +26261,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
         "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
@@ -1859,7 +1859,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2277,130 +2277,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3154,7 +3154,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5394,6 +5394,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
         "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_raw_image_customizations-boot.json
@@ -1934,7 +1934,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2641,130 +2641,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3538,7 +3538,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5778,6 +5778,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20221025/Packages/z/zlib-1.2.12-5.fc38.aarch64.rpm",
         "checksum": "sha256:fa38c933e194c67185d9982e700bd67f65b9c8fbe23f0146a3a96987516eb668",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10838,7 +10838,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13943,7 +13943,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26895,6 +26895,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10867,7 +10867,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13994,7 +13994,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26946,6 +26946,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
@@ -1867,7 +1867,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2985,7 +2985,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5235,6 +5235,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_38-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_raw_image_customizations-boot.json
@@ -1942,7 +1942,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3369,7 +3369,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5619,6 +5619,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-branched-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10724,7 +10724,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13803,7 +13803,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26645,6 +26645,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
         "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10753,7 +10753,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -13854,7 +13854,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -26696,6 +26696,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
         "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_raw_image-boot.json
@@ -1875,7 +1875,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2293,130 +2293,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3176,7 +3176,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5436,6 +5436,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
         "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-aarch64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_raw_image_customizations-boot.json
@@ -1950,7 +1950,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2657,130 +2657,130 @@
                 "type": "org.osbuild.ostree.checkout",
                 "origin": "org.osbuild.source",
                 "references": [
-                  ""
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
                 ]
               }
             },
             "options": {
               "paths": [
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/bootcode.bin",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/config.txt",
                   "to": "mount://root/boot/efi/config.txt"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup4x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_cd.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_db.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/fixup_x.dat",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/overlays",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/share/uboot/rpi_arm64/u-boot.bin",
                   "to": "mount://root/boot/efi/rpi-u-boot.bin"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start4x.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_cd.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_db.elf",
                   "to": "mount://root/boot/efi/"
                 },
                 {
-                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "from": "input://ostree-tree/88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6/usr/lib/ostree-boot/efi/start_x.elf",
                   "to": "mount://root/boot/efi/"
                 }
               ]
@@ -3560,7 +3560,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5820,6 +5820,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
         "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -10934,7 +10934,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14072,7 +14072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27144,6 +27144,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/iot",
       "url": "http://iot.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10963,7 +10963,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
                     "ref": "test/iot"
                   }
                 }
@@ -14123,7 +14123,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f": {
             "remote": {
               "url": "http://iot.example.com/repo"
             }
@@ -27195,6 +27195,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/iot",
+        "URL": "http://iot.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "466e747c4d158f3443d3f92407e9f93a6ec8a2cbf0565ab716850f027b90a76f"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_raw_image-boot.json
@@ -1875,7 +1875,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -2996,7 +2996,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5256,6 +5256,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/fedora_39-x86_64-iot_raw_image_customizations-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_raw_image_customizations-boot.json
@@ -1950,7 +1950,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "": {
+                  "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
                     "ref": "test/fedora/iot"
                   }
                 }
@@ -3380,7 +3380,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "": {
+          "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6": {
             "remote": {
               "url": "http://fedora.example.com/repo"
             }
@@ -5640,6 +5640,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230310/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
         "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/fedora/iot",
+        "URL": "http://fedora.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "88a9428978d79e31177c543da1d32a338ec6fd95522f5e50e12f39a4dfd2eae6"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3775,7 +3775,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6368,12 +6368,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16328,6 +16325,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3805,7 +3805,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6420,7 +6420,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16377,6 +16377,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -814,7 +814,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2072,7 +2072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4305,6 +4305,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -951,7 +951,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3994,7 +3994,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9766,6 +9766,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3879,7 +3879,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6537,12 +6537,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16731,6 +16728,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3909,7 +3909,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6589,7 +6589,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16780,6 +16780,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -856,7 +856,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2183,7 +2183,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4542,6 +4542,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -969,7 +969,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4110,7 +4110,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10017,6 +10017,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_84-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3754,7 +3754,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6293,12 +6293,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16190,6 +16187,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_84-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3784,7 +3784,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6345,7 +6345,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16239,6 +16239,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.4-20210921/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_84-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3852,7 +3852,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6450,12 +6450,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16563,6 +16560,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_84-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3882,7 +3882,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6502,7 +6502,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16612,6 +16612,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.4-20210921/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_85-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3718,7 +3718,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6248,12 +6248,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16037,6 +16034,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_85-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -3718,7 +3718,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6248,7 +6248,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16034,6 +16034,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-r8.5-20220504/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_85-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3816,7 +3816,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6405,12 +6405,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16410,6 +16407,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_85-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -3816,7 +3816,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6405,7 +6405,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16407,6 +16407,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-r8.5-20220504/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3712,7 +3712,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6239,12 +6239,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16010,6 +16007,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3742,7 +3742,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6291,7 +6291,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16059,6 +16059,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -814,7 +814,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2072,7 +2072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4305,6 +4305,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -954,7 +954,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3997,7 +3997,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9778,6 +9778,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.6-20220201/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3810,7 +3810,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6396,12 +6396,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16383,6 +16380,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3840,7 +3840,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6448,7 +6448,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16432,6 +16432,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -856,7 +856,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2183,7 +2183,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4542,6 +4542,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -972,7 +972,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4113,7 +4113,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10029,6 +10029,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3775,7 +3775,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6368,12 +6368,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16328,6 +16325,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3805,7 +3805,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6420,7 +6420,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16377,6 +16377,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -814,7 +814,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2072,7 +2072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4305,6 +4305,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -951,7 +951,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3994,7 +3994,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9766,6 +9766,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3879,7 +3879,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6537,12 +6537,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16731,6 +16728,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3909,7 +3909,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6589,7 +6589,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16780,6 +16780,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -856,7 +856,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2183,7 +2183,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4542,6 +4542,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -969,7 +969,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4110,7 +4110,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10017,6 +10017,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3775,7 +3775,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6368,12 +6368,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16328,6 +16325,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3805,7 +3805,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6420,7 +6420,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16377,6 +16377,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -814,7 +814,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2072,7 +2072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4305,6 +4305,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -951,7 +951,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3994,7 +3994,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9766,6 +9766,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.8-20221025/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3879,7 +3879,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6537,12 +6537,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16731,6 +16728,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3909,7 +3909,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6589,7 +6589,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16780,6 +16780,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -856,7 +856,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2183,7 +2183,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4542,6 +4542,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -969,7 +969,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4110,7 +4110,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10017,6 +10017,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_89-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3781,7 +3781,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6380,12 +6380,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16358,6 +16355,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.9-20230316/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_89-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3811,7 +3811,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6432,7 +6432,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16407,6 +16407,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.9-20230316/Packages/xorriso-1.4.8-4.el8.aarch64.rpm",
         "checksum": "sha256:7f152ae17a9fd0e8b8c3142fcd1b10c123b7e0f8e0bf033cc5c8a0139bc8be44"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_89-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -814,7 +814,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2072,7 +2072,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4305,6 +4305,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.9-20230316/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_89-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -951,7 +951,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3994,7 +3994,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9766,6 +9766,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-aarch64-appstream-n8.9-20230316/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3885,7 +3885,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6549,12 +6549,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16761,6 +16758,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.9-20230316/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3915,7 +3915,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6601,7 +6601,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16810,6 +16810,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.9-20230316/Packages/xorriso-1.4.8-4.el8.x86_64.rpm",
         "checksum": "sha256:43942232558005b02597efeab0d80e0acae4d6513bb8ecf5e686cd42bb672117"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -856,7 +856,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2183,7 +2183,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4542,6 +4542,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.9-20230316/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_89-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -969,7 +969,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4110,7 +4110,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10017,6 +10017,17 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.9-20230316/Packages/xkeyboard-config-2.28-1.el8.noarch.rpm",
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9797,7 +9797,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12525,12 +12525,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24200,6 +24197,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9827,7 +9827,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12577,7 +12577,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24249,6 +24249,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2188,7 +2188,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3564,7 +3564,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6214,6 +6214,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2572,7 +2572,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7481,7 +7481,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14123,6 +14123,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9967,7 +9967,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12736,12 +12736,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24591,6 +24588,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9997,7 +9997,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12788,7 +12788,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24640,6 +24640,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2308,7 +2308,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3756,7 +3756,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6556,6 +6556,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_9-x86_64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2620,7 +2620,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7661,7 +7661,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14443,6 +14443,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3820,7 +3820,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6476,12 +6476,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16553,6 +16550,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/xz-lzma-compat-5.2.5-7.el9.aarch64.rpm",
         "checksum": "sha256:3a32d8bbd10a5f1b75dbc65d964e515dc094b6e3ea3c447acba914ad6a826668"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3850,7 +3850,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6528,7 +6528,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16602,6 +16602,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/xz-lzma-compat-5.2.5-7.el9.aarch64.rpm",
         "checksum": "sha256:3a32d8bbd10a5f1b75dbc65d964e515dc094b6e3ea3c447acba914ad6a826668"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -793,7 +793,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2097,7 +2097,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4267,6 +4267,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -942,7 +942,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4043,7 +4043,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -9797,6 +9797,17 @@
         "arch": "aarch64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -3909,7 +3909,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6612,12 +6612,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -16878,6 +16875,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/xz-lzma-compat-5.2.5-7.el9.x86_64.rpm",
         "checksum": "sha256:fe65351b850c4520e5c22ddfc15515dcab0b547119cd7d3c2e0181cda988d1e7"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -3939,7 +3939,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -6664,7 +6664,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -16927,6 +16927,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/xz-lzma-compat-5.2.5-7.el9.x86_64.rpm",
         "checksum": "sha256:fe65351b850c4520e5c22ddfc15515dcab0b547119cd7d3c2e0181cda988d1e7"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -841,7 +841,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -2220,7 +2220,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -4534,6 +4534,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -19,7 +19,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -963,7 +963,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -4162,7 +4162,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -10060,6 +10060,17 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c"
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9797,7 +9797,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12525,12 +12525,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24200,6 +24197,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9827,7 +9827,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12577,7 +12577,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24249,6 +24249,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2188,7 +2188,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3564,7 +3564,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6214,6 +6214,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2572,7 +2572,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7481,7 +7481,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14123,6 +14123,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9967,7 +9967,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12736,12 +12736,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24591,6 +24588,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9997,7 +9997,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12788,7 +12788,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24640,6 +24640,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2308,7 +2308,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3756,7 +3756,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6556,6 +6556,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2620,7 +2620,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7661,7 +7661,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14443,6 +14443,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9732,7 +9732,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12457,12 +12457,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24052,6 +24049,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9762,7 +9762,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12509,7 +12509,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24101,6 +24101,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2131,7 +2131,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3500,7 +3500,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6080,6 +6080,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2515,7 +2515,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7415,7 +7415,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -13977,6 +13977,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9910,7 +9910,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12679,12 +12679,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24464,6 +24461,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9940,7 +9940,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12731,7 +12731,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24513,6 +24513,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2251,7 +2251,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3692,7 +3692,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6422,6 +6422,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2563,7 +2563,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7595,7 +7595,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14297,6 +14297,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20230101/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_93-aarch64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -9837,7 +9837,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12580,12 +12580,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24305,6 +24302,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_93-aarch64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -9867,7 +9867,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12632,7 +12632,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24354,6 +24354,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_93-aarch64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2188,7 +2188,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3578,7 +3578,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6228,6 +6228,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.aarch64.rpm",
         "checksum": "sha256:80c1d608109867cbcb0f69f9c6fbd21cf623726052636ac5e3ba4a9b00886b9d",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_93-aarch64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2572,7 +2572,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7498,7 +7498,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14140,6 +14140,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-aarch64-appstream-n9.3-20230316/Packages/volume_key-libs-0.3.12-15.el9.aarch64.rpm",
         "checksum": "sha256:4d3605105404fa6c82ff03f8bf3254fef7c04160878f92a7345b37a4e411141f",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_93-x86_64-edge_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": true
     },
     "blueprint": {}
@@ -10015,7 +10015,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12802,12 +12802,9 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
-              "url": "http://edge.example.com/repo",
-              "secrets": {
-                "name": "org.osbuild.rhsm.consumer"
-              }
+              "url": "http://edge.example.com/repo"
             }
           }
         }
@@ -24717,6 +24714,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_93-x86_64-edge_installer_with_users-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -10045,7 +10045,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -12854,7 +12854,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -24766,6 +24766,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "bootiso-tree": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_93-x86_64-edge_raw_image-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {}
@@ -2308,7 +2308,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -3770,7 +3770,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -6570,6 +6570,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.3-20230316/Packages/yajl-2.1.0-21.el9.x86_64.rpm",
         "checksum": "sha256:69d721b451dc548595d838c60e06c771942ed05bd96ad0661f221c3403d304c5",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/test/data/manifests/rhel_93-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_93-x86_64-edge_simplified_installer-boot.json
@@ -21,7 +21,7 @@
     "ostree": {
       "ref": "test/edge",
       "url": "http://edge.example.com/repo",
-      "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "parent": "",
       "rhsm": false
     },
     "blueprint": {
@@ -2620,7 +2620,7 @@
                 "type": "org.osbuild.ostree",
                 "origin": "org.osbuild.source",
                 "references": {
-                  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+                  "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
                     "ref": "test/edge"
                   }
                 }
@@ -7678,7 +7678,7 @@
       },
       "org.osbuild.ostree": {
         "items": {
-          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+          "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad": {
             "remote": {
               "url": "http://edge.example.com/repo"
             }
@@ -14460,6 +14460,17 @@
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.3-20230316/Packages/volume_key-libs-0.3.12-15.el9.x86_64.rpm",
         "checksum": "sha256:d98118f8ea3c179d56198d0189d916d5604d3643d51007b364479905cb8e652c",
         "check_gpg": true
+      }
+    ]
+  },
+  "ostree-commits": {
+    "ostree-deployment": [
+      {
+        "Ref": "test/edge",
+        "URL": "http://edge.example.com/repo",
+        "ContentURL": "",
+        "Secrets": "",
+        "Checksum": "8119013dc0bbd4a0140d7392c3a07395399d5a12112f911bd3fc37ba6b7df6ad"
       }
     ]
   },

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -468,8 +468,7 @@
       "filename": "installer.iso",
       "ostree": {
         "ref": "test/iot",
-        "url": "http://iot.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "url": "http://iot.example.com/repo"
       },
       "blueprint": {}
     },
@@ -485,8 +484,7 @@
       "filename": "installer.iso",
       "ostree": {
         "ref": "test/iot",
-        "url": "http://iot.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "url": "http://iot.example.com/repo"
       },
       "blueprint": {
         "name": "iot-installer-users",
@@ -757,7 +755,6 @@
       "ostree": {
         "ref": "test/edge",
         "url": "http://edge.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "rhsm": true
       },
       "blueprint": {}
@@ -774,8 +771,7 @@
       "filename": "installer.iso",
       "ostree": {
         "ref": "test/edge",
-        "url": "http://edge.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "url": "http://edge.example.com/repo"
       },
       "blueprint": {
         "name": "edge-installer-users",
@@ -827,8 +823,7 @@
       "filename": "installer.iso",
       "ostree": {
         "ref": "test/edge",
-        "url": "http://edge.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "url": "http://edge.example.com/repo"
       },
       "blueprint": {
         "customizations": {
@@ -860,8 +855,7 @@
       "filename": "image.raw.xz",
       "ostree": {
         "ref": "test/edge",
-        "url": "http://edge.example.com/repo",
-        "parent": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "url": "http://edge.example.com/repo"
       },
       "blueprint": {}
     },


### PR DESCRIPTION
This PR is a follow-up to #3444 and completes the redesign of the image definition interface.
There's two major changes here:
- OSTree option and commit resolution handling
- Cloud API manifest generation process

### OSTree options

Until now, the ostree option handling was a bit weird.  We would take what the user provided (ref, url, parent ref), resolve any commit ID we might need, then put it back on the image options.  Also, when an image required an ostree ref to be specified, we read the default one off the image type and put it in the options if it wasn't already set.  I've changed this now so that the ostree options **always** hold just what the user provided (or the test caller).  Using the default ref when an image type needs it is a responsibility of the image type function (each corresponding `imageFunc` implementation).  The options will never be used for resolved information.  So the process now is:
* Call the `Manifest()` function with ostree options exactly as the user specified them (just like we do with the blueprint for example)
* `checkOptions()` returns an error if an ostree URL was required and not specified (for ostree installers and raw images which require an ostree commit payload to be pulled)
* The `Manifest()` function constructs the ostree commit source specification from the ostree options (similar to how it creates container source specifications from the blueprint customizations)
* The image function is called with the commit source specification argument for image types that require it for content (e.g., ostree installers)
* Image function adds the user-specified ref (or default ref if empty) where needed in the manifest when initialising
* The manifest returns an ostree commit source specification for the caller to resolve (like we do with package sets and containers)
* `manifest.Serialize()` takes a resolved ostree commit spec to serialise into the manifest as content (like we do with package specs and resolved container specs)

This unifies the handling of all three content types and makes it easier to separate user options from manifest values.

### Cloud API manifest generation

The manifest initialisation now only happens once in the Cloud API as well.  The manifest is initialised in the composer handler and the content getters (e.g., `GetPackageSetChains()`) are used to retrieve content source specifications and set up the resolve jobs on the worker queue.  The initialised manifest is passed through to the `serializeManifest()` function (which was previously called `generateManifest()`) along with the dependency job IDs.  Once each resolve job is finished, the manifest is serialised with the content specs.

-----

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
