### PR TITLE
templates/composer: fix fluentd requests/limits

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -164,9 +164,9 @@ objects:
           resources:
             requests:
               cpu: "${FLUENTD_CPU_REQUEST}"
-              memory: "${FLUENTD_MEMORY_REQUEST}"
+              memory: "${MEMORY_REQUEST}"
             limits:
-              cpu: "${CPU_LIMIT}"
+              cpu: "${FLUENTD_CPU_LIMIT}"
               memory: "${MEMORY_LIMIT}"
           env:
           - name: PGHOST


### PR DESCRIPTION
No separate request for memory was defined in #3472, only cpu request/limit.

