### PR TITLE
Enable CI for Fedora 38 & a few cleanups

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,6 +181,8 @@ Base:
       - RUNNER:
           - aws/fedora-37-x86_64
           - aws/fedora-37-aarch64
+          - aws/fedora-38-x86_64
+          - aws/fedora-38-aarch64
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
           - aws/rhel-8.7-ga-x86_64
@@ -227,6 +229,8 @@ Manifests:
       - RUNNER:
           - aws/fedora-37-x86_64
           - aws/fedora-37-aarch64
+          - aws/fedora-38-x86_64
+          - aws/fedora-38-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
       - RUNNER:
@@ -380,6 +384,7 @@ Trigger-rhel-edge-ci:
 .fedora_runners: &fedora_runners
     RUNNER:
       - aws/fedora-37-x86_64
+      - aws/fedora-38-x86_64
 
 .integration_fedora:
   extends: .integration_base
@@ -514,6 +519,7 @@ API:
       - IMAGE_TYPE: ["iot-commit"]
         RUNNER:
           - aws/fedora-37-x86_64
+          - aws/fedora-38-x86_64
       - IMAGE_TYPE: ["aws"]
         RUNNER:
           - aws/rhel-8.7-ga-aarch64
@@ -696,9 +702,11 @@ ContainerUpload:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/container-upload.sh
-  variables:
-    RUNNER: aws/fedora-37-x86_64
-    INTERNAL_NETWORK: "false"
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/fedora-37-x86_64
+          - aws/fedora-38-x86_64
 
 ContainerEmbedding:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -538,6 +538,9 @@ API:
   parallel:
     matrix:
       - RUNNER:
+          - rhos-01/fedora-37-x86_64
+          - rhos-01/fedora-38-x86_64
+      - RUNNER:
           - gcp/centos-stream-8-x86_64
           - gcp/rhel-8.7-ga-x86_64
           - gcp/rhel-9.1-ga-x86_64

--- a/test/cases/libvirt.sh
+++ b/test/cases/libvirt.sh
@@ -14,6 +14,9 @@ source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 # Test the images
 /usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2
 
-/usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
+# Fedora's openstack image is an alias of qcow2, we don't need to test it separately
+if [[ "$ID" != "fedora" ]] ; then
+    /usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
+fi
 
 /usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2 uefi

--- a/test/cases/libvirt.sh
+++ b/test/cases/libvirt.sh
@@ -16,8 +16,4 @@ source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 
 /usr/libexec/osbuild-composer-test/libvirt_test.sh openstack
 
-# RHEL 8.4+ and Centos Stream 8+ images also supports uefi, check that
-if [[ "$ID" == "rhel" || "$ID" == "centos" ]] ; then
-  echo "🐄 Booting qcow2 image in UEFI mode on RHEL/Centos Stream"
-  /usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2 uefi
-fi
+/usr/libexec/osbuild-composer-test/libvirt_test.sh qcow2 uefi

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -73,16 +73,12 @@ SSH_KEY=${SSH_DATA_DIR}/id_rsa
 SSH_KEY_PUB=$(cat "${SSH_KEY}".pub)
 EDGE_USER_PASSWORD=foobar
 
-case "${ID}-${VERSION_ID}" in
-    "fedora-37")
-        # CI runner does not support fedora37 os name in this case
-        # ERROR    Unknown OS name 'fedora37'. See `--osinfo list` for valid values.
-        OS_VARIANT="fedora-unknown"
-        ;;
-    *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
-        exit 1;;
-esac
+if [[ $ID != fedora ]]; then
+    echo "unsupported distro: ${ID}-${VERSION_ID}"
+    exit 1
+fi
+
+OS_VARIANT="fedora-unknown"
 
 # Get the compose log.
 get_compose_log () {

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -106,17 +106,7 @@ KERNEL_RT_PKG="kernel-rt"
 SYSROOT_RO="false"
 
 case "${ID}-${VERSION_ID}" in
-    "fedora-37")
-        CONTAINER_TYPE=iot-container
-        INSTALLER_TYPE=iot-installer
-        OSTREE_REF="fedora/${VERSION_ID}/${ARCH}/iot"
-        OSTREE_OSNAME=fedora
-        OS_VARIANT="fedora-unknown"
-        EMBEDED_CONTAINER="false"
-        DIRS_FILES_CUSTOMIZATION="true"
-        SYSROOT_RO="true"
-        ;;
-    "fedora-38")
+    fedora-*)
         CONTAINER_TYPE=iot-container
         INSTALLER_TYPE=iot-installer
         OSTREE_REF="fedora/${VERSION_ID}/${ARCH}/iot"

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -19,23 +19,12 @@ SYSROOT_RO="false"
 
 # Set os-variant and boot location used by virt-install.
 case "${ID}-${VERSION_ID}" in
-    "fedora-37")
+    fedora-*)
         IMAGE_TYPE=iot-commit
-        OSTREE_REF="fedora/37/${ARCH}/iot"
+        OSTREE_REF="fedora/${VERSION_ID}/${ARCH}/iot"
         OS_VARIANT="fedora-unknown"
         USER_IN_COMMIT="false"
-        BOOT_LOCATION="https://mirrors.kernel.org/fedora/releases/37/Everything/x86_64/os/"
-        EMBEDED_CONTAINER="false"
-        FIREWALL_FEATURE="false"
-        DIRS_FILES_CUSTOMIZATION="true"
-        SYSROOT_RO="true"
-        ;;
-    "fedora-38")
-        IMAGE_TYPE=iot-commit
-        OSTREE_REF="fedora/38/${ARCH}/iot"
-        OS_VARIANT="fedora-unknown"
-        USER_IN_COMMIT="false"
-        BOOT_LOCATION="https://mirrors.kernel.org/fedora/releases/38/Everything/x86_64/os/"
+        BOOT_LOCATION="https://mirrors.kernel.org/fedora/releases/${VERSION_ID}/Everything/x86_64/os/"
         EMBEDED_CONTAINER="false"
         FIREWALL_FEATURE="false"
         DIRS_FILES_CUSTOMIZATION="true"

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -1016,7 +1016,7 @@
         - name: Check that 'custom.service' was overridden by drop-in
           assert:
             that:
-              - result_custom_service.status['DropInPaths'] == "/etc/systemd/system/custom.service.d/override.conf"
+              - "'/etc/systemd/system/custom.service.d/override.conf' in result_custom_service.status['DropInPaths']"
             fail_msg: "Service 'custom.service' was not overridden by drop-in"
             success_msg: "Service 'custom.service' was overridden by drop-in"
 

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -270,28 +270,23 @@ elif [[ $ARCH == 's390x' ]]; then
         --network network=integration,mac=34:49:22:B0:83:30
 else
     case "${ID}-${VERSION_ID}" in
-        "rhel-8"* | "centos-8")
+        "rhel-8"*)
              # was 1024 before 8.9
              MIN_RAM="1536"
-             ;;
-        "rhel-9"* | "centos-9")
-             MIN_RAM="1536"
-             ;;
-        *)
-            echo "unsupported distro: ${ID}-${VERSION_ID}"
-            exit 1;;
-    esac
-
-    case "${ID}-${VERSION_ID}" in
-        "rhel-8"* | "centos-8")
              NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
              ;;
-        "centos-9" )
-            # Disable secure boot for CS9 due to bug bz#2108646
-            NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
-            ;;
+        "centos-8")
+             MIN_RAM="1536"
+             NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
+             ;;
         "rhel-9"*)
+             MIN_RAM="1536"
              NVRAM_TEMPLATE=""
+             ;;
+        "centos-9")
+             MIN_RAM="1536"
+             # Disable secure boot for CS9 due to bug bz#2108646
+             NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
              ;;
         *)
             echo "unsupported distro: ${ID}-${VERSION_ID}"

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -272,22 +272,22 @@ else
     case "${ID}-${VERSION_ID}" in
         "rhel-8"*)
              # was 1024 before 8.9
-             MIN_RAM="1536"
-             NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
-             ;;
+            MIN_RAM="1536"
+            NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
+            ;;
         "centos-8")
-             MIN_RAM="1536"
-             NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
-             ;;
+            MIN_RAM="1536"
+            NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
+            ;;
         "rhel-9"*)
-             MIN_RAM="1536"
-             NVRAM_TEMPLATE=""
-             ;;
+            MIN_RAM="1536"
+            NVRAM_TEMPLATE=""
+            ;;
         "centos-9")
-             MIN_RAM="1536"
-             # Disable secure boot for CS9 due to bug bz#2108646
-             NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
-             ;;
+            MIN_RAM="1536"
+            # Disable secure boot for CS9 due to bug bz#2108646
+            NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
+            ;;
         *)
             echo "unsupported distro: ${ID}-${VERSION_ID}"
             exit 1;;

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -292,6 +292,11 @@ else
             NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
             OS_VARIANT="centos-stream9"
             ;;
+        "fedora"*)
+            MIN_RAM="1536"
+            NVRAM_TEMPLATE=""
+            OS_VARIANT="fedora-unknown"
+            ;;
         *)
             echo "unsupported distro: ${ID}-${VERSION_ID}"
             exit 1;;

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -274,19 +274,23 @@ else
              # was 1024 before 8.9
             MIN_RAM="1536"
             NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
+            OS_VARIANT="rhel8-unknown"
             ;;
         "centos-8")
             MIN_RAM="1536"
             NVRAM_TEMPLATE="nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd"
+            OS_VARIANT="centos-stream8"
             ;;
         "rhel-9"*)
             MIN_RAM="1536"
             NVRAM_TEMPLATE=""
+            OS_VARIANT="rhel9-unknown"
             ;;
         "centos-9")
             MIN_RAM="1536"
             # Disable secure boot for CS9 due to bug bz#2108646
             NVRAM_TEMPLATE="firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
+            OS_VARIANT="centos-stream9"
             ;;
         *)
             echo "unsupported distro: ${ID}-${VERSION_ID}"
@@ -302,7 +306,7 @@ else
             --disk path="${LIBVIRT_IMAGE_PATH}" \
             --disk path=${CLOUD_INIT_PATH},device=cdrom \
             --import \
-            --os-variant rhel8-unknown \
+            --os-variant "${OS_VARIANT}" \
             --noautoconsole \
             --boot uefi,"${NVRAM_TEMPLATE}" \
             --network network=integration,mac=34:49:22:B0:83:30
@@ -314,7 +318,7 @@ else
             --disk path="${LIBVIRT_IMAGE_PATH}" \
             --disk path=${CLOUD_INIT_PATH},device=cdrom \
             --import \
-            --os-variant rhel8-unknown \
+            --os-variant "${OS_VARIANT}" \
             --noautoconsole \
             --network network=integration,mac=34:49:22:B0:83:30
     fi


### PR DESCRIPTION
This PR:
- updates the Fedora 38 runners to the GA version
- makes some adjustments to the testing suite so it supports all Fedora versions - we no longer need to change anything in the test scripts in order to enable CI for a new version
- enables CI on Fedora 38
- enables running even more tests on Fedora 38 (libvirt and installer) - some adjustments were needed

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue