### PR TITLE
osbuild: Add validation error logging

### DIFF
--- a/internal/osbuild/result_test_data.go
+++ b/internal/osbuild/result_test_data.go
@@ -7872,3 +7872,18 @@ const fullResultRaw = `
   }
 }
 `
+
+const validationResultFailure = `
+{
+	"type": "https://osbuild.org/validation-error",
+	"success": false,
+	"title": "JSON Schema validation failed",
+	"errors": [{
+		"message": "Additional properties are not allowed ('homer' was unexpected)",
+		"path": ["sources", "org.osbuild.curl"]
+	},{
+		"message": "Additional properties are not allowed ('file_contextso' was unexpected)",
+		"path": ["pipelines", 0, "stages", 1, "options"]
+	}]
+}
+`


### PR DESCRIPTION
osbuild can return a json object with details about manifest validation errors. This adds support for saving those, and printing them when the Write function is called. eg. when using composer-cli compose log UUID

Includes tests for new behavior.


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
