### PR TITLE
distro/fedora: add the 'iot-ami' image type

### DIFF
--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -254,6 +254,7 @@ func TestDistro_KernelOption(t *testing.T, d distro.Distro) {
 		"iot-raw-image":             true,
 		"edge-raw-image":            true,
 		"edge-ami":                  true,
+		"iot-ami":                   true,
 
 		// the tar image type is a minimal image type which is not expected to
 		// be usable without a blueprint (see commit 83a63aaf172f556f6176e6099ffaa2b5357b58f5).

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -165,6 +165,31 @@ var (
 		requiredPartitionSizes: map[string]uint64{},
 	}
 
+	iotAMIImgType = imageType{
+		name:        "iot-ami",
+		nameAliases: []string{"fedora-iot-ami"},
+		filename:    "image.raw",
+		mimeType:    "application/octet-stream",
+		packageSets: nil,
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
+		},
+		defaultSize:         10 * common.GibiByte,
+		rpmOstree:           true,
+		bootable:            true,
+		bootISO:             false,
+		image:               iotRawImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"ostree-deployment", "image"},
+		exports:             []string{"image"},
+		basePartitionTables: iotBasePartitionTables,
+		// Passing an empty map into the required partition sizes disables the
+		// default partition sizes normally set so our `basePartitionTables` can
+		// override them (and make them smaller, in this case).
+		requiredPartitionSizes: map[string]uint64{},
+		environment:            &environment.EC2{},
+	}
+
 	qcow2ImgType = imageType{
 		name:     "qcow2",
 		filename: "disk.qcow2",
@@ -588,6 +613,7 @@ func newDistro(version int) distro.Distro {
 			UEFIVendor: "fedora",
 		},
 		iotRawImgType,
+		iotAMIImgType,
 	)
 	aarch64.addImageTypes(
 		&platform.Aarch64{
@@ -678,6 +704,7 @@ func newDistro(version int) distro.Distro {
 			},
 		},
 		iotRawImgType,
+		iotAMIImgType,
 	)
 	x86_64.addImageTypes(
 		&platform.X86{

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -169,17 +169,33 @@ func TestFilenameFromType(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid-output-type",
-			args: args{"foobar"},
-			want: wantResult{wantErr: true},
-		},
-		{
 			name: "minimal-raw",
 			args: args{"minimal-raw"},
 			want: wantResult{
 				filename: "raw.img",
 				mimeType: "application/disk",
 			},
+		},
+		{
+			name: "iot-ami",
+			args: args{"iot-ami"},
+			want: wantResult{
+				filename: "image.raw",
+				mimeType: "application/octet-stream",
+			},
+		},
+		{ // Alias
+			name: "fedora-iot-ami",
+			args: args{"fedora-iot-ami"},
+			want: wantResult{
+				filename: "image.raw",
+				mimeType: "application/octet-stream",
+			},
+		},
+		{
+			name: "invalid-output-type",
+			args: args{"foobar"},
+			want: wantResult{wantErr: true},
 		},
 	}
 	for _, dist := range fedoraFamilyDistros {
@@ -280,6 +296,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-container",
 				"iot-installer",
 				"iot-raw-image",
+				"iot-ami",
 				"oci",
 				"image-installer",
 				"minimal-raw",
@@ -296,6 +313,7 @@ func TestImageType_Name(t *testing.T) {
 				"iot-container",
 				"iot-installer",
 				"iot-raw-image",
+				"iot-ami",
 				"image-installer",
 				"minimal-raw",
 			},
@@ -366,6 +384,16 @@ func TestImageTypeAliases(t *testing.T) {
 				imageTypeName: "iot-installer",
 			},
 		},
+
+		{
+			name: "iot-ami aliases",
+			args: args{
+				imageTypeAliases: []string{"fedora-iot-ami"},
+			},
+			want: wantResult{
+				imageTypeName: "iot-ami",
+			},
+		},
 	}
 	for _, dist := range fedoraFamilyDistros {
 		t.Run(dist.name, func(t *testing.T) {
@@ -430,7 +458,7 @@ func TestDistro_ManifestError(t *testing.T) {
 				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
 			} else if imgTypeName == "image-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for boot ISO image type \"%s\": (allowed: User, Group)", imgTypeName))
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-ami" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else {
 				assert.NoError(t, err)
@@ -458,6 +486,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-container",
 				"iot-installer",
 				"iot-raw-image",
+				"iot-ami",
 				"oci",
 				"container",
 				"image-installer",
@@ -474,6 +503,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-container",
 				"iot-installer",
 				"iot-raw-image",
+				"iot-ami",
 				"oci",
 				"container",
 				"image-installer",
@@ -576,7 +606,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-ami" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
@@ -606,7 +636,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-ami" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
@@ -742,7 +772,7 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-ami" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue
@@ -772,7 +802,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			_, _, err := imgType.Manifest(&bp, distro.ImageOptions{}, nil, 0)
 			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
-			} else if imgTypeName == "iot-raw-image" {
+			} else if imgTypeName == "iot-raw-image" || imgTypeName == "iot-ami" {
 				assert.EqualError(t, err, fmt.Sprintf("unsupported blueprint customizations found for image type %q: (allowed: User, Group, Directories, Files, Services)", imgTypeName))
 			} else if imgTypeName == "iot-installer" || imgTypeName == "image-installer" {
 				continue

--- a/test/data/manifests/fedora_37-aarch64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_ami-boot.json
@@ -1,0 +1,5434 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "aarch64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-modular-20221124/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f6ca9de0cbf98956bf3180f550c1d9909e7e945ebebd20380a9bf77ebd8daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8d48d7281ea210739dab7683b99bd258ecf55ea9000b4760a3e4a184e793271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ab06f92a73a2c4fcaf9f37f01b2ff3dc836e9368e71535edf6a0e2c28fa1a8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d37c6882158f2d0e5c023a9a79f871f6fa4f13fac2e3c50051e922df527a3c2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48d1ca2ee7b6bcd7a7f6f60baefe4c57a4a45e664bc338ac25bbb556d4558fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e1ef0a0154ad65fb92afaab2d78427d06bf92ad6dfbf743dbf315de19c431d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:150002881c14cefcb4b3deb97b39c424121a6ca065472617a52f1d887df9d0f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6589e8170270f31dafd680a1bb4a57b47798a6f5b22ddd7c82be67f397e6bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6e593903ff1f499c5abb8deb49b7dd0d7b65b75ee7121553a361d320ccc427",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b60c73d7dc66f752dc8510de3ce1eb3780c31f1375c8bdae658cfbb6f6f32d1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e23a05a54cac23795f6457aa88d6d001e62e3dbf5113878ee0f737c4f2845291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48e6dd59e7daaba3c407e7b271b3f5a8012d51f35b9ed2298a005caf1bfff16d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:488e9a07587b0a866e39aae0fd91edd88f67836fda8ffcdfe7a5412b9f55c6cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fddae44964d432ec1e7f29e0cef352a849f3feb5db19767f72259dfdfcef4fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa361bf36d96298ea8e486f255ddb8b4948a64428e435d85f5cd00a07bbbae1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3a5e5ba1bc64c23c57877c645adb9e8b169917f7f11343de6e358738a1f9d72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f5a3d9730c0cd2d5db942e6b127f493053c95917fd1f15adaf28414692ce8ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbbf689594edc72d15b3ead81957da9328e89bd7ae41469cf7b869fe9c8f645c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a312f8a6db297717048369e37e8602be6e8d80c75302e013ae9ad7f91d0f635",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b742a439a5c503f4557eff3d17445e549a29fc8fad99dd40f3dbfb07fd50a125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:deec0a7da26227cf9f5c3841c4493e9bb12855f4e107116107e1d8361be05f46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3e4d8e17c8f766c2048964c0c29d4b391fe7e5a243d14985246439aa53bc435",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8e8f22ebe704e0b8224ba5ddb83f7a3786b0b6db005b6c574b7f94938463ec3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6ee6976236056e8651c3844c1d9fc35a3039da594e855c28ac1f22034c1c434",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23a73747b6174d9e10a0bd0e0d7857623a137f51aa309906408fbcc9a2ac3f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31271c94bae57cf20439deabcf58eb4e2d387a1a347137134637b80fec18e2c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50ad09e48c108e0f8536c45af9625517682256deb4fa41860e41de6810a39876",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc84893932face7a7f453fa05a3f6c8fcbfefa81d4654d04ab0dd9ecb1601cda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b86eef4734a15061c9d75322d7b4c83eb05fda101149cf49f784d89b661af16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c924ce26e661940e2e8699b9a3005f362fe2e2cc814c896c2b44ff616406a41b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dcac57a317164c1d461c94885d9f6d5758d3e2358b86cde5272b996cdf4a711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a994a75c98ff7a31dd6d72d1ad170b712c285d1ba5a6cdabc617f05c5d9ab206",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:019d2ecf6a8ae64005ca8af5a589f0870604552df2d37f983559b2336379d1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42df3a3b3108800a0c04d8eeaa86d72996979d00b77ac25573676d779004ed5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24f70859f93e04eb55e8011f79cd597b99eb35618ad4ac3beca9b86eb09b7590",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f7109f2dd51edd47ec3245db5fcb59b001cc8fe436f3d8e775ba0a853608129",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3850b6dd0e626046fa856ad8898b107ac6a576cf43b2f8faef274ad7bc35037",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fe2d7b927c7f5a95822e907b8cf5c35726f9f128ba89489f17c1c1a423c2207",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efb1f868b73851d3bb0934fbd9248297e1b1b72f30f46a11ec10c3481f0a56c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96cf2581640c2f2b1af62104b6272b67248d49705a3305c279ef4676e7d80a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85e1cea3acc32b11a948b6678a0f93f2b110fbcd99647a0bb1756de81878a93e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9b86f3f5bec3585cb87bf5ea2d83cdf23f013739a868153bafe8b07fb5c84fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2936413da643fcfc27d974394f57f2ad930cc128794bd3c55abd1918115737d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5673e66cf599efb1b6de1314651f6f8ade57e0748eab1405bb60d820f709d3c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebf44cdced84fcacf8f635b6e105733cf33aba3cf119480c473c27fe310ce9a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364493c57eb5d03454eee1dd81e36acbaefdbe95f6e8af08166fb0a41644346c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47291119309bdeafde6e524dd666dfb03dfe3a988bceeffcb48a9fe18100c333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cdc7bd5c850ec2f9e51e86580def05c2e6beb5c6328f39f731d882d363912a2c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3becdf1fcbb26b646fd431a9edf87d2cc7debe8f4e3bc8d2396dda8065e8e1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c1b026577edb4422f2fa491d5ec268ee664d2840a419fb6232eaddcaa017d72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20bdb749286a7de94279e92c91d12a3606beda44c60399e731ec96d14794eed0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06bf4ce7962510a159332ba67d7e5050d94486a23909b99071118b88f5bd1f82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45eabcf9dc9c30a84f0b546a4b94059b0df03cfa675a1ce97bdf1a09e1ce4bfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59efdb6ef00614f5455f3afa3d0d6db1c366c8d1b9e651fe3479eaaf76741e0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3eabc45953ae7782eec81f0e6091765f115d1bab504424fab2785a71d119822",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daa2903bbb115115bf236a28f3ef45f1b53d99d8d2ee4466b5565b9723d72f54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6dd3a1ecccb4c982a4abfa2e15787a45715954db220560b8f1a7cd48c9b348c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3f9b8367f563033c8e39cd8225f383a0c07b6429834225d1853de51e25294a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:271e74e2fe3e497fc18edd1a9464921c33afe94553114f17a46dab25b89ea7eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e26dd78533f477636c31e697780fa3fc200cb81ec2a9c653d8585d3b5280a256",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35df361cb45564cecad69570e7c312b173810330979b4282d43f31cf260a38f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2585b6ff902a79054c49c66d395d5fce317cacba575f614556df57a25ed62f3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42cfdee459665f1a7b5b356e0e90283ee4094552370abb42315d9243d0320a69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd6ddd76a3a5f1973d1d63a8a3d0954fefeb895d062eb3800ffd88b49b36a689",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b04e41229130c237265cd6e843bb2a32b9063b813429ac6a5a2480543222f86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28d80cd115635d1351da32a67e289a51451cd2346af8302bf27249dead67ce05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995e8a5333bf075a3e7091d14b915a8ac748361a9e2f3aa2c99d0979baa56b6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7cf1113bcf5922ce3f0643f3db1999a00cda65e30531ae2e2cdebfba9abcb72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f39ecbec3414c8cec69bdbad78d37821c8bc3ff456d42e49654bae4894712c2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e6f1806614d132e0569f8fb33991f5f29e0e6f2bb849e6dc3652a8ed3357065",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4d742921a241631d570f363f6a464a550c91e32cc672fed6f5b55657b103e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4259103f53a185bd4ea6138bcd6e3fe87788858754b897ab6d3f3c4fd338d4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd934451704cf44e374e9d3b034bdcc47dade95d43cb96ce9c2625b6aad3f2d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef1a41cd63b09555d51c1f8328411ce42403183a8540499c6823e08774aca35d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eead91720ac2660f8d96005035a541e893d3d7ec43039404cc8fbcc14f2a1884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a32f267edc8706df2a4f7621160acbacbad95cb76a6a63e37e4b311b1afae97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2a90558e9caef1600e4f9bd4aa369b5a9fbbd5271cfd769d03b40012d08d63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d83044111c1115aa97ae42c223e8939e2776b7a981bd29dd1854f5d16bde341b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8fa2f95339b373524453f7957bf11111f2752df463529308fa581d427871e02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd8751590ce26d187ae0acc8a6c926ca97977f97d4b11c609339545c36d1500a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f00b4ddd2d088a22d5c655487a9ce2484db60bf6ba70ee5c2da2640cb6b13ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9f788227eaa3457d95f6e07a512fa4a7d31fb019f8562a074172973ffbe13d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb4f373538d5eae216ee832dedd2969f62c561acb48b298cc27b0de03a0e2417",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:badabbe5320139f9904186ed35c7290704d1e3b23adf2805fe5c172d5ce7a968",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebbf70618c9164072cfa0a3ae3f6f0e6ed011ebace68bb939ce4994f4f08b229",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c4e8f525f42431ee3d0554cfba40dd71296407b3c40c0159a7d38f1c8411078",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:084cce3cd53c4039dae21b29d9c7a93f6da354d08455c15f049848c908eecc80",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e88c079833bdfdee49aaf6eb9b5a54d3588e30ec90a296041c9819e1b8bbbfb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15b3baab1390174eaea557022701bbfe61d8e567aa3ef6724b887146941651db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a277222ae354325b1913783a2b0d33ae7fd43456f2a1b947e3ff5a6137c08039",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0db39885030f18581efa981ac64ac178af231059c1448cdc1958f8540f14b2ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03394059c90c75aac91f312678bd9e9c2e48543339bc5e6a111fff911ca5b442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60df17f90cd3fafe85a4512b323c1773bb174a717b7de6dcd6235f71807fab1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4430b8aafa44d6b1ff5a6085e6f02a5fdbc5effb9817843090b120274014297",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f6dfc01d894a18954e247c1040453ffed4063ad6139b41e4424abc7103f772b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63df934e3fc969330fa1be978cbc34098c96afbde3dd6c2c86cc5e3ccb482817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 17846272,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:019d2ecf6a8ae64005ca8af5a589f0870604552df2d37f983559b2336379d1e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-94.fc37.aarch64.rpm"
+          },
+          "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:03394059c90c75aac91f312678bd9e9c2e48543339bc5e6a111fff911ca5b442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tpm2-tss-3.2.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:06bf4ce7962510a159332ba67d7e5050d94486a23909b99071118b88f5bd1f82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libsepol-3.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:084cce3cd53c4039dae21b29d9c7a93f6da354d08455c15f049848c908eecc80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-networkd-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:0b04e41229130c237265cd6e843bb2a32b9063b813429ac6a5a2480543222f86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/openldap-2.6.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cpio-2.13-13.fc37.aarch64.rpm"
+          },
+          "sha256:0b86eef4734a15061c9d75322d7b4c83eb05fda101149cf49f784d89b661af16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnupg2-smime-2.3.8-1.fc37.aarch64.rpm"
+          },
+          "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:0db39885030f18581efa981ac64ac178af231059c1448cdc1958f8540f14b2ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tpm2-tools-5.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:150002881c14cefcb4b3deb97b39c424121a6ca065472617a52f1d887df9d0f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/coreutils-common-9.1-8.fc37.aarch64.rpm"
+          },
+          "sha256:15b3baab1390174eaea557022701bbfe61d8e567aa3ef6724b887146941651db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-resolved-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cracklib-dicts-2.9.7-30.fc37.aarch64.rpm"
+          },
+          "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:1f6ca9de0cbf98956bf3180f550c1d9909e7e945ebebd20380a9bf77ebd8daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc37.aarch64.rpm"
+          },
+          "sha256:20bdb749286a7de94279e92c91d12a3606beda44c60399e731ec96d14794eed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libsemanage-3.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:23a73747b6174d9e10a0bd0e0d7857623a137f51aa309906408fbcc9a2ac3f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-common-2.36-9.fc37.aarch64.rpm"
+          },
+          "sha256:24f70859f93e04eb55e8011f79cd597b99eb35618ad4ac3beca9b86eb09b7590": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/k/kpartx-0.9.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:2585b6ff902a79054c49c66d395d5fce317cacba575f614556df57a25ed62f3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc37.aarch64.rpm"
+          },
+          "sha256:271e74e2fe3e497fc18edd1a9464921c33afe94553114f17a46dab25b89ea7eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:28d80cd115635d1351da32a67e289a51451cd2346af8302bf27249dead67ce05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/openssl-libs-3.0.8-1.fc37.aarch64.rpm"
+          },
+          "sha256:2936413da643fcfc27d974394f57f2ad930cc128794bd3c55abd1918115737d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libidn2-2.3.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:2dcac57a317164c1d461c94885d9f6d5758d3e2358b86cde5272b996cdf4a711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-efi-aa64-2.06-94.fc37.aarch64.rpm"
+          },
+          "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-common-1.14.6-1.fc37.noarch.rpm"
+          },
+          "sha256:2f7109f2dd51edd47ec3245db5fcb59b001cc8fe436f3d8e775ba0a853608129": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/k/krb5-libs-1.19.2-13.fc37.aarch64.rpm"
+          },
+          "sha256:2fe2d7b927c7f5a95822e907b8cf5c35726f9f128ba89489f17c1c1a423c2207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libcurl-7.85.0-8.fc37.aarch64.rpm"
+          },
+          "sha256:31271c94bae57cf20439deabcf58eb4e2d387a1a347137134637b80fec18e2c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.36-9.fc37.aarch64.rpm"
+          },
+          "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/containers-common-1-82.fc37.noarch.rpm"
+          },
+          "sha256:35df361cb45564cecad69570e7c312b173810330979b4282d43f31cf260a38f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/lz4-libs-1.9.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:364493c57eb5d03454eee1dd81e36acbaefdbe95f6e8af08166fb0a41644346c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libnghttp2-1.51.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:3becdf1fcbb26b646fd431a9edf87d2cc7debe8f4e3bc8d2396dda8065e8e1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libselinux-3.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:3c1b026577edb4422f2fa491d5ec268ee664d2840a419fb6232eaddcaa017d72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libselinux-utils-3.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:3c4e8f525f42431ee3d0554cfba40dd71296407b3c40c0159a7d38f1c8411078": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-libs-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3e6f1806614d132e0569f8fb33991f5f29e0e6f2bb849e6dc3652a8ed3357065": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/polkit-121-4.fc37.2.aarch64.rpm"
+          },
+          "sha256:3f5a3d9730c0cd2d5db942e6b127f493053c95917fd1f15adaf28414692ce8ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc37.aarch64.rpm"
+          },
+          "sha256:42cfdee459665f1a7b5b356e0e90283ee4094552370abb42315d9243d0320a69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/m/mozjs102-102.9.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:42df3a3b3108800a0c04d8eeaa86d72996979d00b77ac25573676d779004ed5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/j/json-c-0.16-3.fc37.aarch64.rpm"
+          },
+          "sha256:45eabcf9dc9c30a84f0b546a4b94059b0df03cfa675a1ce97bdf1a09e1ce4bfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:47291119309bdeafde6e524dd666dfb03dfe3a988bceeffcb48a9fe18100c333": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libpwquality-1.4.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-gpg-keys-37-2.noarch.rpm"
+          },
+          "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse3-libs-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/popt-1.19-1.fc37.aarch64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:488e9a07587b0a866e39aae0fd91edd88f67836fda8ffcdfe7a5412b9f55c6cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dracut-config-generic-059-2.fc37.aarch64.rpm"
+          },
+          "sha256:48d1ca2ee7b6bcd7a7f6f60baefe4c57a4a45e664bc338ac25bbb556d4558fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/b/bash-5.2.15-1.fc37.aarch64.rpm"
+          },
+          "sha256:48e6dd59e7daaba3c407e7b271b3f5a8012d51f35b9ed2298a005caf1bfff16d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dracut-059-2.fc37.aarch64.rpm"
+          },
+          "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4a9f788227eaa3457d95f6e07a512fa4a7d31fb019f8562a074172973ffbe13d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:50ad09e48c108e0f8536c45af9625517682256deb4fa41860e41de6810a39876": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.36-9.fc37.aarch64.rpm"
+          },
+          "sha256:5673e66cf599efb1b6de1314651f6f8ade57e0748eab1405bb60d820f709d3c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libksba-1.6.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-common-37-16.noarch.rpm"
+          },
+          "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:59efdb6ef00614f5455f3afa3d0d6db1c366c8d1b9e651fe3479eaaf76741e0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libstdc++-12.3.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:5a312f8a6db297717048369e37e8602be6e8d80c75302e013ae9ad7f91d0f635": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc37.aarch64.rpm"
+          },
+          "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:5e88c079833bdfdee49aaf6eb9b5a54d3588e30ec90a296041c9819e1b8bbbfb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-pam-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse3-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:60df17f90cd3fafe85a4512b323c1773bb174a717b7de6dcd6235f71807fab1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/w/which-2.21-39.fc37.aarch64.rpm"
+          },
+          "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/n/ncurses-base-6.3-5.20220501.fc37.noarch.rpm"
+          },
+          "sha256:63df934e3fc969330fa1be978cbc34098c96afbde3dd6c2c86cc5e3ccb482817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/n/npth-1.6-9.fc37.aarch64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/selinux-policy-targeted-37.21-2.fc37.noarch.rpm"
+          },
+          "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc37.noarch.rpm"
+          },
+          "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc37.noarch.rpm"
+          },
+          "sha256:6a32f267edc8706df2a4f7621160acbacbad95cb76a6a63e37e4b311b1afae97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-4.18.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:6ab06f92a73a2c4fcaf9f37f01b2ff3dc836e9368e71535edf6a0e2c28fa1a8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/authselect-1.4.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-common-3.10.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-setuptools-wheel-62.6.0-3.fc37.noarch.rpm"
+          },
+          "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc37.noarch.rpm"
+          },
+          "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm"
+          },
+          "sha256:7f6dfc01d894a18954e247c1040453ffed4063ad6139b41e4424abc7103f772b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xz-libs-5.4.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:85e1cea3acc32b11a948b6678a0f93f2b110fbcd99647a0bb1756de81878a93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgomp-12.3.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/grep-3.7-4.fc37.aarch64.rpm"
+          },
+          "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:96cf2581640c2f2b1af62104b6272b67248d49705a3305c279ef4676e7d80a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgcc-12.3.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:995e8a5333bf075a3e7091d14b915a8ac748361a9e2f3aa2c99d0979baa56b6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/ostree-2022.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:9e1ef0a0154ad65fb92afaab2d78427d06bf92ad6dfbf743dbf315de19c431d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/coreutils-9.1-8.fc37.aarch64.rpm"
+          },
+          "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:9f00b4ddd2d088a22d5c655487a9ce2484db60bf6ba70ee5c2da2640cb6b13ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/shadow-utils-4.12.3-6.fc37.aarch64.rpm"
+          },
+          "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a277222ae354325b1913783a2b0d33ae7fd43456f2a1b947e3ff5a6137c08039": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-udev-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:a2a90558e9caef1600e4f9bd4aa369b5a9fbbd5271cfd769d03b40012d08d63d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a4d742921a241631d570f363f6a464a550c91e32cc672fed6f5b55657b103e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/polkit-libs-121-4.fc37.2.aarch64.rpm"
+          },
+          "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc37.noarch.rpm"
+          },
+          "sha256:a6dd3a1ecccb4c982a4abfa2e15787a45715954db220560b8f1a7cd48c9b348c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libxcrypt-4.4.33-4.fc37.aarch64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a6ee6976236056e8651c3844c1d9fc35a3039da594e855c28ac1f22034c1c434": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-2.36-9.fc37.aarch64.rpm"
+          },
+          "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tzdata-2023c-1.fc37.noarch.rpm"
+          },
+          "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:a994a75c98ff7a31dd6d72d1ad170b712c285d1ba5a6cdabc617f05c5d9ab206": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-tools-2.06-94.fc37.aarch64.rpm"
+          },
+          "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/ca-certificates-2023.2.60-1.0.fc37.noarch.rpm"
+          },
+          "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/selinux-policy-37.21-2.fc37.noarch.rpm"
+          },
+          "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm"
+          },
+          "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b60c73d7dc66f752dc8510de3ce1eb3780c31f1375c8bdae658cfbb6f6f32d1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-1.14.6-1.fc37.aarch64.rpm"
+          },
+          "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-identity-basic-37-16.noarch.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b742a439a5c503f4557eff3d17445e549a29fc8fad99dd40f3dbfb07fd50a125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-envsubst-0.21.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm"
+          },
+          "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:badabbe5320139f9904186ed35c7290704d1e3b23adf2805fe5c172d5ce7a968": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:bd6ddd76a3a5f1973d1d63a8a3d0954fefeb895d062eb3800ffd88b49b36a689": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/n/ncurses-libs-6.3-5.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm"
+          },
+          "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:c3a5e5ba1bc64c23c57877c645adb9e8b169917f7f11343de6e358738a1f9d72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc37.aarch64.rpm"
+          },
+          "sha256:c6589e8170270f31dafd680a1bb4a57b47798a6f5b22ddd7c82be67f397e6bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:c7cf1113bcf5922ce3f0643f3db1999a00cda65e30531ae2e2cdebfba9abcb72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/ostree-libs-2022.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:c8d48d7281ea210739dab7683b99bd258ecf55ea9000b4760a3e4a184e793271": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:c924ce26e661940e2e8699b9a3005f362fe2e2cc814c896c2b44ff616406a41b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnutls-3.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:cd934451704cf44e374e9d3b034bdcc47dade95d43cb96ce9c2625b6aad3f2d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:cdc7bd5c850ec2f9e51e86580def05c2e6beb5c6328f39f731d882d363912a2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/librepo-1.15.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:d37c6882158f2d0e5c023a9a79f871f6fa4f13fac2e3c50051e922df527a3c2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/authselect-libs-1.4.2-1.fc37.aarch64.rpm"
+          },
+          "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:d83044111c1115aa97ae42c223e8939e2776b7a981bd29dd1854f5d16bde341b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:d8e8f22ebe704e0b8224ba5ddb83f7a3786b0b6db005b6c574b7f94938463ec3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glib2-2.74.7-1.fc37.aarch64.rpm"
+          },
+          "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:daa2903bbb115115bf236a28f3ef45f1b53d99d8d2ee4466b5565b9723d72f54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc37.aarch64.rpm"
+          },
+          "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-37-16.noarch.rpm"
+          },
+          "sha256:dc84893932face7a7f453fa05a3f6c8fcbfefa81d4654d04ab0dd9ecb1601cda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnupg2-2.3.8-1.fc37.aarch64.rpm"
+          },
+          "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:dd8751590ce26d187ae0acc8a6c926ca97977f97d4b11c609339545c36d1500a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xkeyboard-config-2.36-3.fc37.noarch.rpm"
+          },
+          "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:deec0a7da26227cf9f5c3841c4493e9bb12855f4e107116107e1d8361be05f46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-libs-0.21.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:e23a05a54cac23795f6457aa88d6d001e62e3dbf5113878ee0f737c4f2845291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-broker-33-1.fc37.aarch64.rpm"
+          },
+          "sha256:e26dd78533f477636c31e697780fa3fc200cb81ec2a9c653d8585d3b5280a256": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/lua-libs-5.4.4-9.fc37.aarch64.rpm"
+          },
+          "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:e3850b6dd0e626046fa856ad8898b107ac6a576cf43b2f8faef274ad7bc35037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libarchive-3.6.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:e4259103f53a185bd4ea6138bcd6e3fe87788858754b897ab6d3f3c4fd338d4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/procps-ng-3.3.17-6.fc37.2.aarch64.rpm"
+          },
+          "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc37.noarch.rpm"
+          },
+          "sha256:eb4f373538d5eae216ee832dedd2969f62c561acb48b298cc27b0de03a0e2417": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/sqlite-libs-3.40.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc37.noarch.rpm"
+          },
+          "sha256:ebbf70618c9164072cfa0a3ae3f6f0e6ed011ebace68bb939ce4994f4f08b229": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-boot-unsigned-251.14-2.fc37.aarch64.rpm"
+          },
+          "sha256:ebf44cdced84fcacf8f635b6e105733cf33aba3cf119480c473c27fe310ce9a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:ed6e593903ff1f499c5abb8deb49b7dd0d7b65b75ee7121553a361d320ccc427": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/curl-7.85.0-8.fc37.aarch64.rpm"
+          },
+          "sha256:eead91720ac2660f8d96005035a541e893d3d7ec43039404cc8fbcc14f2a1884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/readline-8.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:ef1a41cd63b09555d51c1f8328411ce42403183a8540499c6823e08774aca35d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:efb1f868b73851d3bb0934fbd9248297e1b1b72f30f46a11ec10c3481f0a56c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libffi-3.4.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libicu-71.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:f39ecbec3414c8cec69bdbad78d37821c8bc3ff456d42e49654bae4894712c2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/policycoreutils-3.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:f3e4d8e17c8f766c2048964c0c29d4b391fe7e5a243d14985246439aa53bc435": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-runtime-0.21.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:f3eabc45953ae7782eec81f0e6091765f115d1bab504424fab2785a71d119822": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libtasn1-4.19.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:f3f9b8367f563033c8e39cd8225f383a0c07b6429834225d1853de51e25294a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-repos-37-2.noarch.rpm"
+          },
+          "sha256:f4430b8aafa44d6b1ff5a6085e6f02a5fdbc5effb9817843090b120274014297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xz-5.4.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/grubby-8.40-66.fc37.aarch64.rpm"
+          },
+          "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-pip-wheel-22.2.2-3.fc37.noarch.rpm"
+          },
+          "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm"
+          },
+          "sha256:f8fa2f95339b373524453f7957bf11111f2752df463529308fa581d427871e02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:f9b86f3f5bec3585cb87bf5ea2d83cdf23f013739a868153bafe8b07fb5c84fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgpg-error-1.46-1.fc37.aarch64.rpm"
+          },
+          "sha256:fa361bf36d96298ea8e486f255ddb8b4948a64428e435d85f5cd00a07bbbae1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc37.aarch64.rpm"
+          },
+          "sha256:fbbf689594edc72d15b3ead81957da9328e89bd7ae41469cf7b869fe9c8f645c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/expat-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-common-2.06-94.fc37.noarch.rpm"
+          },
+          "sha256:fddae44964d432ec1e7f29e0cef352a849f3feb5db19767f72259dfdfcef4fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/efivar-libs-38-6.fc37.aarch64.rpm"
+          },
+          "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cracklib-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:f83d5f59d9e289df361e2d46bf18143245b1324f3e2fb71b91ff7740a897a215",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cracklib-dicts-2.9.7-30.fc37.aarch64.rpm",
+        "checksum": "sha256:162c1a1b7c420d6a68eefa26936cac74a378ddfc268b4e48058be0773601d808",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:f40c72435d400e98d507c95a1e4993d70ed5a80556a7436bc8c51c82fa92f2b8",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-common-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:6c50aa26df3d6c070897a3349eb72f47d144a79bc387a38ecbdc63063e85af03",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse3-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e983c066245eb18c7209a3165fe9335efe0ef74dba849a47e1c1332dcf4c320",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/f/fuse3-libs-3.10.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:47af1946fbfaa768f34e4d7818286123d1ea8679140479fa1b3c1d6f62560983",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-2.5.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d0e859a97a8167af62e273093e454a01bfd64b9ff60897bc97711f3591970106",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libicu-71.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2bd8534e896f251cd58b8cbb0b069fcaa464aa2a84fbd9d8187690f3c979fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm",
+        "checksum": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/n/npth-1.6-9.fc37.aarch64.rpm",
+        "checksum": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ce155c86d0bd2ff0bf29a3ffd454fcf085389e2568a6d158cad79c55f895d683",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ba7fe160856cb5c4385d6cd5ed9b2973de52521e3a944dacf221eacc77dc44de",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9bef843589abaf3dfb3ff5c72b6630f5b6e6ec8d706f2d569d6b503385844444",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/pinentry-1.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5cc444fb3971b6889d20cb009bbe91cc464c2fc027e6aacd6927a13d3bbb10be",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/p/popt-1.19-1.fc37.aarch64.rpm",
+        "checksum": "sha256:48410dce2b1c514e23d2e9e067714be0eb2923ff44e3ac7dde373a92474ff642",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-20221124/Packages/z/zlib-1.2.12-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b36a3a887d8c0ba3c92f10d19cdea086b9ade294032a7b7524a655da3a343875",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1f6ca9de0cbf98956bf3180f550c1d9909e7e945ebebd20380a9bf77ebd8daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c8d48d7281ea210739dab7683b99bd258ecf55ea9000b4760a3e4a184e793271",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/authselect-1.4.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6ab06f92a73a2c4fcaf9f37f01b2ff3dc836e9368e71535edf6a0e2c28fa1a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/a/authselect-libs-1.4.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d37c6882158f2d0e5c023a9a79f871f6fa4f13fac2e3c50051e922df527a3c2d",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/b/bash-5.2.15-1.fc37.aarch64.rpm",
+        "checksum": "sha256:48d1ca2ee7b6bcd7a7f6f60baefe4c57a4a45e664bc338ac25bbb556d4558fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "1.0.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/ca-certificates-2023.2.60-1.0.fc37.noarch.rpm",
+        "checksum": "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "82.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/containers-common-1-82.fc37.noarch.rpm",
+        "checksum": "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/coreutils-9.1-8.fc37.aarch64.rpm",
+        "checksum": "sha256:9e1ef0a0154ad65fb92afaab2d78427d06bf92ad6dfbf743dbf315de19c431d0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/coreutils-common-9.1-8.fc37.aarch64.rpm",
+        "checksum": "sha256:150002881c14cefcb4b3deb97b39c424121a6ca065472617a52f1d887df9d0f4",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c6589e8170270f31dafd680a1bb4a57b47798a6f5b22ddd7c82be67f397e6bee",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/c/curl-7.85.0-8.fc37.aarch64.rpm",
+        "checksum": "sha256:ed6e593903ff1f499c5abb8deb49b7dd0d7b65b75ee7121553a361d320ccc427",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-1.14.6-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b60c73d7dc66f752dc8510de3ce1eb3780c31f1375c8bdae658cfbb6f6f32d1e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-broker-33-1.fc37.aarch64.rpm",
+        "checksum": "sha256:e23a05a54cac23795f6457aa88d6d001e62e3dbf5113878ee0f737c4f2845291",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dbus-common-1.14.6-1.fc37.noarch.rpm",
+        "checksum": "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dracut-059-2.fc37.aarch64.rpm",
+        "checksum": "sha256:48e6dd59e7daaba3c407e7b271b3f5a8012d51f35b9ed2298a005caf1bfff16d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/d/dracut-config-generic-059-2.fc37.aarch64.rpm",
+        "checksum": "sha256:488e9a07587b0a866e39aae0fd91edd88f67836fda8ffcdfe7a5412b9f55c6cb",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/efivar-libs-38-6.fc37.aarch64.rpm",
+        "checksum": "sha256:fddae44964d432ec1e7f29e0cef352a849f3feb5db19767f72259dfdfcef4fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fa361bf36d96298ea8e486f255ddb8b4948a64428e435d85f5cd00a07bbbae1b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc37.noarch.rpm",
+        "checksum": "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c3a5e5ba1bc64c23c57877c645adb9e8b169917f7f11343de6e358738a1f9d72",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3f5a3d9730c0cd2d5db942e6b127f493053c95917fd1f15adaf28414692ce8ee",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/e/expat-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fbbf689594edc72d15b3ead81957da9328e89bd7ae41469cf7b869fe9c8f645c",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-gpg-keys-37-2.noarch.rpm",
+        "checksum": "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-37-16.noarch.rpm",
+        "checksum": "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-common-37-16.noarch.rpm",
+        "checksum": "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-release-identity-basic-37-16.noarch.rpm",
+        "checksum": "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fedora-repos-37-2.noarch.rpm",
+        "checksum": "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5a312f8a6db297717048369e37e8602be6e8d80c75302e013ae9ad7f91d0f635",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-envsubst-0.21.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b742a439a5c503f4557eff3d17445e549a29fc8fad99dd40f3dbfb07fd50a125",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-libs-0.21.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:deec0a7da26227cf9f5c3841c4493e9bb12855f4e107116107e1d8361be05f46",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gettext-runtime-0.21.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f3e4d8e17c8f766c2048964c0c29d4b391fe7e5a243d14985246439aa53bc435",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.7",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glib2-2.74.7-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d8e8f22ebe704e0b8224ba5ddb83f7a3786b0b6db005b6c574b7f94938463ec3",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-2.36-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a6ee6976236056e8651c3844c1d9fc35a3039da594e855c28ac1f22034c1c434",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-common-2.36-9.fc37.aarch64.rpm",
+        "checksum": "sha256:23a73747b6174d9e10a0bd0e0d7857623a137f51aa309906408fbcc9a2ac3f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.36-9.fc37.aarch64.rpm",
+        "checksum": "sha256:31271c94bae57cf20439deabcf58eb4e2d387a1a347137134637b80fec18e2c4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.36-9.fc37.aarch64.rpm",
+        "checksum": "sha256:50ad09e48c108e0f8536c45af9625517682256deb4fa41860e41de6810a39876",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnupg2-2.3.8-1.fc37.aarch64.rpm",
+        "checksum": "sha256:dc84893932face7a7f453fa05a3f6c8fcbfefa81d4654d04ab0dd9ecb1601cda",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnupg2-smime-2.3.8-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0b86eef4734a15061c9d75322d7b4c83eb05fda101149cf49f784d89b661af16",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/gnutls-3.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c924ce26e661940e2e8699b9a3005f362fe2e2cc814c896c2b44ff616406a41b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-common-2.06-94.fc37.noarch.rpm",
+        "checksum": "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-efi-aa64-2.06-94.fc37.aarch64.rpm",
+        "checksum": "sha256:2dcac57a317164c1d461c94885d9f6d5758d3e2358b86cde5272b996cdf4a711",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-tools-2.06-94.fc37.aarch64.rpm",
+        "checksum": "sha256:a994a75c98ff7a31dd6d72d1ad170b712c285d1ba5a6cdabc617f05c5d9ab206",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-94.fc37.aarch64.rpm",
+        "checksum": "sha256:019d2ecf6a8ae64005ca8af5a589f0870604552df2d37f983559b2336379d1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/j/json-c-0.16-3.fc37.aarch64.rpm",
+        "checksum": "sha256:42df3a3b3108800a0c04d8eeaa86d72996979d00b77ac25573676d779004ed5d",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/k/kpartx-0.9.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:24f70859f93e04eb55e8011f79cd597b99eb35618ad4ac3beca9b86eb09b7590",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/k/krb5-libs-1.19.2-13.fc37.aarch64.rpm",
+        "checksum": "sha256:2f7109f2dd51edd47ec3245db5fcb59b001cc8fe436f3d8e775ba0a853608129",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libarchive-3.6.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e3850b6dd0e626046fa856ad8898b107ac6a576cf43b2f8faef274ad7bc35037",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libcurl-7.85.0-8.fc37.aarch64.rpm",
+        "checksum": "sha256:2fe2d7b927c7f5a95822e907b8cf5c35726f9f128ba89489f17c1c1a423c2207",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libffi-3.4.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:efb1f868b73851d3bb0934fbd9248297e1b1b72f30f46a11ec10c3481f0a56c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgcc-12.3.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:96cf2581640c2f2b1af62104b6272b67248d49705a3305c279ef4676e7d80a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgomp-12.3.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:85e1cea3acc32b11a948b6678a0f93f2b110fbcd99647a0bb1756de81878a93e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libgpg-error-1.46-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f9b86f3f5bec3585cb87bf5ea2d83cdf23f013739a868153bafe8b07fb5c84fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libidn2-2.3.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:2936413da643fcfc27d974394f57f2ad930cc128794bd3c55abd1918115737d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libksba-1.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5673e66cf599efb1b6de1314651f6f8ade57e0748eab1405bb60d820f709d3c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ebf44cdced84fcacf8f635b6e105733cf33aba3cf119480c473c27fe310ce9a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.51.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libnghttp2-1.51.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:364493c57eb5d03454eee1dd81e36acbaefdbe95f6e8af08166fb0a41644346c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libpwquality-1.4.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:47291119309bdeafde6e524dd666dfb03dfe3a988bceeffcb48a9fe18100c333",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/librepo-1.15.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:cdc7bd5c850ec2f9e51e86580def05c2e6beb5c6328f39f731d882d363912a2c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libselinux-3.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3becdf1fcbb26b646fd431a9edf87d2cc7debe8f4e3bc8d2396dda8065e8e1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libselinux-utils-3.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3c1b026577edb4422f2fa491d5ec268ee664d2840a419fb6232eaddcaa017d72",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libsemanage-3.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:20bdb749286a7de94279e92c91d12a3606beda44c60399e731ec96d14794eed0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libsepol-3.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:06bf4ce7962510a159332ba67d7e5050d94486a23909b99071118b88f5bd1f82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:45eabcf9dc9c30a84f0b546a4b94059b0df03cfa675a1ce97bdf1a09e1ce4bfb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc37.noarch.rpm",
+        "checksum": "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libstdc++-12.3.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:59efdb6ef00614f5455f3afa3d0d6db1c366c8d1b9e651fe3479eaaf76741e0d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libtasn1-4.19.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f3eabc45953ae7782eec81f0e6091765f115d1bab504424fab2785a71d119822",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc37.aarch64.rpm",
+        "checksum": "sha256:daa2903bbb115115bf236a28f3ef45f1b53d99d8d2ee4466b5565b9723d72f54",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libxcrypt-4.4.33-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a6dd3a1ecccb4c982a4abfa2e15787a45715954db220560b8f1a7cd48c9b348c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f3f9b8367f563033c8e39cd8225f383a0c07b6429834225d1853de51e25294a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:271e74e2fe3e497fc18edd1a9464921c33afe94553114f17a46dab25b89ea7eb",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/lua-libs-5.4.4-9.fc37.aarch64.rpm",
+        "checksum": "sha256:e26dd78533f477636c31e697780fa3fc200cb81ec2a9c653d8585d3b5280a256",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/l/lz4-libs-1.9.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:35df361cb45564cecad69570e7c312b173810330979b4282d43f31cf260a38f3",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc37.aarch64.rpm",
+        "checksum": "sha256:2585b6ff902a79054c49c66d395d5fce317cacba575f614556df57a25ed62f3b",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.9.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/m/mozjs102-102.9.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:42cfdee459665f1a7b5b356e0e90283ee4094552370abb42315d9243d0320a69",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "5.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/n/ncurses-base-6.3-5.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "5.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/n/ncurses-libs-6.3-5.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:bd6ddd76a3a5f1973d1d63a8a3d0954fefeb895d062eb3800ffd88b49b36a689",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/openldap-2.6.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0b04e41229130c237265cd6e843bb2a32b9063b813429ac6a5a2480543222f86",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/openssl-libs-3.0.8-1.fc37.aarch64.rpm",
+        "checksum": "sha256:28d80cd115635d1351da32a67e289a51451cd2346af8302bf27249dead67ce05",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/ostree-2022.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:995e8a5333bf075a3e7091d14b915a8ac748361a9e2f3aa2c99d0979baa56b6f",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/o/ostree-libs-2022.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c7cf1113bcf5922ce3f0643f3db1999a00cda65e30531ae2e2cdebfba9abcb72",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/policycoreutils-3.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f39ecbec3414c8cec69bdbad78d37821c8bc3ff456d42e49654bae4894712c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/polkit-121-4.fc37.2.aarch64.rpm",
+        "checksum": "sha256:3e6f1806614d132e0569f8fb33991f5f29e0e6f2bb849e6dc3652a8ed3357065",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/polkit-libs-121-4.fc37.2.aarch64.rpm",
+        "checksum": "sha256:a4d742921a241631d570f363f6a464a550c91e32cc672fed6f5b55657b103e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/procps-ng-3.3.17-6.fc37.2.aarch64.rpm",
+        "checksum": "sha256:e4259103f53a185bd4ea6138bcd6e3fe87788858754b897ab6d3f3c4fd338d4b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc37.noarch.rpm",
+        "checksum": "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-pip-wheel-22.2.2-3.fc37.noarch.rpm",
+        "checksum": "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-setuptools-wheel-62.6.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cd934451704cf44e374e9d3b034bdcc47dade95d43cb96ce9c2625b6aad3f2d0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ef1a41cd63b09555d51c1f8328411ce42403183a8540499c6823e08774aca35d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/readline-8.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eead91720ac2660f8d96005035a541e893d3d7ec43039404cc8fbcc14f2a1884",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-4.18.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6a32f267edc8706df2a4f7621160acbacbad95cb76a6a63e37e4b311b1afae97",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a2a90558e9caef1600e4f9bd4aa369b5a9fbbd5271cfd769d03b40012d08d63d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d83044111c1115aa97ae42c223e8939e2776b7a981bd29dd1854f5d16bde341b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f8fa2f95339b373524453f7957bf11111f2752df463529308fa581d427871e02",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:dd8751590ce26d187ae0acc8a6c926ca97977f97d4b11c609339545c36d1500a",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.21",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/selinux-policy-37.21-2.fc37.noarch.rpm",
+        "checksum": "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.21",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/selinux-policy-targeted-37.21-2.fc37.noarch.rpm",
+        "checksum": "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/shadow-utils-4.12.3-6.fc37.aarch64.rpm",
+        "checksum": "sha256:9f00b4ddd2d088a22d5c655487a9ce2484db60bf6ba70ee5c2da2640cb6b13ae",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9f788227eaa3457d95f6e07a512fa4a7d31fb019f8562a074172973ffbe13d",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/sqlite-libs-3.40.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:eb4f373538d5eae216ee832dedd2969f62c561acb48b298cc27b0de03a0e2417",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:badabbe5320139f9904186ed35c7290704d1e3b23adf2805fe5c172d5ce7a968",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-boot-unsigned",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-boot-unsigned-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ebbf70618c9164072cfa0a3ae3f6f0e6ed011ebace68bb939ce4994f4f08b229",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-libs-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3c4e8f525f42431ee3d0554cfba40dd71296407b3c40c0159a7d38f1c8411078",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-networkd-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:084cce3cd53c4039dae21b29d9c7a93f6da354d08455c15f049848c908eecc80",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-pam-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:5e88c079833bdfdee49aaf6eb9b5a54d3588e30ec90a296041c9819e1b8bbbfb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-resolved-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:15b3baab1390174eaea557022701bbfe61d8e567aa3ef6724b887146941651db",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/s/systemd-udev-251.14-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a277222ae354325b1913783a2b0d33ae7fd43456f2a1b947e3ff5a6137c08039",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tpm2-tools-5.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0db39885030f18581efa981ac64ac178af231059c1448cdc1958f8540f14b2ae",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.2",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tpm2-tss-3.2.2-1.fc37.aarch64.rpm",
+        "checksum": "sha256:03394059c90c75aac91f312678bd9e9c2e48543339bc5e6a111fff911ca5b442",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/t/tzdata-2023c-1.fc37.noarch.rpm",
+        "checksum": "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/w/which-2.21-39.fc37.aarch64.rpm",
+        "checksum": "sha256:60df17f90cd3fafe85a4512b323c1773bb174a717b7de6dcd6235f71807fab1e",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc37.noarch.rpm",
+        "checksum": "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xkeyboard-config-2.36-3.fc37.noarch.rpm",
+        "checksum": "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xz-5.4.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f4430b8aafa44d6b1ff5a6085e6f02a5fdbc5effb9817843090b120274014297",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/x/xz-libs-5.4.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7f6dfc01d894a18954e247c1040453ffed4063ad6139b41e4424abc7103f772b",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:63df934e3fc969330fa1be978cbc34098c96afbde3dd6c2c86cc5e3ccb482817",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_37-x86_64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_ami-boot.json
@@ -1,0 +1,5275 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "x86_64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-modular-20221124/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fd3c9e8aedd1cf2a620c7580999c8510a1b93f5c85be8e24c59ca9b3c27aa8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68a1300b2d1b97e196d88f67e4ca666469c8154ffec79da693a630f752988470",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c356d05e80f2b57ea2598b45b168fff6da189038e3f3ef0305dd90cfdd2a045f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:275c282a240a3b7225e98b540a91af3419a9fa527623c5f152c48f8209779146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e50ddbdb35ecec1a9bf4e19fd87c6216382be313c3b671704d444053a1cfd183",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17b3091ae5bf8c8cdead807f63861c20daf9b4294d9ff46bfb19f0b19a0da9a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c7d47481af3e0984fdef66ed3b33100082bcf8ae022967706113ecf320fa8c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ea172dc9edc25482c09a0a09cd87384f001ce9bd80575f580439584d0dc15a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0955f3b625d4f9f953d988b6e2460dd1db455c674188e9ca73dd261984de9a61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:671e7cb382f4cab02530739fd9c57463f6d2649571834e6874c8050abf556e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:069f79144219815854e47cda0bf47c5f5e361d48cbfa652405ac68c0d24d29ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da132feaa95d275f20ff4444d88bfbe74b904281a266b9a680a7973430dc157d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19c56819bc4310585c053c165f8cd28bebe9c9977e8e204ce9579a129400fe3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbcf0ad6eac841b110f09098872a65e603431ce74296a23f38e91a67acda7466",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b7bf293c744038f0de75f6bffa0287f19b18553af272ba83934fb760dda0809",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed808bc010d6bf23ad11542c97f52d150af6011d6f5a57a6b0540fbe05f152f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3eceab01639e226a2ac645b6be7c242ac31ab04d549f9a8297603980728162e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e49c2393e5507bbaa16ededf0176e731e0196dd3230f6371d67be8b919e3429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6f5f327d3deace517c02bca099d8449b6bef706185850c0e5062c518c3fb1ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:797ba3836bebbf955b6df4258d2db042063e4c7acb9b076012e3e0cf6f47011a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:971fa1897680062f9f6a90d6717f5db0548b4bd304be346f0ff1e1b197989a18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27aac6ad641e8308216ae2b433982cb5807c9e4bd4b346ada67a0cc22ac3959e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d3fc9b210be82e3f434388abfe819b1ba13445c03cd3336835bec1b02fc3c70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c8463cd9f194f03ea1607670399e2fbf068857f566c43dd07d351228c25f187",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4237c10e5edacc5d5a9ea88e9fc5fef37249d459b13d4a0715c7836374a8da7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd04a5e5045f34e89a0ce0b1c2e579da1a4752a994d7bfcb0859b84c450aaee7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:623704f0cb0285ab55acfb41c10a1b5d04a6167e1056ce72ad20bcd6b5313f14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:87230a42e847ee21330d2bff385ed78031c20aa6c74463350b32e3b28122e331",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add80854df5585f76797dafa8fc19ede24db34b6d23e7bed868f28e6d6aad0a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91b08de00abe5430f61bc5491ea1f11a23712877da5ab9828865e5c17d4841ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:faa43148fcf25914baa0f00ae5ab9865ebf10e7a175e530de7b891be5e707086",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:813f696682616a8bd5a9f0363c23c99846f2490f26e0ca2dacebf784c74aa6c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:354b355a53cec57af445783bb2584e9faa4c13603e911024d154e0f94d183856",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7c83a9058c7e7e05e4c7ba97a363414eb973343ea8f00a1140fbdafe6ca67e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:298b24f4adff850f87098d6a64808fc9f8f94b4e88d8131bc0f400b8f14b2e11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f2ffaa4084cb8918d3990ef352dbfdd9ac28d30c2ed2693c1011641199bb369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a21c75bf1af2f299b06879592d9eb89a20168d3c5306365438e6403e1d1064ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43e8a4e927d64daa9733f6c761a66715849ac3da3a9aed9eefdfcc2228510a5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66bae5662d9287e769f5d8b7f723d45eb19f2902d912be40bf9e5dd8d5c68067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:527ee4ac72cf16db23bc5510ce37ff744be2ea3946f8a2982dd3481e491d2a1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10b0f71a8db70c7a9c456c01cd3154a7ab329ebf99e728994eee1646f32f92d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfa65a9946b2547110994855d168e4434313ad26280cb935c19bb88d2af283d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e32e2ab71cfb0bedb84611251987db7acdf665917864be335d0786ea6bbd02b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2301ca3ff0df8a51f1a872b1c68bdb7defedd099271ecb2f00ed1ff2fb347574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad990204d884c40e457e83bcbf45fb9911cfa15d296bf11167066b03e43f6dc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fbaaacbeb241755d8448dd5672bbbcc48cbe9548c095ce0efef4140bc12520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9019a471496fdada529757331ec004397db7a0c4347531bd639c127bbaf8300",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:344a9fc34ec697522d8a4f92880ab9fdf24d68e531c03747f866a45831b1af62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43d73a574c3c0838d213c4d5f038766d41e4eb6930c68b09db53d65c30c2de1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:723efbdc421150c13f6a2fe47e3d2587f83a26bfae8561e3361985793762b05d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39a7db1792d9b17dd8a4339cef7037e32c100dce4dab242207ca86efffc4b61c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cdfb41068ac6e211652b3e2ed88c16d606e7374f9f52dfd1248981101501299",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1687bf1e38fcd6ba696cdceed7ac99b564a0583ff8380803cce06c512f5549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc99d77eec7b347e6867391d306c1641393ef6470ba6dcf4c087c78ce26443ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35b51a0796af6930b2a8a511df8c51938006cfcfdf74ddfe6482eb9febd87dfa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55a12c31a1f8650f0c517411fff30301a8644a8c3a3505667846e5b59a4de5c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:547b9cffb0211abc4445d159e944f4fb59606b2eddfc14813b8c068859294ba6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c977a6b3aa87e7ca00fb5d0c086499ecf32414b8b800b0ad9f52fb4123746e7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2997441f2d1e07318a932b8e01d39c69d891c6f931a6f398d9970ac4de3e6c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58af9287e3afe709e2f898e679168485a713382c155f03ed94204094cfa8dd37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:561ebd5154e2d0d56f6a90283065b27304f81fc57fc881faf485e55d6414fad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f39b8b018fcb2b55477cdbfa4af7c9db9b660c85000a4a42e880b1a951efbe5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5357dd51e69b6a88b4069228f10abd98b92285cd016d8fd10af74746905797e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc833951b3ff2d5527b618f17d670afe6b58d13155010fc74a9004b48f145e39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfdb87b1ca4bbfb85ce362b13ca27cbfce0d5c471f7d77c6cf769e3bfe5027e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:613788ec7bdccd9d14f3ffa97b06c32d43857a5ade51dc54d36d83a57007333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f250396bc408a880a50a53535e8038d593107594af1d9d348c01aa27a6348dae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f98cf146c74705ea0099e62db60fac76ca61fcf4db3cb2dbda31a2294d910be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d93d3c54fff7d8fd1d1c7defd399573b0974b642099b24c3924aafe3862d54db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:199f28e3ecd24e0650ed7b8bc596f14e7a9cdef79c36989b710da1f557b347d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cca5e3dcefe1f30dbaff83cafd81f6de4ba00732b578b6e07946f39ffee87b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6be0f8e78bf0437c64ed2fba415166398c2a2e3493e67893e6c1eef785c8149",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6fa5d8fa7701d57583dce45fc056341639c234946de032174e165a7cc27b3da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:809f3385106e29f5748e826644162f4de3c2aa22c9681fb38f32d5d84c81de28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef7ea6ad5550a29dea36842dfd23bde0689cbcc1780a3f68bc05a3e57a72e7f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0663e23dc42a7ce84f60f5f3154ba640460a0e5b7158459abf9d5d0986d69d06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac3915164eb1e4dd24a94fe7f77f5722c5b7e50ccb3bde29804ffe5c97ae49ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1a55d458afb2e5c30ceb704ec7424da64a7b7bb872249522590799a5aa786df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:508330b6d8f5e2a0fa95985b8c87af88c18b46a944e8f483e342ef1a1bd03986",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b4ce15327094d94659188ba4374341f1d55bd56c09661c7dd574b1867180c75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f98bfc30379e94251f50ed2542cf7b3e3c313478f2ab2f6319bbac6a2e945bc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b85714adf81c11f87479305bb324ad15c0cf92ca0f5560cef5c99995f1e9c942",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46c547bcfe971a7cf00760334505514dbb860e35e439e8118fdcd12fd545dfbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d1603de146f9bbe90810100df0afa2efe32e13cc86ed42e32528bc50b8f03dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec407a50153db3d466ed6063bc9274ce73192197e08e22ee88f7c364036ffc66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18ba36dec0758ea7204e306b82eff1099f3ea417e2eea2b21636da19cd71653f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37934c2adce2bf1559a8b74a9e6c62510acb0d0653ab5d80b2676f69388beee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d61a2c880db45f1bb592d1896d048460401bb5f70486d877f8dc351843fca10b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3f416c1d6cb05491f61e4f9cf2e976b0ccda4cb3eebc2c1b6dfa633e876bbef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa25738c396b5da9019989248229548a8291e613528e07f176beeaf2df44ef7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb8ae18f87b52e898bc3d4bbcb8aa448d100bd47cf630c6156f9f9a0a356add2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e68dbb3136877c39b8ba78733c24b03724d92bdcf40bc051f5647843d2ed781",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fecd2ef49993396a00deaae7d591957424a03c760d61318b514721a595998087",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a014a589f3342898dfe96024a04fc0541ddfb48894774af6668ccd6fde5d483",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7af1096450d0d76dcd5666e31736f18ff44de9908f2e87d89be88592b176c643",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c06eef8dd28d6dc1406e65e4eb8ee3db359cf6624729be4e426f6b01c4117fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f37e2fd76c1227d1cf305c53c6065d3a6ebc864f6e0dd238e35abb3f32de30c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 17846239,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm"
+          },
+          "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:0663e23dc42a7ce84f60f5f3154ba640460a0e5b7158459abf9d5d0986d69d06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/readline-8.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:069f79144219815854e47cda0bf47c5f5e361d48cbfa652405ac68c0d24d29ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-broker-33-1.fc37.x86_64.rpm"
+          },
+          "sha256:0955f3b625d4f9f953d988b6e2460dd1db455c674188e9ca73dd261984de9a61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/curl-7.85.0-8.fc37.x86_64.rpm"
+          },
+          "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:0c7d47481af3e0984fdef66ed3b33100082bcf8ae022967706113ecf320fa8c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/coreutils-common-9.1-8.fc37.x86_64.rpm"
+          },
+          "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:0e49c2393e5507bbaa16ededf0176e731e0196dd3230f6371d67be8b919e3429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/expat-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:10b0f71a8db70c7a9c456c01cd3154a7ab329ebf99e728994eee1646f32f92d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgomp-12.3.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:17b3091ae5bf8c8cdead807f63861c20daf9b4294d9ff46bfb19f0b19a0da9a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/coreutils-9.1-8.fc37.x86_64.rpm"
+          },
+          "sha256:18ba36dec0758ea7204e306b82eff1099f3ea417e2eea2b21636da19cd71653f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-boot-unsigned-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:199f28e3ecd24e0650ed7b8bc596f14e7a9cdef79c36989b710da1f557b347d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/policycoreutils-3.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:19c56819bc4310585c053c165f8cd28bebe9c9977e8e204ce9579a129400fe3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dracut-config-generic-059-2.fc37.x86_64.rpm"
+          },
+          "sha256:1b7bf293c744038f0de75f6bffa0287f19b18553af272ba83934fb760dda0809": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc37.x86_64.rpm"
+          },
+          "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-common-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:2301ca3ff0df8a51f1a872b1c68bdb7defedd099271ecb2f00ed1ff2fb347574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libksba-1.6.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:275c282a240a3b7225e98b540a91af3419a9fa527623c5f152c48f8209779146": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/authselect-libs-1.4.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:27aac6ad641e8308216ae2b433982cb5807c9e4bd4b346ada67a0cc22ac3959e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-runtime-0.21.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:298b24f4adff850f87098d6a64808fc9f8f94b4e88d8131bc0f400b8f14b2e11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/k/kpartx-0.9.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:2cdfb41068ac6e211652b3e2ed88c16d606e7374f9f52dfd1248981101501299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libsepol-3.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:2d3fc9b210be82e3f434388abfe819b1ba13445c03cd3336835bec1b02fc3c70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glib2-2.74.7-1.fc37.x86_64.rpm"
+          },
+          "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-common-1.14.6-1.fc37.noarch.rpm"
+          },
+          "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/containers-common-1-82.fc37.noarch.rpm"
+          },
+          "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:344a9fc34ec697522d8a4f92880ab9fdf24d68e531c03747f866a45831b1af62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/librepo-1.15.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:354b355a53cec57af445783bb2584e9faa4c13603e911024d154e0f94d183856": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-94.fc37.x86_64.rpm"
+          },
+          "sha256:35b51a0796af6930b2a8a511df8c51938006cfcfdf74ddfe6482eb9febd87dfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libtasn1-4.19.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:37934c2adce2bf1559a8b74a9e6c62510acb0d0653ab5d80b2676f69388beee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-libs-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:39a7db1792d9b17dd8a4339cef7037e32c100dce4dab242207ca86efffc4b61c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libsemanage-3.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3eceab01639e226a2ac645b6be7c242ac31ab04d549f9a8297603980728162e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc37.x86_64.rpm"
+          },
+          "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:4237c10e5edacc5d5a9ea88e9fc5fef37249d459b13d4a0715c7836374a8da7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-common-2.36-9.fc37.x86_64.rpm"
+          },
+          "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:42fbaaacbeb241755d8448dd5672bbbcc48cbe9548c095ce0efef4140bc12520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libnghttp2-1.51.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:43d73a574c3c0838d213c4d5f038766d41e4eb6930c68b09db53d65c30c2de1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libselinux-3.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:43e8a4e927d64daa9733f6c761a66715849ac3da3a9aed9eefdfcc2228510a5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libcurl-7.85.0-8.fc37.x86_64.rpm"
+          },
+          "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:46c547bcfe971a7cf00760334505514dbb860e35e439e8118fdcd12fd545dfbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-gpg-keys-37-2.noarch.rpm"
+          },
+          "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse3-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/grubby-8.40-66.fc37.x86_64.rpm"
+          },
+          "sha256:4a014a589f3342898dfe96024a04fc0541ddfb48894774af6668ccd6fde5d483": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/w/which-2.21-39.fc37.x86_64.rpm"
+          },
+          "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:4d1603de146f9bbe90810100df0afa2efe32e13cc86ed42e32528bc50b8f03dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/sqlite-libs-3.40.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm"
+          },
+          "sha256:4fd3c9e8aedd1cf2a620c7580999c8510a1b93f5c85be8e24c59ca9b3c27aa8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc37.x86_64.rpm"
+          },
+          "sha256:508330b6d8f5e2a0fa95985b8c87af88c18b46a944e8f483e342ef1a1bd03986": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:527ee4ac72cf16db23bc5510ce37ff744be2ea3946f8a2982dd3481e491d2a1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgcc-12.3.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:5357dd51e69b6a88b4069228f10abd98b92285cd016d8fd10af74746905797e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc37.x86_64.rpm"
+          },
+          "sha256:547b9cffb0211abc4445d159e944f4fb59606b2eddfc14813b8c068859294ba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxcrypt-4.4.33-4.fc37.x86_64.rpm"
+          },
+          "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse3-libs-3.10.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:55a12c31a1f8650f0c517411fff30301a8644a8c3a3505667846e5b59a4de5c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc37.x86_64.rpm"
+          },
+          "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cpio-2.13-13.fc37.x86_64.rpm"
+          },
+          "sha256:561ebd5154e2d0d56f6a90283065b27304f81fc57fc881faf485e55d6414fad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/lua-libs-5.4.4-9.fc37.x86_64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-common-37-16.noarch.rpm"
+          },
+          "sha256:58af9287e3afe709e2f898e679168485a713382c155f03ed94204094cfa8dd37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:5e68dbb3136877c39b8ba78733c24b03724d92bdcf40bc051f5647843d2ed781": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tpm2-tools-5.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:5f2ffaa4084cb8918d3990ef352dbfdd9ac28d30c2ed2693c1011641199bb369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/k/krb5-libs-1.19.2-13.fc37.x86_64.rpm"
+          },
+          "sha256:613788ec7bdccd9d14f3ffa97b06c32d43857a5ade51dc54d36d83a57007333c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/openldap-2.6.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:623704f0cb0285ab55acfb41c10a1b5d04a6167e1056ce72ad20bcd6b5313f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.36-9.fc37.x86_64.rpm"
+          },
+          "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/n/ncurses-base-6.3-5.20220501.fc37.noarch.rpm"
+          },
+          "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/selinux-policy-targeted-37.21-2.fc37.noarch.rpm"
+          },
+          "sha256:66bae5662d9287e769f5d8b7f723d45eb19f2902d912be40bf9e5dd8d5c68067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libffi-3.4.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:671e7cb382f4cab02530739fd9c57463f6d2649571834e6874c8050abf556e68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-1.14.6-1.fc37.x86_64.rpm"
+          },
+          "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc37.noarch.rpm"
+          },
+          "sha256:68a1300b2d1b97e196d88f67e4ca666469c8154ffec79da693a630f752988470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc37.noarch.rpm"
+          },
+          "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/n/npth-1.6-9.fc37.x86_64.rpm"
+          },
+          "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:6cca5e3dcefe1f30dbaff83cafd81f6de4ba00732b578b6e07946f39ffee87b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/polkit-121-4.fc37.2.x86_64.rpm"
+          },
+          "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-setuptools-wheel-62.6.0-3.fc37.noarch.rpm"
+          },
+          "sha256:723efbdc421150c13f6a2fe47e3d2587f83a26bfae8561e3361985793762b05d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libselinux-utils-3.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:797ba3836bebbf955b6df4258d2db042063e4c7acb9b076012e3e0cf6f47011a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-envsubst-0.21.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cracklib-dicts-2.9.7-30.fc37.x86_64.rpm"
+          },
+          "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc37.noarch.rpm"
+          },
+          "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7aa25738c396b5da9019989248229548a8291e613528e07f176beeaf2df44ef7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-resolved-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:7af1096450d0d76dcd5666e31736f18ff44de9908f2e87d89be88592b176c643": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xz-5.4.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm"
+          },
+          "sha256:7b4ce15327094d94659188ba4374341f1d55bd56c09661c7dd574b1867180c75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:7f37e2fd76c1227d1cf305c53c6065d3a6ebc864f6e0dd238e35abb3f32de30c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:809f3385106e29f5748e826644162f4de3c2aa22c9681fb38f32d5d84c81de28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:813f696682616a8bd5a9f0363c23c99846f2490f26e0ca2dacebf784c74aa6c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-tools-2.06-94.fc37.x86_64.rpm"
+          },
+          "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm"
+          },
+          "sha256:87230a42e847ee21330d2bff385ed78031c20aa6c74463350b32e3b28122e331": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnupg2-2.3.8-1.fc37.x86_64.rpm"
+          },
+          "sha256:8c06eef8dd28d6dc1406e65e4eb8ee3db359cf6624729be4e426f6b01c4117fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xz-libs-5.4.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:8c8463cd9f194f03ea1607670399e2fbf068857f566c43dd07d351228c25f187": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-2.36-9.fc37.x86_64.rpm"
+          },
+          "sha256:8ea172dc9edc25482c09a0a09cd87384f001ce9bd80575f580439584d0dc15a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:8f98cf146c74705ea0099e62db60fac76ca61fcf4db3cb2dbda31a2294d910be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/ostree-2022.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:91b08de00abe5430f61bc5491ea1f11a23712877da5ab9828865e5c17d4841ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnutls-3.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:971fa1897680062f9f6a90d6717f5db0548b4bd304be346f0ff1e1b197989a18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-libs-0.21.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:a21c75bf1af2f299b06879592d9eb89a20168d3c5306365438e6403e1d1064ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libarchive-3.6.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc37.noarch.rpm"
+          },
+          "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tzdata-2023c-1.fc37.noarch.rpm"
+          },
+          "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:a9019a471496fdada529757331ec004397db7a0c4347531bd639c127bbaf8300": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libpwquality-1.4.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:ac3915164eb1e4dd24a94fe7f77f5722c5b7e50ccb3bde29804ffe5c97ae49ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-4.18.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:ad990204d884c40e457e83bcbf45fb9911cfa15d296bf11167066b03e43f6dc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:add80854df5585f76797dafa8fc19ede24db34b6d23e7bed868f28e6d6aad0a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnupg2-smime-2.3.8-1.fc37.x86_64.rpm"
+          },
+          "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b1687bf1e38fcd6ba696cdceed7ac99b564a0583ff8380803cce06c512f5549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/ca-certificates-2023.2.60-1.0.fc37.noarch.rpm"
+          },
+          "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/selinux-policy-37.21-2.fc37.noarch.rpm"
+          },
+          "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-identity-basic-37-16.noarch.rpm"
+          },
+          "sha256:b6be0f8e78bf0437c64ed2fba415166398c2a2e3493e67893e6c1eef785c8149": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/polkit-libs-121-4.fc37.2.x86_64.rpm"
+          },
+          "sha256:b6f5f327d3deace517c02bca099d8449b6bef706185850c0e5062c518c3fb1ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc37.x86_64.rpm"
+          },
+          "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm"
+          },
+          "sha256:b85714adf81c11f87479305bb324ad15c0cf92ca0f5560cef5c99995f1e9c942": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/shadow-utils-4.12.3-6.fc37.x86_64.rpm"
+          },
+          "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:bd04a5e5045f34e89a0ce0b1c2e579da1a4752a994d7bfcb0859b84c450aaee7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.36-9.fc37.x86_64.rpm"
+          },
+          "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:bfa65a9946b2547110994855d168e4434313ad26280cb935c19bb88d2af283d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgpg-error-1.46-1.fc37.x86_64.rpm"
+          },
+          "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:c2997441f2d1e07318a932b8e01d39c69d891c6f931a6f398d9970ac4de3e6c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:c356d05e80f2b57ea2598b45b168fff6da189038e3f3ef0305dd90cfdd2a045f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/authselect-1.4.2-1.fc37.x86_64.rpm"
+          },
+          "sha256:c3f416c1d6cb05491f61e4f9cf2e976b0ccda4cb3eebc2c1b6dfa633e876bbef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-pam-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:c6fa5d8fa7701d57583dce45fc056341639c234946de032174e165a7cc27b3da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/procps-ng-3.3.17-6.fc37.2.x86_64.rpm"
+          },
+          "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c977a6b3aa87e7ca00fb5d0c086499ecf32414b8b800b0ad9f52fb4123746e7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxcrypt-compat-4.4.33-4.fc37.x86_64.rpm"
+          },
+          "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:cc833951b3ff2d5527b618f17d670afe6b58d13155010fc74a9004b48f145e39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/m/mozjs102-102.9.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:cc99d77eec7b347e6867391d306c1641393ef6470ba6dcf4c087c78ce26443ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libstdc++-12.3.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:cfdb87b1ca4bbfb85ce362b13ca27cbfce0d5c471f7d77c6cf769e3bfe5027e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/n/ncurses-libs-6.3-5.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libicu-71.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:d61a2c880db45f1bb592d1896d048460401bb5f70486d877f8dc351843fca10b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-networkd-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:d93d3c54fff7d8fd1d1c7defd399573b0974b642099b24c3924aafe3862d54db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/ostree-libs-2022.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/grep-3.7-4.fc37.x86_64.rpm"
+          },
+          "sha256:da132feaa95d275f20ff4444d88bfbe74b904281a266b9a680a7973430dc157d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dracut-059-2.fc37.x86_64.rpm"
+          },
+          "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-37-16.noarch.rpm"
+          },
+          "sha256:dbcf0ad6eac841b110f09098872a65e603431ce74296a23f38e91a67acda7466": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/efivar-libs-38-6.fc37.x86_64.rpm"
+          },
+          "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xkeyboard-config-2.36-3.fc37.noarch.rpm"
+          },
+          "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm"
+          },
+          "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e1a55d458afb2e5c30ceb704ec7424da64a7b7bb872249522590799a5aa786df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:e32e2ab71cfb0bedb84611251987db7acdf665917864be335d0786ea6bbd02b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libidn2-2.3.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/popt-1.19-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:e50ddbdb35ecec1a9bf4e19fd87c6216382be313c3b671704d444053a1cfd183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/b/bash-5.2.15-1.fc37.x86_64.rpm"
+          },
+          "sha256:e7c83a9058c7e7e05e4c7ba97a363414eb973343ea8f00a1140fbdafe6ca67e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/j/json-c-0.16-3.fc37.x86_64.rpm"
+          },
+          "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc37.noarch.rpm"
+          },
+          "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:eb8ae18f87b52e898bc3d4bbcb8aa448d100bd47cf630c6156f9f9a0a356add2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-udev-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc37.noarch.rpm"
+          },
+          "sha256:ec407a50153db3d466ed6063bc9274ce73192197e08e22ee88f7c364036ffc66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-251.14-2.fc37.x86_64.rpm"
+          },
+          "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:ed808bc010d6bf23ad11542c97f52d150af6011d6f5a57a6b0540fbe05f152f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc37.x86_64.rpm"
+          },
+          "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:ef7ea6ad5550a29dea36842dfd23bde0689cbcc1780a3f68bc05a3e57a72e7f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f250396bc408a880a50a53535e8038d593107594af1d9d348c01aa27a6348dae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/openssl-libs-3.0.8-1.fc37.x86_64.rpm"
+          },
+          "sha256:f39b8b018fcb2b55477cdbfa4af7c9db9b660c85000a4a42e880b1a951efbe5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/lz4-libs-1.9.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-repos-37-2.noarch.rpm"
+          },
+          "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-pip-wheel-22.2.2-3.fc37.noarch.rpm"
+          },
+          "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:f98bfc30379e94251f50ed2542cf7b3e3c313478f2ab2f6319bbac6a2e945bc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:faa43148fcf25914baa0f00ae5ab9865ebf10e7a175e530de7b891be5e707086": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-efi-x64-2.06-94.fc37.x86_64.rpm"
+          },
+          "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-common-2.06-94.fc37.noarch.rpm"
+          },
+          "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:fecd2ef49993396a00deaae7d591957424a03c760d61318b514721a595998087": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tpm2-tss-3.2.2-1.fc37.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cracklib-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:3847abdc8ff973aeb0fb7e681bdf7c37b19cd49e5df17e8bf6bc35f34615c88f",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "30.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cracklib-dicts-2.9.7-30.fc37.x86_64.rpm",
+        "checksum": "sha256:7a2829a5012094cf436e39495f0fd8f14604f8f295e98b8bb6e85eab9e0472f1",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/e/efibootmgr-18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:157a95e5d0a70dcb97682ae484d6238e99db218071855483283c61486029ce8e",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:de73e6a453152a5e3635d4796d4b92587f7ad9428647cf85a9bc9506839ed1e8",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-common-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:1f2c3773b6d2a19f5b2a3ea190b210a9f06e186eff763e70662c63fe5c85d394",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse3-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:47e1ed14816cd8b66a07911789defd41d6b840baf8ccd0439f99dd1ded4ff15d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/f/fuse3-libs-3.10.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:559626f87751e9b10db9237e0bf05589081f69a5436ee88344352cbb5c4ef7cf",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-2.5.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7c660eada8cb6e2d2b0c035a9d1696db945761c07e7900b8003b1b405243adef",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-legacy-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:a6e8f6c0a9973883d33d35381234a88acee5d075ba0a92f811e9728441756d1f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kbd-misc-2.5.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:b71602703b63f87199a145cd64cf804b19af7275eede730bd3b82296b64417d7",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libicu-71.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d1a35de9152869803d6667926c330f7e0bffdb52c0d513ee0f3ecdc25f289aff",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm",
+        "checksum": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mokutil-0.6.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:9af923799a1ee9a07dbfe10ba28c3a28bc081d77648b1b5f6271f426af7212b2",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/n/npth-1.6-9.fc37.x86_64.rpm",
+        "checksum": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:557322822a4aa090b2c4d24154f25a7417b1015327c92f463d98161e46f65c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2662ac74bdff1706965ab83236c1c65c34287e8008eac2785b9b52ffe01816dd",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pcsc-lite-libs-1.9.9-1.fc37.x86_64.rpm",
+        "checksum": "sha256:de4dcfa7271758f759bfa291ac552eccb586047ee0b91471991bb46b2161b2a3",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/pinentry-1.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c562efa8f886aa0ca1d6bb55b532f88f8030bf6400e14e65f5a6601df1c0f8a3",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/p/popt-1.19-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e3c9a6a1611d967fbff4321b5b1ae54377fed22454298859108138c1f64b0c63",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:4da0677be2e68ab8e7d9132c6350186cf7c1116f545515fc16a43f6daaa92ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-20221124/Packages/z/zlib-1.2.12-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7b0eda1ad9e9a06e61d9fe41e5e4e0fbdc8427bc252f06a7d29cd7ba81a71a70",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4fd3c9e8aedd1cf2a620c7580999c8510a1b93f5c85be8e24c59ca9b3c27aa8a",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:68a1300b2d1b97e196d88f67e4ca666469c8154ffec79da693a630f752988470",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/authselect-1.4.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c356d05e80f2b57ea2598b45b168fff6da189038e3f3ef0305dd90cfdd2a045f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/a/authselect-libs-1.4.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:275c282a240a3b7225e98b540a91af3419a9fa527623c5f152c48f8209779146",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/b/bash-5.2.15-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e50ddbdb35ecec1a9bf4e19fd87c6216382be313c3b671704d444053a1cfd183",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "1.0.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/ca-certificates-2023.2.60-1.0.fc37.noarch.rpm",
+        "checksum": "sha256:b2dcac3e49cbf75841d41ee1c53f1a91ffa78ba03dab8febb3153dbf76b2c5b2",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:ea774c744870f0cfa6add60a9fec9db9982dd9b0c6355f983e706afcb998c058",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "82.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/containers-common-1-82.fc37.noarch.rpm",
+        "checksum": "sha256:314a51da455ca20575d100fa0d6de0756c3a4c8f64f41940d49c61040dc9c66c",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/coreutils-9.1-8.fc37.x86_64.rpm",
+        "checksum": "sha256:17b3091ae5bf8c8cdead807f63861c20daf9b4294d9ff46bfb19f0b19a0da9a3",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/coreutils-common-9.1-8.fc37.x86_64.rpm",
+        "checksum": "sha256:0c7d47481af3e0984fdef66ed3b33100082bcf8ae022967706113ecf320fa8c2",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:8ea172dc9edc25482c09a0a09cd87384f001ce9bd80575f580439584d0dc15a6",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/c/curl-7.85.0-8.fc37.x86_64.rpm",
+        "checksum": "sha256:0955f3b625d4f9f953d988b6e2460dd1db455c674188e9ca73dd261984de9a61",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-1.14.6-1.fc37.x86_64.rpm",
+        "checksum": "sha256:671e7cb382f4cab02530739fd9c57463f6d2649571834e6874c8050abf556e68",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-broker-33-1.fc37.x86_64.rpm",
+        "checksum": "sha256:069f79144219815854e47cda0bf47c5f5e361d48cbfa652405ac68c0d24d29ee",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dbus-common-1.14.6-1.fc37.noarch.rpm",
+        "checksum": "sha256:2f5d8c77a752f02e4fc98f5ac53ca7ca2811831c8e805907dfce05007be95027",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dracut-059-2.fc37.x86_64.rpm",
+        "checksum": "sha256:da132feaa95d275f20ff4444d88bfbe74b904281a266b9a680a7973430dc157d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/d/dracut-config-generic-059-2.fc37.x86_64.rpm",
+        "checksum": "sha256:19c56819bc4310585c053c165f8cd28bebe9c9977e8e204ce9579a129400fe3c",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/efivar-libs-38-6.fc37.x86_64.rpm",
+        "checksum": "sha256:dbcf0ad6eac841b110f09098872a65e603431ce74296a23f38e91a67acda7466",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1b7bf293c744038f0de75f6bffa0287f19b18553af272ba83934fb760dda0809",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc37.noarch.rpm",
+        "checksum": "sha256:ebbe2588b24c7731cc79361fd4e707f69801304c035f08c5590bae24bc187afe",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ed808bc010d6bf23ad11542c97f52d150af6011d6f5a57a6b0540fbe05f152f4",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3eceab01639e226a2ac645b6be7c242ac31ab04d549f9a8297603980728162e2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/e/expat-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:0e49c2393e5507bbaa16ededf0176e731e0196dd3230f6371d67be8b919e3429",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-gpg-keys-37-2.noarch.rpm",
+        "checksum": "sha256:47a0fdf0c8d0aecd3d4b2eee160affec5ba0d12b7ac6647b3f12fdef275e9738",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-37-16.noarch.rpm",
+        "checksum": "sha256:db9a0c2a1b841efdd1811e508427316770ae2460d4ad38c5147e3a2e6dfb272d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-common-37-16.noarch.rpm",
+        "checksum": "sha256:5887ea74e3b3525a31fc0a685e10b8ef0be80afe223a9d327c53a5a3168e36d7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "16",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-release-identity-basic-37-16.noarch.rpm",
+        "checksum": "sha256:b64f4a6d634f9c5127c734763bd7f7f98aa8a8b5d7159b23a6a2b659b3cf9711",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fedora-repos-37-2.noarch.rpm",
+        "checksum": "sha256:f43a00322ae512135f695e9378eadcb3f8a8314bd4e290ea40c7c576621297f6",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b6f5f327d3deace517c02bca099d8449b6bef706185850c0e5062c518c3fb1ad",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-envsubst-0.21.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:797ba3836bebbf955b6df4258d2db042063e4c7acb9b076012e3e0cf6f47011a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-libs-0.21.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:971fa1897680062f9f6a90d6717f5db0548b4bd304be346f0ff1e1b197989a18",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gettext-runtime-0.21.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:27aac6ad641e8308216ae2b433982cb5807c9e4bd4b346ada67a0cc22ac3959e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.74.7",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glib2-2.74.7-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2d3fc9b210be82e3f434388abfe819b1ba13445c03cd3336835bec1b02fc3c70",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-2.36-9.fc37.x86_64.rpm",
+        "checksum": "sha256:8c8463cd9f194f03ea1607670399e2fbf068857f566c43dd07d351228c25f187",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-common-2.36-9.fc37.x86_64.rpm",
+        "checksum": "sha256:4237c10e5edacc5d5a9ea88e9fc5fef37249d459b13d4a0715c7836374a8da7a",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.36-9.fc37.x86_64.rpm",
+        "checksum": "sha256:bd04a5e5045f34e89a0ce0b1c2e579da1a4752a994d7bfcb0859b84c450aaee7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.36-9.fc37.x86_64.rpm",
+        "checksum": "sha256:623704f0cb0285ab55acfb41c10a1b5d04a6167e1056ce72ad20bcd6b5313f14",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnupg2-2.3.8-1.fc37.x86_64.rpm",
+        "checksum": "sha256:87230a42e847ee21330d2bff385ed78031c20aa6c74463350b32e3b28122e331",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.8",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnupg2-smime-2.3.8-1.fc37.x86_64.rpm",
+        "checksum": "sha256:add80854df5585f76797dafa8fc19ede24db34b6d23e7bed868f28e6d6aad0a3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/gnutls-3.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:91b08de00abe5430f61bc5491ea1f11a23712877da5ab9828865e5c17d4841ee",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-common-2.06-94.fc37.noarch.rpm",
+        "checksum": "sha256:fd20e8010ace7696fbb2fa3f67bc05079ba320aa30d6e424f7818dbc7db07f6e",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-efi-x64-2.06-94.fc37.x86_64.rpm",
+        "checksum": "sha256:faa43148fcf25914baa0f00ae5ab9865ebf10e7a175e530de7b891be5e707086",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-tools-2.06-94.fc37.x86_64.rpm",
+        "checksum": "sha256:813f696682616a8bd5a9f0363c23c99846f2490f26e0ca2dacebf784c74aa6c4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "94.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-94.fc37.x86_64.rpm",
+        "checksum": "sha256:354b355a53cec57af445783bb2584e9faa4c13603e911024d154e0f94d183856",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/j/json-c-0.16-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e7c83a9058c7e7e05e4c7ba97a363414eb973343ea8f00a1140fbdafe6ca67e2",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/k/kpartx-0.9.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:298b24f4adff850f87098d6a64808fc9f8f94b4e88d8131bc0f400b8f14b2e11",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/k/krb5-libs-1.19.2-13.fc37.x86_64.rpm",
+        "checksum": "sha256:5f2ffaa4084cb8918d3990ef352dbfdd9ac28d30c2ed2693c1011641199bb369",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libarchive-3.6.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a21c75bf1af2f299b06879592d9eb89a20168d3c5306365438e6403e1d1064ce",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.85.0",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libcurl-7.85.0-8.fc37.x86_64.rpm",
+        "checksum": "sha256:43e8a4e927d64daa9733f6c761a66715849ac3da3a9aed9eefdfcc2228510a5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libffi-3.4.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:66bae5662d9287e769f5d8b7f723d45eb19f2902d912be40bf9e5dd8d5c68067",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgcc-12.3.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:527ee4ac72cf16db23bc5510ce37ff744be2ea3946f8a2982dd3481e491d2a1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgomp-12.3.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:10b0f71a8db70c7a9c456c01cd3154a7ab329ebf99e728994eee1646f32f92d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.46",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libgpg-error-1.46-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bfa65a9946b2547110994855d168e4434313ad26280cb935c19bb88d2af283d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libidn2-2.3.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e32e2ab71cfb0bedb84611251987db7acdf665917864be335d0786ea6bbd02b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libksba-1.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2301ca3ff0df8a51f1a872b1c68bdb7defedd099271ecb2f00ed1ff2fb347574",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ad990204d884c40e457e83bcbf45fb9911cfa15d296bf11167066b03e43f6dc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.51.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libnghttp2-1.51.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:42fbaaacbeb241755d8448dd5672bbbcc48cbe9548c095ce0efef4140bc12520",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libpwquality-1.4.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9019a471496fdada529757331ec004397db7a0c4347531bd639c127bbaf8300",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/librepo-1.15.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:344a9fc34ec697522d8a4f92880ab9fdf24d68e531c03747f866a45831b1af62",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libselinux-3.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:43d73a574c3c0838d213c4d5f038766d41e4eb6930c68b09db53d65c30c2de1d",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libselinux-utils-3.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:723efbdc421150c13f6a2fe47e3d2587f83a26bfae8561e3361985793762b05d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libsemanage-3.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39a7db1792d9b17dd8a4339cef7037e32c100dce4dab242207ca86efffc4b61c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libsepol-3.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2cdfb41068ac6e211652b3e2ed88c16d606e7374f9f52dfd1248981101501299",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b1687bf1e38fcd6ba696cdceed7ac99b564a0583ff8380803cce06c512f5549b",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc37.noarch.rpm",
+        "checksum": "sha256:685603934a1d64b89e8f126831b1ff33d8780ced722f188a1dafc27cdd389ded",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.3.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libstdc++-12.3.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:cc99d77eec7b347e6867391d306c1641393ef6470ba6dcf4c087c78ce26443ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libtasn1-4.19.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:35b51a0796af6930b2a8a511df8c51938006cfcfdf74ddfe6482eb9febd87dfa",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc37.x86_64.rpm",
+        "checksum": "sha256:55a12c31a1f8650f0c517411fff30301a8644a8c3a3505667846e5b59a4de5c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxcrypt-4.4.33-4.fc37.x86_64.rpm",
+        "checksum": "sha256:547b9cffb0211abc4445d159e944f4fb59606b2eddfc14813b8c068859294ba6",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxcrypt-compat-4.4.33-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c977a6b3aa87e7ca00fb5d0c086499ecf32414b8b800b0ad9f52fb4123746e7d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c2997441f2d1e07318a932b8e01d39c69d891c6f931a6f398d9970ac4de3e6c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:58af9287e3afe709e2f898e679168485a713382c155f03ed94204094cfa8dd37",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/lua-libs-5.4.4-9.fc37.x86_64.rpm",
+        "checksum": "sha256:561ebd5154e2d0d56f6a90283065b27304f81fc57fc881faf485e55d6414fad6",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/l/lz4-libs-1.9.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f39b8b018fcb2b55477cdbfa4af7c9db9b660c85000a4a42e880b1a951efbe5a",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc37.x86_64.rpm",
+        "checksum": "sha256:5357dd51e69b6a88b4069228f10abd98b92285cd016d8fd10af74746905797e4",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.9.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/m/mozjs102-102.9.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:cc833951b3ff2d5527b618f17d670afe6b58d13155010fc74a9004b48f145e39",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "5.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/n/ncurses-base-6.3-5.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:6293e79a167585854a320cfe71ed6ad9ca6839d74a6f724c5a2e9de0571e0db4",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "5.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/n/ncurses-libs-6.3-5.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:cfdb87b1ca4bbfb85ce362b13ca27cbfce0d5c471f7d77c6cf769e3bfe5027e4",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/openldap-2.6.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:613788ec7bdccd9d14f3ffa97b06c32d43857a5ade51dc54d36d83a57007333c",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/openssl-libs-3.0.8-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f250396bc408a880a50a53535e8038d593107594af1d9d348c01aa27a6348dae",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2022.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/ostree-2022.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8f98cf146c74705ea0099e62db60fac76ca61fcf4db3cb2dbda31a2294d910be",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2022.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/o/ostree-libs-2022.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d93d3c54fff7d8fd1d1c7defd399573b0974b642099b24c3924aafe3862d54db",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/policycoreutils-3.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:199f28e3ecd24e0650ed7b8bc596f14e7a9cdef79c36989b710da1f557b347d9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/polkit-121-4.fc37.2.x86_64.rpm",
+        "checksum": "sha256:6cca5e3dcefe1f30dbaff83cafd81f6de4ba00732b578b6e07946f39ffee87b1",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/polkit-libs-121-4.fc37.2.x86_64.rpm",
+        "checksum": "sha256:b6be0f8e78bf0437c64ed2fba415166398c2a2e3493e67893e6c1eef785c8149",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/procps-ng-3.3.17-6.fc37.2.x86_64.rpm",
+        "checksum": "sha256:c6fa5d8fa7701d57583dce45fc056341639c234946de032174e165a7cc27b3da",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc37.noarch.rpm",
+        "checksum": "sha256:6a0d0b6f30926f925ab67cde466a327848e9bbe237620ffb062ddf8be003bec4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2.2",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-pip-wheel-22.2.2-3.fc37.noarch.rpm",
+        "checksum": "sha256:f7800b3f5acca7863bf47981258582728b74861c19b2bef38ae47efe3b042eb4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-setuptools-wheel-62.6.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:71eb63ef6b25df748b6d2b66c3fba8c47b4a72dc7e1562fddb1073f5bd8af36a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc37.noarch.rpm",
+        "checksum": "sha256:a5dd4381cbb094898a23c72d9d9143d695e77a5b69ff651f43a9258c941e5279",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:809f3385106e29f5748e826644162f4de3c2aa22c9681fb38f32d5d84c81de28",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ef7ea6ad5550a29dea36842dfd23bde0689cbcc1780a3f68bc05a3e57a72e7f6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/readline-8.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0663e23dc42a7ce84f60f5f3154ba640460a0e5b7158459abf9d5d0986d69d06",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-4.18.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ac3915164eb1e4dd24a94fe7f77f5722c5b7e50ccb3bde29804ffe5c97ae49ae",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e1a55d458afb2e5c30ceb704ec7424da64a7b7bb872249522590799a5aa786df",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:508330b6d8f5e2a0fa95985b8c87af88c18b46a944e8f483e342ef1a1bd03986",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7b4ce15327094d94659188ba4374341f1d55bd56c09661c7dd574b1867180c75",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:f98bfc30379e94251f50ed2542cf7b3e3c313478f2ab2f6319bbac6a2e945bc3",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.21",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/selinux-policy-37.21-2.fc37.noarch.rpm",
+        "checksum": "sha256:b316ebbfff1340150b759aee22c7a37175740ece8d0263397b33b38b5e605311",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.21",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/selinux-policy-targeted-37.21-2.fc37.noarch.rpm",
+        "checksum": "sha256:65effbe999cc162331276a5c4968dcfff002333f3bc8653eb1de62894074d11e",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.12.3",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/shadow-utils-4.12.3-6.fc37.x86_64.rpm",
+        "checksum": "sha256:b85714adf81c11f87479305bb324ad15c0cf92ca0f5560cef5c99995f1e9c942",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:46c547bcfe971a7cf00760334505514dbb860e35e439e8118fdcd12fd545dfbb",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/sqlite-libs-3.40.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4d1603de146f9bbe90810100df0afa2efe32e13cc86ed42e32528bc50b8f03dd",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec407a50153db3d466ed6063bc9274ce73192197e08e22ee88f7c364036ffc66",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-boot-unsigned",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-boot-unsigned-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:18ba36dec0758ea7204e306b82eff1099f3ea417e2eea2b21636da19cd71653f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-libs-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:37934c2adce2bf1559a8b74a9e6c62510acb0d0653ab5d80b2676f69388beee5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-networkd-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d61a2c880db45f1bb592d1896d048460401bb5f70486d877f8dc351843fca10b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-pam-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c3f416c1d6cb05491f61e4f9cf2e976b0ccda4cb3eebc2c1b6dfa633e876bbef",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-resolved-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7aa25738c396b5da9019989248229548a8291e613528e07f176beeaf2df44ef7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.14",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/s/systemd-udev-251.14-2.fc37.x86_64.rpm",
+        "checksum": "sha256:eb8ae18f87b52e898bc3d4bbcb8aa448d100bd47cf630c6156f9f9a0a356add2",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tpm2-tools-5.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:5e68dbb3136877c39b8ba78733c24b03724d92bdcf40bc051f5647843d2ed781",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.2",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tpm2-tss-3.2.2-1.fc37.x86_64.rpm",
+        "checksum": "sha256:fecd2ef49993396a00deaae7d591957424a03c760d61318b514721a595998087",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/t/tzdata-2023c-1.fc37.noarch.rpm",
+        "checksum": "sha256:a7116693b8cc1a857e8a515e6196e2fd3272e56d7c844b65c286d931ad6c3631",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/w/which-2.21-39.fc37.x86_64.rpm",
+        "checksum": "sha256:4a014a589f3342898dfe96024a04fc0541ddfb48894774af6668ccd6fde5d483",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc37.noarch.rpm",
+        "checksum": "sha256:7a45a0934f29b10d73ec95438ceddec758cb391d54f967c2eeee7bec1e71bca6",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xkeyboard-config-2.36-3.fc37.noarch.rpm",
+        "checksum": "sha256:ddbe0299565bb8cff68a554ff8401fc9127b9fcecfeb030140951b89a551f0fc",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xz-5.4.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7af1096450d0d76dcd5666e31736f18ff44de9908f2e87d89be88592b176c643",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/x/xz-libs-5.4.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:8c06eef8dd28d6dc1406e65e4eb8ee3db359cf6624729be4e426f6b01c4117fd",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7f37e2fd76c1227d1cf305c53c6065d3a6ebc864f6e0dd238e35abb3f32de30c",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-aarch64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_ami-boot.json
@@ -1,0 +1,5413 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "aarch64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-modular-20230413/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:8a4baaebebc2065ff8565b5b3c9f9d40bb939d1abff96168ebcaa1af1c6715cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba0fc33d7e7168313996f5c79937db58f410da70b26df48b7166736aff5ffb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0aa1cdcc509b71c213a3dec422edd010063597742942b1bd08789315ca8462d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8706ffe41bfc9449bd6e9dcff3cc1c074944d34ee3271e6f557f67a6ca9047b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeabc2a929fa364677839c3d56b2230f7694668b9a6118303931f980e3d21d0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:617eaa72b28f2322aa02236940715fb31864e3d3561141079e1e3287331829fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9b11470655ca9328c00a8d2078447af1caf0248699464f6f61b82ecfc41ba83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43a5fc865a2eacfd9724afc3706be78e72814d1f7fa92011186a3dc5be53bcf7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c289dca4b7d4b7ff09bfc3973c23fa27828a0d17e280e6dffeb119f642bec3b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3849a6d8de295750088598fbe7246d7dc8fe857e267e48edb3deedb12d8edb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8ca1130421307e95e823137e4ca04ac6e402557523da78e4e4fb157438c019e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bbe96417ee7bc5758c77fb8cb6a762a566248b5af199310f65cd0a7f7c2e7e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8fb3c7d0c16b39ca3b472e991238bcdfcdf7029da030aa90d248f5a303b8734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3dc9503625f8ccec829de7804e4a852bf6e31210c3afb0a9d4d96f83287130b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af65e2f6e568e916d46f404f522e014d8fd57a7c9c9acd9cafc60fcf88b7c065",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a2eeb191bed31eb0dd350c48c13708fb823d17bd126cea6bf9a52d07e1c319a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f9bb83854722b3eda07903f0680c00659ce88b6714f9e581b41ab705355d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c5bb03e965a4e7205720bdc351896afaa78f7d18858525b15ea2ea8d83cef17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:482550236810538bae9b7a7dbffee8c756c0def8e3b34db40659d37bd2af8fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:281ce5635ad029dd4df1998a84dd5d0cdb797b603b703ece5022c125fab147ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0de12f38bf863088edd60073b59c6d1a831a2cfd604574c658f8eb290ebb51d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e2cafda8609942719699ae99772a096a621c64f2ca13ea1c9163ea6fd9d05e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3515d98cb1757a4d2299566cc26e4f90fbf8dd5afe384a10253c49a755f692bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94431a8578a0f0342392090d284b912f14a45efe887c954415ac22e8e15643d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2d82acbad79031da034857c01221983ed5184e3d49c31a435c1fd30e79cb62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c66f06e10707d03b491fb130bfe501fb5a3ef9eeffcc23c1a4bdfeae9f8ea452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0274e746ea0ada3f51696f26abffeaaece46f725595610af1c930e24466fb40a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98dd2f179b6d4ba7665a051f64f8a1947ef59def5818f297dc265c2deef6b2bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c03fdf1f9a8ce61bb49145ef39e10aab2fe5b93d2a6113dc3c845b000ece6ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02dfb1bcb5194bee30f27c513e17e1740553c5c3e2fe08c92fbca5f92cebe604",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9266ea9453cac0230fd04de6df6c86956a96d35d32b893009ec351681b763507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e06a7695a2b6fb118d0d4668a8a0454f96cf105d29c9309a91fbbfba606aeff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bddc649cdf571d3329fae93d0f0f53d12aba317970ae63f3852aa9693f9ff281",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c421c6dd086ac1d3be1a099b1f38870c2ff5bb35d2bf2407a2d5e96e9723452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d90ad8a8f8844e1b3dc2cb9b20103bcc96b5f99c0d3f8d5edc71ff21984dcc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:073c216d2699a73912ff0f2db4d3fb83eaba8bbbbafa7b650875439814cd6c36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f4c6ebdfa1498e338dce5a1c3862434a0e06296118870c182d9212cb9438095",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22af041002b0e8e6f3f69b851bb42476a695dbd893990270ede8498c7bcbbf35",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8f4e6c4dae9fb0a880c3f0fb8952f83623416000a92a47879a11e6900cfddf6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:822730809e15c6a117f5c3729ff63549c3712841b4e9d45747c1d45e15323e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8074eec4ad7794687deee6f9e217b713e6691485de3678ee8629aac04cc6bf9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10a540bedd42485014afa023ab613b1189bc8d56af5c84b1f470a01010ae8b43",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bfc873da712dbcf4fffa525879f8a97e016823e4c8aa9567d4a5dec32b7b084",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c31b5312684e830c6f7ebc634af507530135eefb1d171bc7cc5716f8cd35c675",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcfd7dd56e3996efa7398fe2d1f35dfbb7b7520e208e42d2e7a5714e096d072b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12eb5906dfd74ad0f439bbce4d213c22a1db84e47dbb9a8e7090d116263a5666",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de733c7a0ffdefb415a76aa2c10cedbe57ca803b41d698d72dca0ac99cd71e58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e123a5a7f7a7ae0664739d890973bc9710638932ee40c94c42be274248590e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39c59ca6abbb12344a0c1933d853b2f11ad665f5db1755daea244b3ba8b59e52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac6fe64efa5c7e3c778478c8f15aecae6bdf55aec462f27deff0c8a9b248e2f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a75a6040a6bfdcfea5da3bdce6b91c4dca9a5063fda2c0f611136615a561d9ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdf57fa262d0995a92f61df4a2aec626c0aa663d41d669b096972c7068ecc288",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00f09471d69891113ac7983763aaf5e3ecfc7580ebc471688cc1a883aeebb29b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea57c01703b1314a229e21a29326d45e3cb8bc935620446c25525a9047dfcdc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22c1fda0f37b8669101ebe719e81d4770b3a039fd96c6f6f8d93da4723eec6bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:021c4d31d33b21f3ccee1ae50681a8e3d47e129120ac2fe270b8ec6ef680c3d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd5238f372454393bbb3f551de0b3e4fb7ad77af75b9b6301d1835460920e999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7db3f51e407e88506946ef763d96cdde22aec1b42421875e683e557293cd32e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a1e4b6798d57d0883d7bdc92e9d92211ddc9628d36d79630cf3253eff728761",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d515d72a040ed6288cf2dbb791e2174af5c61ade83d1484b40d28756de34d4a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a4f7ad6f54c6ac9575b33d2865ef63ee45da11b9df825d2c672adee3a7e9021",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eb97429bf8fcb473e948af4d2608ec373fe48481ef488f0341683aa1c7e50e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bf1e1726e0250d714560f1ec3977287c917c419d819b0e72756edef91d401b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4abc25c2d9e982759a9f4a4c9a83b6a5add367ed9b0f45d195dbbbcf254190a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:547908864163efaee3c29c3584203ee4cc0b7099b24fa19064ddea7685ce698b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:992c4a4ef6d7048e6974b03ac9ea149b4370ed04db11f6f24a0473a295773f9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b56ab0e709dd96dcd3e4e328e3b2b6b15f33a2b4812f25364ee435d30319092b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4aeb7d54152d48f4716fab3d176327720bbbc6fd325badb98ebbe97caecb803",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d81b296bb0df280445b341fc767e813eed64844a83c1680a67554dfb7a6ff39e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4293a87defccfc402360385c02625a9dd6607bc00db99e8000476f43cefd37b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0047142c2c2bb0a2cc868b9b44b6e819a5a55d8946387ac0471567a0504acf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e2b9788379e4fd5f36f141ded6425b363b6e3efc8b6bc23691785f0a4751f74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75dd39b0589830a3a06032780f04459666fbb22d3dce9b4689969b0bf1f132ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef6fe390d0b1ef456012ae6139f9d386e76ed4990716c23b8bd1f6769201bd58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31c109dbedb61d8a7610de000f58ce0942e1e534266ecc97edaf91fea82c4e93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3910521a4101f8fa34ad243f26c05c8fa1ddb4df278a05ac2e186bce6370f1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f10853c75085541d1056eda7ec188c321532f35e0b89d0561c391cea269a8204",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:679d2fc2911dc01f001d6d13e5013f22bdff7a9eefdf55b675d6e22504b937c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d310dfed42a1db630e22b74b399a71c2247e58f06dec4d1df192e74b56e791f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7c4ee5f37e5ee847725d9aaf78bf97710f463d18dd6c47b0473edf8d16934f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0f80e9d906d21d5105787f3e362eef7519604a4decb96c23ecdc5088d574505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3f53150e220a12421f1fb295d3ece42aa2e174887cd4aa3dd4bf4d763a41b2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bc57215b45668477d659123507242a0cd257e5b1d13941ac80ceb8496b28142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc3b829418261e018d6bb15fb3e84fca8d1f232ef53ad4c37b4939a07a3a84ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3523f40ba01e060cd9aa2c3a7c0a21693696298f8e9ebbc4e9b689d6851f950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:855dd0c7aa5d1762fdf4294d813a47e098fb281e58b57b7bccd9e3f5f18eb1c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daca9346f66c9cf88b649178972c15ee236207b97681c54a2246713632e1bc11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5aa4601eb358b162dffa5b6d126e019f1fa67a1f2d36b294f4524ea89a2016cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad5edd39f36abaaeeb42c5b9304d8157045bd27aeaac24ff29fedb82c2ebccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08d0a1411840b3ca222095c9d2dd39b9cbad643e997defafa9b05211f365e24c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e26ec1ec298590c5e6b56db325e68bf170e6ac2ac5ac8fdf08bedf5283b07a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6753e8f94517a3224ef5b955d45144ff354f6fddb1737870d1b151fe30ec925",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:128a5de6769cb229683bca33106341aced54b97dc5806bb5d571c37384988924",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c48b62ce7ccb65c82097b687d4eb68c5765baf24504976ddfb67cc332073d8db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33bc878679d75791447ce16f5d00a33fc6a207eae2bf83d38203732b808e6a54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da059b7cadabe81a378c08a929fc391354e01e96b5b4d951e6627096b0a60671",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71b87827b2375cd91a39e5d534e3682eaca33756b9ff00cf86b9fcdc2fc0a26b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff2f6fed64555c4e83e5433d6845ece042cc1ee113e96ff94148baa1f4c820bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26c04558f99ff8754be611a90a35570fab09d06514464c569272b3601bc55b4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aefcc29050240901824da737ea2ddcf0cc171d4654338c916578bfdfec148207",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02c4d78eb71234579a540d0627c3606fa63e3ee8d49463063b9480370c1c4030",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6eed553d444dd0eb0a1a3cb4fc504874fab9a979a5ef941d29c8c61c91cafbf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:831b1874f0d5aa14267d32a38da4d866bb04d43d692403ecb155218e9846d12d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab5bf07996f81efd15640f421a14bbe25e25f04f14347c5f37d70c84f298ba4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1afa90119a69b82ad57fab9e6851731cefa502338f717d89fec76aae964d3b5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d29f6773d1b36fd44e670d561c7dbf96039029fed355c144eef50e022047655b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3acb1eed119d43ed430c233816fb9d2d53b190376dc682face5193e0c6828c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51aebc456415ed90d74d36c76782523e0eec59a30be6b98f7f17fb5ca2b99f29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d80b199b45bd2b852098348cc89cc48afd31c4450fd0e2972e202f42f813547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38cda530b79c2861fc2a3a9739db5fb63209be65b1a7b22ad35f6d354ba4ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3275be80093f05657e49df1a80a60005e433d76c7a35be9f1934f9ee83de178d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2071c518e33f57812786511e1bf83095881ab5b6d2a527f8f3b379d847f4556",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f6bc8e3c61c85080715058c008f72bf155213495c41e0c553d8a375020be108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55474a91a1cc3dfe11f030309bdba48d042800d5a4ee37f0ca169b1ef6fcbc10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06e7bf833445e81b5fb0a3e768b8b628ce18c3432bf0c3abc3298c0a3e05affc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:791336f5d0ad956b83bfa52d8acb2f27e47ce91aa3b0574daf6bce5a20fa81e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d45ee3d12d376b288196c952d68e4e4d74d156a4fb0c3542438a56b35d701d39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a14a5c269f0fcd145837e945b97ded6e14d05917eb5b3678f47524d1fdf06ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb5f1a3d96ef70ed49d52f76f9a03ea480ceb4e18f4528c71176f11adc280a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf5dfb205d86080627e39b7c355af3f31b5503bfdf7a3c67af417836b6b17cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f0902a9eb84cb0a2c312932145fa12dc9736cb232870a79ee61f3fc5ec89f6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:978fc89869fce9ba0d7298776da75c64c4fbe207e8473ba23c216fde4ea9d128",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f09c95b8ea14475abc705f3ec58c2bac9cc12627b1eb2bde8df0bf9922e5f011",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a2422b58950e753123232fc22b33cd9c3ef50bb054cc457d275d33aa8f5fe88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b9250302db0ca1ae1544766f751919b7e9ef08f7fc14c224e035334d7d18253",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41122a51c47efb38e63e992a6997a99dc14739df4081d3ce581cb6166e7ca0fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d94cb7b257e67e63e1ac1646a3388df3d8687aa7589141e9d88575dbc6ad87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:622a80c09665eccc5c8ff7d397b76fae41a074ac7a5bcd55f0f12f2b0a8401f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb45d1114ed97e2e375607df27bbca890eefaa43c8d0887ea861de12c24739ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3094eda7a013a532d6651ef0efaa66162f52baaf60fc0dd5cdeea0f957ba8ee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c80f68f0b194af9be448d69cffbe4b4dc387e8be803f28368aa1b24192a5dcaf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d035427c1831cd1f3a87cea493d693e231193d597ae4fd5da9dbfe54745c79a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b58fccbaffa23cbd78a393ac2f0d51bd9d15d43c8433501195499e6526e2db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcc0aacff8ded1d0cfcc997dcefe2b954527242996368ecd753c97878164ec91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e041dc0000070f0954178eb808cfd6be2daa5ef0cc4656fbd2b68eaf3b3318bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7308dd3715530ebc6f3a8b86939936056815e6929ee0a7abca1d07bcab9e73f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab05c8b70d12d454fb87e9282e689c222e7f1e2b4e69ae6bdd8b8d3324ba6b77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8946cab1baa41f4818935b151292647d9a96942acb3de1126335cdfb8c42170f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40261aa7487e1c7f0b8a529e7e2d2efdb79bb8b22fb684cdff92b52e85e6947c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86c6766a94b65c0a251c346de4cc1501cdbe827e01dd0be5c9ebf726271cf684",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f1937630234f9c42b969a9f81791a7e6f0f2972c4ec392c8e383054acaa69b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c08cbed9d20cd2a49bbead543ac83358298f895c6ca7f5a51309b4943e8403d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a1f6fca9921d7e90113208c3fb379604eee9d9794467e2f652c74ceb9c3a980",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:233abea1b68904e73177df5a7bff96d8d0238053e6061225e4df05d5f8f205d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7fd4ae63cc37207d3a4bcb6b7ec58e8d07cb67b55fb6a85f0aa7ebbbe92e861",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7be00dc6494d236494f1fe6bf8961781f82939422322d80bcb74ef14a5ad0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbbf6a8e693bc019dc0dd5c40da8c4c6c5523cb160e840c52bc7e4f541e1bb87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8b1d1ab3effd4bc07accb16dcabe0538a7f8c2daeabf8bfe9f18208a32b8a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e05908892b57924e187e9e457b8d2b5a8226883403ed6e6559fa131b4541af07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a54f778abf552a8421d764495a6ce189bda7a8c51665da04b420bc89a6ab541b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13b3f5fbda0609542288be20e45f4b8711d6d5939135e0879205c13163af08f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e71bec04105d4a92bbecabc588ddadf8193df6fa9a982a83d60838a2e7460d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b890d9e481435aa36684c8a041384ca7dcbe7e9da75e3d9d08903f6aca2d20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a45da92d5b0fb12397ddb256777003c763a6d9e9951b571dc3d1fbb48a70288",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ba6cb03a91d937283f6c083ce9de087b816c3f091baeab1d2e762ca6353a74b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcd7fa64243f3038d8e638bf23d0ce02e95a0f844220ab2d12d65495e522740f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1f0ee8dbaa9b71dfb26d11856744ef74376ff90c476b9cec89b9c93c8fe2059",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:622fd85b30c27fa16d056acd9c25a9b65a34791601e96390cecf25e19e0a317d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74d642136ebb3ea38de7dfe8f7b74f03467b72135ae8af8ff58b6a45dfef9046",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f78f1e088792b93081bd6a2b9575e3ae9306ff1c12696f21d77eb47f9f8cc0f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5341c12b3f09067d29901363dab407ed8bab66167befa89bdef255bd8b82d8a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d796836566b74c929e97126fd90a348bab6ef931a64aac2ceb2812b1fc82311e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3481c41cb8d785ac8ced947802a7bc543b3a409e5257020380263301f3a0296a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5331eab8bace52c93fe3758f7e6cb343461073c20d16c94d642cdd201e647b21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3df21bcafa4efa4183efa60ae50d4ffe4a52e67868ab2375df2b274aa4d3e5c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dcc2a3b5f06dd6a2abc1f945113b6277b4ebb9eddfc505dc5c02e16c0180eb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56d32b932a3fb88fe551d4ec69f017d561d003a429b5ba63e03ae1567459f154",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfb6f3ee7a456e97bc807ff6b06a49a018ce28f94cf85e126cc1a794acbb4ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5010c732079d3fdca7c81569386643773157c0b1da936eaa37bd292d7cdef7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b001adb81776dfa1c755aa566466cca29d33c7608a1c410f63de5f3ffaacdaf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec00f8c51ee6b1eb5434d1a5812a933a12989a53aebacc1a7d3c60258c8bd8d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b28da4db47c11a4757e5f26ff5d3ee72298126e077580a3540e3cc94d5543a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e4c3823de7003d3240ca75802a111fa4a17fbc09c710a33a3b9990fa815b017",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5985b3157536a8d2b42ac0b75027603ddbeddc20d3137e6e1638c7319bf8669a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:626d715912b0dd188fcd105c4ed1b63d6d3c8de87f955f95138eb03b589a96a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fa18a2010fb71a7ac93c11757fa484c3bacb4cfec575bb03ea965169dafc64e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f89d0b33f9d1de26706e014bf5c6564099af9df35a493b0220d3500800fe73d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45935cafe28c0238d0c8f17f547032a3401b4009465ee751994f9c88ef659469",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8a06fcbf4164a2cfb5c9e212eb5c895f5fcdf3a72b862f70f01a85340a93b4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61e2f6d7365e54d6eb1a9a9ad3f0660e41005c42d4a0679a206dcbaab88f9d2c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff9544d1a2170e48bdc7ff941cc70c3321aaf2f6b2e2922444d4fb4811dc6a94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:345d91cc09459265a9d90c5b6ab527b7614122529ccaafcd0b09f62dcc8643eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13ffb19e7a8899022cc6c3b7a8b8d757dbb379a744f470385f81bde9fb04883d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f013ff26865de9ee898cb247f2ca6512f3ac0c65ad124b9e09322989494da6ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bcbf92f0264dfa83fb5ac63cae5d0c312a26df05e4ecc2e69d94a86072a8dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cacc4a03ba6f6d19f4944834c74ad3eac09642d1323bba14f01e313d26f71cf7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db529f9292f84096bec3ade8fa0b7669ba16da2b5b55d65590e768aabf506cfa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da868912dec8c24eb697f4c2aeeb6eb884c23279b89948ef241c3c67e11e34a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cd60382cbbcefc2b991949c32a76a52750df1728224914d3a8dd67440f809c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade1f69a89cedf340edfaee70b8b8e4d19d291dd0a95dca4ee8fd8b3f4361c0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc062d2cf09a2338039b339c22fcab84f09fe8aa248ac623afdfacea363b18c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b33122476fcc97589761d93a1054dea77c886b0e27164e78e47c86544cdf645",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bae80ceb03683e5480064137c192e4b4fcba1d744b0940ae990511bbdb65e3f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 17846272,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00f09471d69891113ac7983763aaf5e3ecfc7580ebc471688cc1a883aeebb29b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm"
+          },
+          "sha256:021c4d31d33b21f3ccee1ae50681a8e3d47e129120ac2fe270b8ec6ef680c3d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:0274e746ea0ada3f51696f26abffeaaece46f725595610af1c930e24466fb40a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:02c4d78eb71234579a540d0627c3606fa63e3ee8d49463063b9480370c1c4030": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:02dfb1bcb5194bee30f27c513e17e1740553c5c3e2fe08c92fbca5f92cebe604": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.aarch64.rpm"
+          },
+          "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/t/tzdata-2023c-1.fc38.noarch.rpm"
+          },
+          "sha256:06e7bf833445e81b5fb0a3e768b8b628ce18c3432bf0c3abc3298c0a3e05affc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pam-libs-1.5.2-16.fc38.aarch64.rpm"
+          },
+          "sha256:073c216d2699a73912ff0f2db4d3fb83eaba8bbbbafa7b650875439814cd6c36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnupg2-2.4.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:08d0a1411840b3ca222095c9d2dd39b9cbad643e997defafa9b05211f365e24c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:09f1937630234f9c42b969a9f81791a7e6f0f2972c4ec392c8e383054acaa69b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/coreutils-common-9.1-12.fc38.aarch64.rpm"
+          },
+          "sha256:0a38cda530b79c2861fc2a3a9739db5fb63209be65b1a7b22ad35f6d354ba4ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:0bf1e1726e0250d714560f1ec3977287c917c419d819b0e72756edef91d401b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm"
+          },
+          "sha256:0bfc873da712dbcf4fffa525879f8a97e016823e4c8aa9567d4a5dec32b7b084": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/j/json-c-0.16-4.fc38.aarch64.rpm"
+          },
+          "sha256:0c03fdf1f9a8ce61bb49145ef39e10aab2fe5b93d2a6113dc3c845b000ece6ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gawk-5.1.1-5.fc38.aarch64.rpm"
+          },
+          "sha256:0cd60382cbbcefc2b991949c32a76a52750df1728224914d3a8dd67440f809c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-pam-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:10a540bedd42485014afa023ab613b1189bc8d56af5c84b1f470a01010ae8b43": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gzip-1.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:128a5de6769cb229683bca33106341aced54b97dc5806bb5d571c37384988924": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libutempter-1.2.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:12bcbf92f0264dfa83fb5ac63cae5d0c312a26df05e4ecc2e69d94a86072a8dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:12eb5906dfd74ad0f439bbce4d213c22a1db84e47dbb9a8e7090d116263a5666": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:13b3f5fbda0609542288be20e45f4b8711d6d5939135e0879205c13163af08f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse3-libs-3.14.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:13ffb19e7a8899022cc6c3b7a8b8d757dbb379a744f470385f81bde9fb04883d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:1a4f7ad6f54c6ac9575b33d2865ef63ee45da11b9df825d2c672adee3a7e9021": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcbor-0.7.0-9.fc38.aarch64.rpm"
+          },
+          "sha256:1afa90119a69b82ad57fab9e6851731cefa502338f717d89fec76aae964d3b5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/ncurses-libs-6.4-3.20230114.fc38.aarch64.rpm"
+          },
+          "sha256:1d8b1d1ab3effd4bc07accb16dcabe0538a7f8c2daeabf8bfe9f18208a32b8a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse-common-3.14.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:1e26ec1ec298590c5e6b56db325e68bf170e6ac2ac5ac8fdf08bedf5283b07a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:1f9bb83854722b3eda07903f0680c00659ce88b6714f9e581b41ab705355d7d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/duktape-2.7.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:22af041002b0e8e6f3f69b851bb42476a695dbd893990270ede8498c7bcbbf35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnutls-3.8.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:22c1fda0f37b8669101ebe719e81d4770b3a039fd96c6f6f8d93da4723eec6bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libattr-2.5.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:233abea1b68904e73177df5a7bff96d8d0238053e6061225e4df05d5f8f205d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/d/dracut-config-generic-059-3.fc38.aarch64.rpm"
+          },
+          "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc38.noarch.rpm"
+          },
+          "sha256:26c04558f99ff8754be611a90a35570fab09d06514464c569272b3601bc55b4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/lua-libs-5.4.4-9.fc38.aarch64.rpm"
+          },
+          "sha256:281ce5635ad029dd4df1998a84dd5d0cdb797b603b703ece5022c125fab147ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm"
+          },
+          "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc38.noarch.rpm"
+          },
+          "sha256:2dcc2a3b5f06dd6a2abc1f945113b6277b4ebb9eddfc505dc5c02e16c0180eb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:2e2cafda8609942719699ae99772a096a621c64f2ca13ea1c9163ea6fd9d05e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:2e4c3823de7003d3240ca75802a111fa4a17fbc09c710a33a3b9990fa815b017": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/o/ostree-2023.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-misc-2.5.1-5.fc38.noarch.rpm"
+          },
+          "sha256:2f0902a9eb84cb0a2c312932145fa12dc9736cb232870a79ee61f3fc5ec89f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:3094eda7a013a532d6651ef0efaa66162f52baaf60fc0dd5cdeea0f957ba8ee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/sqlite-libs-3.40.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:31c109dbedb61d8a7610de000f58ce0942e1e534266ecc97edaf91fea82c4e93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:3275be80093f05657e49df1a80a60005e433d76c7a35be9f1934f9ee83de178d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm"
+          },
+          "sha256:33bc878679d75791447ce16f5d00a33fc6a207eae2bf83d38203732b808e6a54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm"
+          },
+          "sha256:345d91cc09459265a9d90c5b6ab527b7614122529ccaafcd0b09f62dcc8643eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc38.noarch.rpm"
+          },
+          "sha256:3481c41cb8d785ac8ced947802a7bc543b3a409e5257020380263301f3a0296a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgcrypt-1.10.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:3515d98cb1757a4d2299566cc26e4f90fbf8dd5afe384a10253c49a755f692bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/file-5.44-3.fc38.aarch64.rpm"
+          },
+          "sha256:3910521a4101f8fa34ad243f26c05c8fa1ddb4df278a05ac2e186bce6370f1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:39c59ca6abbb12344a0c1933d853b2f11ad665f5db1755daea244b3ba8b59e52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kpartx-0.9.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:3acb1eed119d43ed430c233816fb9d2d53b190376dc682face5193e0c6828c47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/npth-1.6-12.fc38.aarch64.rpm"
+          },
+          "sha256:3b9250302db0ca1ae1544766f751919b7e9ef08f7fc14c224e035334d7d18253": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm"
+          },
+          "sha256:3ba6cb03a91d937283f6c083ce9de087b816c3f091baeab1d2e762ca6353a74b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.37-4.fc38.aarch64.rpm"
+          },
+          "sha256:3c5bb03e965a4e7205720bdc351896afaa78f7d18858525b15ea2ea8d83cef17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/e2fsprogs-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:3df21bcafa4efa4183efa60ae50d4ffe4a52e67868ab2375df2b274aa4d3e5c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgpg-error-1.47-1.fc38.aarch64.rpm"
+          },
+          "sha256:3f6bc8e3c61c85080715058c008f72bf155213495c41e0c553d8a375020be108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:40261aa7487e1c7f0b8a529e7e2d2efdb79bb8b22fb684cdff92b52e85e6947c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-38-36.noarch.rpm"
+          },
+          "sha256:41122a51c47efb38e63e992a6997a99dc14739df4081d3ce581cb6166e7ca0fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:4293a87defccfc402360385c02625a9dd6607bc00db99e8000476f43cefd37b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:43a5fc865a2eacfd9724afc3706be78e72814d1f7fa92011186a3dc5be53bcf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:45935cafe28c0238d0c8f17f547032a3401b4009465ee751994f9c88ef659469": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc38.aarch64.rpm"
+          },
+          "sha256:482550236810538bae9b7a7dbffee8c756c0def8e3b34db40659d37bd2af8fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:4a1f6fca9921d7e90113208c3fb379604eee9d9794467e2f652c74ceb9c3a980": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/d/dracut-059-3.fc38.aarch64.rpm"
+          },
+          "sha256:4a2eeb191bed31eb0dd350c48c13708fb823d17bd126cea6bf9a52d07e1c319a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm"
+          },
+          "sha256:4a45da92d5b0fb12397ddb256777003c763a6d9e9951b571dc3d1fbb48a70288": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-common-2.37-4.fc38.aarch64.rpm"
+          },
+          "sha256:4bbe96417ee7bc5758c77fb8cb6a762a566248b5af199310f65cd0a7f7c2e7e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm"
+          },
+          "sha256:4bc57215b45668477d659123507242a0cd257e5b1d13941ac80ceb8496b28142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsemanage-3.5-2.fc38.aarch64.rpm"
+          },
+          "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc38.noarch.rpm"
+          },
+          "sha256:4d80b199b45bd2b852098348cc89cc48afd31c4450fd0e2972e202f42f813547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openssl-libs-3.0.8-2.fc38.aarch64.rpm"
+          },
+          "sha256:4e2b9788379e4fd5f36f141ded6425b363b6e3efc8b6bc23691785f0a4751f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm"
+          },
+          "sha256:5010c732079d3fdca7c81569386643773157c0b1da936eaa37bd292d7cdef7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc38.aarch64.rpm"
+          },
+          "sha256:51aebc456415ed90d74d36c76782523e0eec59a30be6b98f7f17fb5ca2b99f29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openldap-2.6.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:5331eab8bace52c93fe3758f7e6cb343461073c20d16c94d642cdd201e647b21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgomp-13.1.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:5341c12b3f09067d29901363dab407ed8bab66167befa89bdef255bd8b82d8a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libcurl-8.0.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:547908864163efaee3c29c3584203ee4cc0b7099b24fa19064ddea7685ce698b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm"
+          },
+          "sha256:55474a91a1cc3dfe11f030309bdba48d042800d5a4ee37f0ca169b1ef6fcbc10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pam-1.5.2-16.fc38.aarch64.rpm"
+          },
+          "sha256:56d32b932a3fb88fe551d4ec69f017d561d003a429b5ba63e03ae1567459f154": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:5985b3157536a8d2b42ac0b75027603ddbeddc20d3137e6e1638c7319bf8669a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/o/ostree-libs-2023.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:5aa4601eb358b162dffa5b6d126e019f1fa67a1f2d36b294f4524ea89a2016cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libss-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:5b58fccbaffa23cbd78a393ac2f0d51bd9d15d43c8433501195499e6526e2db1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/u/util-linux-core-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:5cf5dfb205d86080627e39b7c355af3f31b5503bfdf7a3c67af417836b6b17cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pigz-2.7-3.fc38.aarch64.rpm"
+          },
+          "sha256:5d94cb7b257e67e63e1ac1646a3388df3d8687aa7589141e9d88575dbc6ad87c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/r/readline-8.2-3.fc38.aarch64.rpm"
+          },
+          "sha256:5e2d82acbad79031da034857c01221983ed5184e3d49c31a435c1fd30e79cb62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/filesystem-3.18-3.fc38.aarch64.rpm"
+          },
+          "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm"
+          },
+          "sha256:617eaa72b28f2322aa02236940715fb31864e3d3561141079e1e3287331829fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cpio-2.13-14.fc38.aarch64.rpm"
+          },
+          "sha256:61e2f6d7365e54d6eb1a9a9ad3f0660e41005c42d4a0679a206dcbaab88f9d2c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:622a80c09665eccc5c8ff7d397b76fae41a074ac7a5bcd55f0f12f2b0a8401f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/sed-4.8-12.fc38.aarch64.rpm"
+          },
+          "sha256:622fd85b30c27fa16d056acd9c25a9b65a34791601e96390cecf25e19e0a317d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-tools-2.06-95.fc38.aarch64.rpm"
+          },
+          "sha256:626d715912b0dd188fcd105c4ed1b63d6d3c8de87f955f95138eb03b589a96a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/polkit-122-3.fc38.1.aarch64.rpm"
+          },
+          "sha256:679d2fc2911dc01f001d6d13e5013f22bdff7a9eefdf55b675d6e22504b937c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:6a2422b58950e753123232fc22b33cd9c3ef50bb054cc457d275d33aa8f5fe88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/popt-1.19-2.fc38.aarch64.rpm"
+          },
+          "sha256:6b33122476fcc97589761d93a1054dea77c886b0e27164e78e47c86544cdf645": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/t/tpm2-tools-5.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:6eed553d444dd0eb0a1a3cb4fc504874fab9a979a5ef941d29c8c61c91cafbf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm"
+          },
+          "sha256:6f4c6ebdfa1498e338dce5a1c3862434a0e06296118870c182d9212cb9438095": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnupg2-smime-2.4.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:71b87827b2375cd91a39e5d534e3682eaca33756b9ff00cf86b9fcdc2fc0a26b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm"
+          },
+          "sha256:74d642136ebb3ea38de7dfe8f7b74f03467b72135ae8af8ff58b6a45dfef9046": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc38.aarch64.rpm"
+          },
+          "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:75dd39b0589830a3a06032780f04459666fbb22d3dce9b4689969b0bf1f132ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libmount-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:78b890d9e481435aa36684c8a041384ca7dcbe7e9da75e3d9d08903f6aca2d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-2.37-4.fc38.aarch64.rpm"
+          },
+          "sha256:791336f5d0ad956b83bfa52d8acb2f27e47ce91aa3b0574daf6bce5a20fa81e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm"
+          },
+          "sha256:7b28da4db47c11a4757e5f26ff5d3ee72298126e077580a3540e3cc94d5543a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc38.aarch64.rpm"
+          },
+          "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fedora-gpg-keys-38-1.noarch.rpm"
+          },
+          "sha256:8074eec4ad7794687deee6f9e217b713e6691485de3678ee8629aac04cc6bf9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/grubby-8.40-69.fc38.aarch64.rpm"
+          },
+          "sha256:822730809e15c6a117f5c3729ff63549c3712841b4e9d45747c1d45e15323e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/grep-3.8-3.fc38.aarch64.rpm"
+          },
+          "sha256:831b1874f0d5aa14267d32a38da4d866bb04d43d692403ecb155218e9846d12d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:855dd0c7aa5d1762fdf4294d813a47e098fb281e58b57b7bccd9e3f5f18eb1c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsmartcols-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:86c6766a94b65c0a251c346de4cc1501cdbe827e01dd0be5c9ebf726271cf684": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/coreutils-9.1-12.fc38.aarch64.rpm"
+          },
+          "sha256:8706ffe41bfc9449bd6e9dcff3cc1c074944d34ee3271e6f557f67a6ca9047b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bubblewrap-0.7.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:8946cab1baa41f4818935b151292647d9a96942acb3de1126335cdfb8c42170f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc38.aarch64.rpm"
+          },
+          "sha256:8a4baaebebc2065ff8565b5b3c9f9d40bb939d1abff96168ebcaa1af1c6715cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:8c08cbed9d20cd2a49bbead543ac83358298f895c6ca7f5a51309b4943e8403d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/curl-8.0.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/selinux-policy-targeted-38.15-1.fc38.noarch.rpm"
+          },
+          "sha256:8d90ad8a8f8844e1b3dc2cb9b20103bcc96b5f99c0d3f8d5edc71ff21984dcc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:8eb97429bf8fcb473e948af4d2608ec373fe48481ef488f0341683aa1c7e50e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcom_err-1.46.5-4.fc38.aarch64.rpm"
+          },
+          "sha256:8fa18a2010fb71a7ac93c11757fa484c3bacb4cfec575bb03ea965169dafc64e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/polkit-libs-122-3.fc38.1.aarch64.rpm"
+          },
+          "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fedora-repos-38-1.noarch.rpm"
+          },
+          "sha256:9266ea9453cac0230fd04de6df6c86956a96d35d32b893009ec351681b763507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm"
+          },
+          "sha256:94431a8578a0f0342392090d284b912f14a45efe887c954415ac22e8e15643d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/file-libs-5.44-3.fc38.aarch64.rpm"
+          },
+          "sha256:978fc89869fce9ba0d7298776da75c64c4fbe207e8473ba23c216fde4ea9d128": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/policycoreutils-3.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-legacy-2.5.1-5.fc38.noarch.rpm"
+          },
+          "sha256:98dd2f179b6d4ba7665a051f64f8a1947ef59def5818f297dc265c2deef6b2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:992c4a4ef6d7048e6974b03ac9ea149b4370ed04db11f6f24a0473a295773f9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libfdisk-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:9a1e4b6798d57d0883d7bdc92e9d92211ddc9628d36d79630cf3253eff728761": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcap-2.48-6.fc38.aarch64.rpm"
+          },
+          "sha256:9c421c6dd086ac1d3be1a099b1f38870c2ff5bb35d2bf2407a2d5e96e9723452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-runtime-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:a14a5c269f0fcd145837e945b97ded6e14d05917eb5b3678f47524d1fdf06ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:a1f0ee8dbaa9b71dfb26d11856744ef74376ff90c476b9cec89b9c93c8fe2059": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-efi-aa64-2.06-95.fc38.aarch64.rpm"
+          },
+          "sha256:a3523f40ba01e060cd9aa2c3a7c0a21693696298f8e9ebbc4e9b689d6851f950": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm"
+          },
+          "sha256:a3dc9503625f8ccec829de7804e4a852bf6e31210c3afb0a9d4d96f83287130b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/device-mapper-libs-1.02.189-2.fc38.aarch64.rpm"
+          },
+          "sha256:a3f53150e220a12421f1fb295d3ece42aa2e174887cd4aa3dd4bf4d763a41b2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libselinux-utils-3.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:a4abc25c2d9e982759a9f4a4c9a83b6a5add367ed9b0f45d195dbbbcf254190a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:a54f778abf552a8421d764495a6ce189bda7a8c51665da04b420bc89a6ab541b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse3-3.14.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc38.noarch.rpm"
+          },
+          "sha256:a75a6040a6bfdcfea5da3bdce6b91c4dca9a5063fda2c0f611136615a561d9ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libacl-2.3.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/selinux-policy-38.15-1.fc38.noarch.rpm"
+          },
+          "sha256:ab05c8b70d12d454fb87e9282e689c222e7f1e2b4e69ae6bdd8b8d3324ba6b77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm"
+          },
+          "sha256:ab5bf07996f81efd15640f421a14bbe25e25f04f14347c5f37d70c84f298ba4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/publicsuffix-list-dafsa-20230318-1.fc38.noarch.rpm"
+          },
+          "sha256:ac6fe64efa5c7e3c778478c8f15aecae6bdf55aec462f27deff0c8a9b248e2f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/krb5-libs-1.20.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-common-38-36.noarch.rpm"
+          },
+          "sha256:ad5edd39f36abaaeeb42c5b9304d8157045bd27aeaac24ff29fedb82c2ebccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:ade1f69a89cedf340edfaee70b8b8e4d19d291dd0a95dca4ee8fd8b3f4361c0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-resolved-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:aeabc2a929fa364677839c3d56b2230f7694668b9a6118303931f980e3d21d0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm"
+          },
+          "sha256:aefcc29050240901824da737ea2ddcf0cc171d4654338c916578bfdfec148207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/lz4-libs-1.9.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:af65e2f6e568e916d46f404f522e014d8fd57a7c9c9acd9cafc60fcf88b7c065": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/diffutils-3.9-1.fc38.aarch64.rpm"
+          },
+          "sha256:b001adb81776dfa1c755aa566466cca29d33c7608a1c410f63de5f3ffaacdaf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:b4aeb7d54152d48f4716fab3d176327720bbbc6fd325badb98ebbe97caecb803": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libfido2-1.12.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:b4e7be00dc6494d236494f1fe6bf8961781f82939422322d80bcb74ef14a5ad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc38.aarch64.rpm"
+          },
+          "sha256:b56ab0e709dd96dcd3e4e328e3b2b6b15f33a2b4812f25364ee435d30319092b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:b7db3f51e407e88506946ef763d96cdde22aec1b42421875e683e557293cd32e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm"
+          },
+          "sha256:b8fb3c7d0c16b39ca3b472e991238bcdfcdf7029da030aa90d248f5a303b8734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/device-mapper-1.02.189-2.fc38.aarch64.rpm"
+          },
+          "sha256:ba0fc33d7e7168313996f5c79937db58f410da70b26df48b7166736aff5ffb60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-identity-basic-38-36.noarch.rpm"
+          },
+          "sha256:bae80ceb03683e5480064137c192e4b4fcba1d744b0940ae990511bbdb65e3f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:bb7c4ee5f37e5ee847725d9aaf78bf97710f463d18dd6c47b0473edf8d16934f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:bbbf6a8e693bc019dc0dd5c40da8c4c6c5523cb160e840c52bc7e4f541e1bb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc38.aarch64.rpm"
+          },
+          "sha256:bd5238f372454393bbb3f551de0b3e4fb7ad77af75b9b6301d1835460920e999": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libblkid-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:bddc649cdf571d3329fae93d0f0f53d12aba317970ae63f3852aa9693f9ff281": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-libs-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:bdf57fa262d0995a92f61df4a2aec626c0aa663d41d669b096972c7068ecc288": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libarchive-3.6.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:c0047142c2c2bb0a2cc868b9b44b6e819a5a55d8946387ac0471567a0504acf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:c0f80e9d906d21d5105787f3e362eef7519604a4decb96c23ecdc5088d574505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libselinux-3.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:c289dca4b7d4b7ff09bfc3973c23fa27828a0d17e280e6dffeb119f642bec3b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cryptsetup-libs-2.6.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:c31b5312684e830c6f7ebc634af507530135eefb1d171bc7cc5716f8cd35c675": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm"
+          },
+          "sha256:c3849a6d8de295750088598fbe7246d7dc8fe857e267e48edb3deedb12d8edb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.aarch64.rpm"
+          },
+          "sha256:c48b62ce7ccb65c82097b687d4eb68c5765baf24504976ddfb67cc332073d8db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libuuid-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:c66f06e10707d03b491fb130bfe501fb5a3ef9eeffcc23c1a4bdfeae9f8ea452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/findutils-4.9.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/setup-2.14.3-2.fc38.noarch.rpm"
+          },
+          "sha256:c7fd4ae63cc37207d3a4bcb6b7ec58e8d07cb67b55fb6a85f0aa7ebbbe92e861": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc38.aarch64.rpm"
+          },
+          "sha256:c80f68f0b194af9be448d69cffbe4b4dc387e8be803f28368aa1b24192a5dcaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:c8f4e6c4dae9fb0a880c3f0fb8952f83623416000a92a47879a11e6900cfddf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gpgme-1.17.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:c9b11470655ca9328c00a8d2078447af1caf0248699464f6f61b82ecfc41ba83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:cacc4a03ba6f6d19f4944834c74ad3eac09642d1323bba14f01e313d26f71cf7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:cb45d1114ed97e2e375607df27bbca890eefaa43c8d0887ea861de12c24739ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/shadow-utils-4.13-6.fc38.aarch64.rpm"
+          },
+          "sha256:cc3b829418261e018d6bb15fb3e84fca8d1f232ef53ad4c37b4939a07a3a84ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsepol-3.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/containers-common-1-89.fc38.noarch.rpm"
+          },
+          "sha256:cfb6f3ee7a456e97bc807ff6b06a49a018ce28f94cf85e126cc1a794acbb4ff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libstdc++-13.1.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:d035427c1831cd1f3a87cea493d693e231193d597ae4fd5da9dbfe54745c79a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/u/util-linux-2.38.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:d2071c518e33f57812786511e1bf83095881ab5b6d2a527f8f3b379d847f4556": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:d29f6773d1b36fd44e670d561c7dbf96039029fed355c144eef50e022047655b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/nettle-3.8-3.fc38.aarch64.rpm"
+          },
+          "sha256:d310dfed42a1db630e22b74b399a71c2247e58f06dec4d1df192e74b56e791f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm"
+          },
+          "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-common-2.06-95.fc38.noarch.rpm"
+          },
+          "sha256:d45ee3d12d376b288196c952d68e4e4d74d156a4fb0c3542438a56b35d701d39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:d4e123a5a7f7a7ae0664739d890973bc9710638932ee40c94c42be274248590e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kmod-libs-30-4.fc38.aarch64.rpm"
+          },
+          "sha256:d515d72a040ed6288cf2dbb791e2174af5c61ade83d1484b40d28756de34d4a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm"
+          },
+          "sha256:d7308dd3715530ebc6f3a8b86939936056815e6929ee0a7abca1d07bcab9e73f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xz-libs-5.4.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:d796836566b74c929e97126fd90a348bab6ef931a64aac2ceb2812b1fc82311e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgcc-13.1.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:d81b296bb0df280445b341fc767e813eed64844a83c1680a67554dfb7a6ff39e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:d8a06fcbf4164a2cfb5c9e212eb5c895f5fcdf3a72b862f70f01a85340a93b4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-4.18.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:da059b7cadabe81a378c08a929fc391354e01e96b5b4d951e6627096b0a60671": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libxcrypt-4.4.33-7.fc38.aarch64.rpm"
+          },
+          "sha256:da868912dec8c24eb697f4c2aeeb6eb884c23279b89948ef241c3c67e11e34a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-networkd-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:daca9346f66c9cf88b649178972c15ee236207b97681c54a2246713632e1bc11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsolv-0.7.22-4.fc38.aarch64.rpm"
+          },
+          "sha256:db529f9292f84096bec3ade8fa0b7669ba16da2b5b55d65590e768aabf506cfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-libs-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:dcc0aacff8ded1d0cfcc997dcefe2b954527242996368ecd753c97878164ec91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/w/which-2.21-39.fc38.aarch64.rpm"
+          },
+          "sha256:dcd7fa64243f3038d8e638bf23d0ce02e95a0f844220ab2d12d65495e522740f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.37-4.fc38.aarch64.rpm"
+          },
+          "sha256:dcfd7dd56e3996efa7398fe2d1f35dfbb7b7520e208e42d2e7a5714e096d072b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-2.5.1-5.fc38.aarch64.rpm"
+          },
+          "sha256:de733c7a0ffdefb415a76aa2c10cedbe57ca803b41d698d72dca0ac99cd71e58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kmod-30-4.fc38.aarch64.rpm"
+          },
+          "sha256:e041dc0000070f0954178eb808cfd6be2daa5ef0cc4656fbd2b68eaf3b3318bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xz-5.4.1-1.fc38.aarch64.rpm"
+          },
+          "sha256:e05908892b57924e187e9e457b8d2b5a8226883403ed6e6559fa131b4541af07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc38.aarch64.rpm"
+          },
+          "sha256:e06a7695a2b6fb118d0d4668a8a0454f96cf105d29c9309a91fbbfba606aeff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-envsubst-0.21.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:e0aa1cdcc509b71c213a3dec422edd010063597742942b1bd08789315ca8462d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm"
+          },
+          "sha256:e71bec04105d4a92bbecabc588ddadf8193df6fa9a982a83d60838a2e7460d03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glib2-2.76.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:ea57c01703b1314a229e21a29326d45e3cb8bc935620446c25525a9047dfcdc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm"
+          },
+          "sha256:ec00f8c51ee6b1eb5434d1a5812a933a12989a53aebacc1a7d3c60258c8bd8d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm"
+          },
+          "sha256:ef6fe390d0b1ef456012ae6139f9d386e76ed4990716c23b8bd1f6769201bd58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libnghttp2-1.52.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:f013ff26865de9ee898cb247f2ca6512f3ac0c65ad124b9e09322989494da6ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc38.aarch64.rpm"
+          },
+          "sha256:f09c95b8ea14475abc705f3ec58c2bac9cc12627b1eb2bde8df0bf9922e5f011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm"
+          },
+          "sha256:f0de12f38bf863088edd60073b59c6d1a831a2cfd604574c658f8eb290ebb51d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm"
+          },
+          "sha256:f10853c75085541d1056eda7ec188c321532f35e0b89d0561c391cea269a8204": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:f6753e8f94517a3224ef5b955d45144ff354f6fddb1737870d1b151fe30ec925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm"
+          },
+          "sha256:f78f1e088792b93081bd6a2b9575e3ae9306ff1c12696f21d77eb47f9f8cc0f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libatomic-13.1.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:f89d0b33f9d1de26706e014bf5c6564099af9df35a493b0220d3500800fe73d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc38.aarch64.rpm"
+          },
+          "sha256:f8ca1130421307e95e823137e4ca04ac6e402557523da78e4e4fb157438c019e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:fb5f1a3d96ef70ed49d52f76f9a03ea480ceb4e18f4528c71176f11adc280a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:fc062d2cf09a2338039b339c22fcab84f09fe8aa248ac623afdfacea363b18c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-udev-253.4-1.fc38.aarch64.rpm"
+          },
+          "sha256:ff2f6fed64555c4e83e5433d6845ece042cc1ee113e96ff94148baa1f4c820bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm"
+          },
+          "sha256:ff9544d1a2170e48bdc7ff941cc70c3321aaf2f6b2e2922444d4fb4811dc6a94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-2.fc38.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:8a4baaebebc2065ff8565b5b3c9f9d40bb939d1abff96168ebcaa1af1c6715cb",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:ba0fc33d7e7168313996f5c79937db58f410da70b26df48b7166736aff5ffb60",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm",
+        "checksum": "sha256:e0aa1cdcc509b71c213a3dec422edd010063597742942b1bd08789315ca8462d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bubblewrap-0.7.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8706ffe41bfc9449bd6e9dcff3cc1c074944d34ee3271e6f557f67a6ca9047b2",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm",
+        "checksum": "sha256:aeabc2a929fa364677839c3d56b2230f7694668b9a6118303931f980e3d21d0d",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "14.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cpio-2.13-14.fc38.aarch64.rpm",
+        "checksum": "sha256:617eaa72b28f2322aa02236940715fb31864e3d3561141079e1e3287331829fd",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:c9b11470655ca9328c00a8d2078447af1caf0248699464f6f61b82ecfc41ba83",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:43a5fc865a2eacfd9724afc3706be78e72814d1f7fa92011186a3dc5be53bcf7",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cryptsetup-libs-2.6.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:c289dca4b7d4b7ff09bfc3973c23fa27828a0d17e280e6dffeb119f642bec3b0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.aarch64.rpm",
+        "checksum": "sha256:c3849a6d8de295750088598fbe7246d7dc8fe857e267e48edb3deedb12d8edb0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f8ca1130421307e95e823137e4ca04ac6e402557523da78e4e4fb157438c019e",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm",
+        "checksum": "sha256:4bbe96417ee7bc5758c77fb8cb6a762a566248b5af199310f65cd0a7f7c2e7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/device-mapper-1.02.189-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b8fb3c7d0c16b39ca3b472e991238bcdfcdf7029da030aa90d248f5a303b8734",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/device-mapper-libs-1.02.189-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a3dc9503625f8ccec829de7804e4a852bf6e31210c3afb0a9d4d96f83287130b",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/diffutils-3.9-1.fc38.aarch64.rpm",
+        "checksum": "sha256:af65e2f6e568e916d46f404f522e014d8fd57a7c9c9acd9cafc60fcf88b7c065",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm",
+        "checksum": "sha256:4a2eeb191bed31eb0dd350c48c13708fb823d17bd126cea6bf9a52d07e1c319a",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/d/duktape-2.7.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:1f9bb83854722b3eda07903f0680c00659ce88b6714f9e581b41ab705355d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/e2fsprogs-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:3c5bb03e965a4e7205720bdc351896afaa78f7d18858525b15ea2ea8d83cef17",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:482550236810538bae9b7a7dbffee8c756c0def8e3b34db40659d37bd2af8fad",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm",
+        "checksum": "sha256:281ce5635ad029dd4df1998a84dd5d0cdb797b603b703ece5022c125fab147ed",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm",
+        "checksum": "sha256:f0de12f38bf863088edd60073b59c6d1a831a2cfd604574c658f8eb290ebb51d",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2e2cafda8609942719699ae99772a096a621c64f2ca13ea1c9163ea6fd9d05e6",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fedora-gpg-keys-38-1.noarch.rpm",
+        "checksum": "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fedora-repos-38-1.noarch.rpm",
+        "checksum": "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/file-5.44-3.fc38.aarch64.rpm",
+        "checksum": "sha256:3515d98cb1757a4d2299566cc26e4f90fbf8dd5afe384a10253c49a755f692bf",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/file-libs-5.44-3.fc38.aarch64.rpm",
+        "checksum": "sha256:94431a8578a0f0342392090d284b912f14a45efe887c954415ac22e8e15643d7",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/filesystem-3.18-3.fc38.aarch64.rpm",
+        "checksum": "sha256:5e2d82acbad79031da034857c01221983ed5184e3d49c31a435c1fd30e79cb62",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/findutils-4.9.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c66f06e10707d03b491fb130bfe501fb5a3ef9eeffcc23c1a4bdfeae9f8ea452",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:0274e746ea0ada3f51696f26abffeaaece46f725595610af1c930e24466fb40a",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:98dd2f179b6d4ba7665a051f64f8a1947ef59def5818f297dc265c2deef6b2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gawk-5.1.1-5.fc38.aarch64.rpm",
+        "checksum": "sha256:0c03fdf1f9a8ce61bb49145ef39e10aab2fe5b93d2a6113dc3c845b000ece6ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.aarch64.rpm",
+        "checksum": "sha256:02dfb1bcb5194bee30f27c513e17e1740553c5c3e2fe08c92fbca5f92cebe604",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm",
+        "checksum": "sha256:9266ea9453cac0230fd04de6df6c86956a96d35d32b893009ec351681b763507",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-envsubst-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:e06a7695a2b6fb118d0d4668a8a0454f96cf105d29c9309a91fbbfba606aeff0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-libs-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:bddc649cdf571d3329fae93d0f0f53d12aba317970ae63f3852aa9693f9ff281",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gettext-runtime-0.21.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:9c421c6dd086ac1d3be1a099b1f38870c2ff5bb35d2bf2407a2d5e96e9723452",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:8d90ad8a8f8844e1b3dc2cb9b20103bcc96b5f99c0d3f8d5edc71ff21984dcc4",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnupg2-2.4.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:073c216d2699a73912ff0f2db4d3fb83eaba8bbbbafa7b650875439814cd6c36",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnupg2-smime-2.4.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:6f4c6ebdfa1498e338dce5a1c3862434a0e06296118870c182d9212cb9438095",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gnutls-3.8.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:22af041002b0e8e6f3f69b851bb42476a695dbd893990270ede8498c7bcbbf35",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gpgme-1.17.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c8f4e6c4dae9fb0a880c3f0fb8952f83623416000a92a47879a11e6900cfddf6",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/grep-3.8-3.fc38.aarch64.rpm",
+        "checksum": "sha256:822730809e15c6a117f5c3729ff63549c3712841b4e9d45747c1d45e15323e85",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "69.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/grubby-8.40-69.fc38.aarch64.rpm",
+        "checksum": "sha256:8074eec4ad7794687deee6f9e217b713e6691485de3678ee8629aac04cc6bf9d",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/g/gzip-1.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:10a540bedd42485014afa023ab613b1189bc8d56af5c84b1f470a01010ae8b43",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/j/json-c-0.16-4.fc38.aarch64.rpm",
+        "checksum": "sha256:0bfc873da712dbcf4fffa525879f8a97e016823e4c8aa9567d4a5dec32b7b084",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm",
+        "checksum": "sha256:c31b5312684e830c6f7ebc634af507530135eefb1d171bc7cc5716f8cd35c675",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-2.5.1-5.fc38.aarch64.rpm",
+        "checksum": "sha256:dcfd7dd56e3996efa7398fe2d1f35dfbb7b7520e208e42d2e7a5714e096d072b",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-legacy-2.5.1-5.fc38.noarch.rpm",
+        "checksum": "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kbd-misc-2.5.1-5.fc38.noarch.rpm",
+        "checksum": "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:12eb5906dfd74ad0f439bbce4d213c22a1db84e47dbb9a8e7090d116263a5666",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kmod-30-4.fc38.aarch64.rpm",
+        "checksum": "sha256:de733c7a0ffdefb415a76aa2c10cedbe57ca803b41d698d72dca0ac99cd71e58",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kmod-libs-30-4.fc38.aarch64.rpm",
+        "checksum": "sha256:d4e123a5a7f7a7ae0664739d890973bc9710638932ee40c94c42be274248590e",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/kpartx-0.9.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:39c59ca6abbb12344a0c1933d853b2f11ad665f5db1755daea244b3ba8b59e52",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/k/krb5-libs-1.20.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:ac6fe64efa5c7e3c778478c8f15aecae6bdf55aec462f27deff0c8a9b248e2f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libacl-2.3.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:a75a6040a6bfdcfea5da3bdce6b91c4dca9a5063fda2c0f611136615a561d9ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libarchive-3.6.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:bdf57fa262d0995a92f61df4a2aec626c0aa663d41d669b096972c7068ecc288",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm",
+        "checksum": "sha256:00f09471d69891113ac7983763aaf5e3ecfc7580ebc471688cc1a883aeebb29b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm",
+        "checksum": "sha256:ea57c01703b1314a229e21a29326d45e3cb8bc935620446c25525a9047dfcdc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libattr-2.5.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:22c1fda0f37b8669101ebe719e81d4770b3a039fd96c6f6f8d93da4723eec6bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:021c4d31d33b21f3ccee1ae50681a8e3d47e129120ac2fe270b8ec6ef680c3d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libblkid-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:bd5238f372454393bbb3f551de0b3e4fb7ad77af75b9b6301d1835460920e999",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm",
+        "checksum": "sha256:b7db3f51e407e88506946ef763d96cdde22aec1b42421875e683e557293cd32e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcap-2.48-6.fc38.aarch64.rpm",
+        "checksum": "sha256:9a1e4b6798d57d0883d7bdc92e9d92211ddc9628d36d79630cf3253eff728761",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm",
+        "checksum": "sha256:d515d72a040ed6288cf2dbb791e2174af5c61ade83d1484b40d28756de34d4a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcbor-0.7.0-9.fc38.aarch64.rpm",
+        "checksum": "sha256:1a4f7ad6f54c6ac9575b33d2865ef63ee45da11b9df825d2c672adee3a7e9021",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libcom_err-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:8eb97429bf8fcb473e948af4d2608ec373fe48481ef488f0341683aa1c7e50e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm",
+        "checksum": "sha256:0bf1e1726e0250d714560f1ec3977287c917c419d819b0e72756edef91d401b3",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:a4abc25c2d9e982759a9f4a4c9a83b6a5add367ed9b0f45d195dbbbcf254190a",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm",
+        "checksum": "sha256:547908864163efaee3c29c3584203ee4cc0b7099b24fa19064ddea7685ce698b",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libfdisk-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:992c4a4ef6d7048e6974b03ac9ea149b4370ed04db11f6f24a0473a295773f9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b56ab0e709dd96dcd3e4e328e3b2b6b15f33a2b4812f25364ee435d30319092b",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libfido2-1.12.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:b4aeb7d54152d48f4716fab3d176327720bbbc6fd325badb98ebbe97caecb803",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:d81b296bb0df280445b341fc767e813eed64844a83c1680a67554dfb7a6ff39e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:4293a87defccfc402360385c02625a9dd6607bc00db99e8000476f43cefd37b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:c0047142c2c2bb0a2cc868b9b44b6e819a5a55d8946387ac0471567a0504acf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm",
+        "checksum": "sha256:4e2b9788379e4fd5f36f141ded6425b363b6e3efc8b6bc23691785f0a4751f74",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libmount-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:75dd39b0589830a3a06032780f04459666fbb22d3dce9b4689969b0bf1f132ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.52.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libnghttp2-1.52.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ef6fe390d0b1ef456012ae6139f9d386e76ed4990716c23b8bd1f6769201bd58",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:31c109dbedb61d8a7610de000f58ce0942e1e534266ecc97edaf91fea82c4e93",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:3910521a4101f8fa34ad243f26c05c8fa1ddb4df278a05ac2e186bce6370f1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f10853c75085541d1056eda7ec188c321532f35e0b89d0561c391cea269a8204",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:679d2fc2911dc01f001d6d13e5013f22bdff7a9eefdf55b675d6e22504b937c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm",
+        "checksum": "sha256:d310dfed42a1db630e22b74b399a71c2247e58f06dec4d1df192e74b56e791f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:bb7c4ee5f37e5ee847725d9aaf78bf97710f463d18dd6c47b0473edf8d16934f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libselinux-3.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:c0f80e9d906d21d5105787f3e362eef7519604a4decb96c23ecdc5088d574505",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libselinux-utils-3.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a3f53150e220a12421f1fb295d3ece42aa2e174887cd4aa3dd4bf4d763a41b2b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsemanage-3.5-2.fc38.aarch64.rpm",
+        "checksum": "sha256:4bc57215b45668477d659123507242a0cd257e5b1d13941ac80ceb8496b28142",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsepol-3.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:cc3b829418261e018d6bb15fb3e84fca8d1f232ef53ad4c37b4939a07a3a84ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm",
+        "checksum": "sha256:a3523f40ba01e060cd9aa2c3a7c0a21693696298f8e9ebbc4e9b689d6851f950",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsmartcols-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:855dd0c7aa5d1762fdf4294d813a47e098fb281e58b57b7bccd9e3f5f18eb1c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libsolv-0.7.22-4.fc38.aarch64.rpm",
+        "checksum": "sha256:daca9346f66c9cf88b649178972c15ee236207b97681c54a2246713632e1bc11",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libss-1.46.5-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5aa4601eb358b162dffa5b6d126e019f1fa67a1f2d36b294f4524ea89a2016cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:ad5edd39f36abaaeeb42c5b9304d8157045bd27aeaac24ff29fedb82c2ebccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:08d0a1411840b3ca222095c9d2dd39b9cbad643e997defafa9b05211f365e24c",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1e26ec1ec298590c5e6b56db325e68bf170e6ac2ac5ac8fdf08bedf5283b07a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm",
+        "checksum": "sha256:f6753e8f94517a3224ef5b955d45144ff354f6fddb1737870d1b151fe30ec925",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libutempter-1.2.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:128a5de6769cb229683bca33106341aced54b97dc5806bb5d571c37384988924",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libuuid-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:c48b62ce7ccb65c82097b687d4eb68c5765baf24504976ddfb67cc332073d8db",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm",
+        "checksum": "sha256:33bc878679d75791447ce16f5d00a33fc6a207eae2bf83d38203732b808e6a54",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libxcrypt-4.4.33-7.fc38.aarch64.rpm",
+        "checksum": "sha256:da059b7cadabe81a378c08a929fc391354e01e96b5b4d951e6627096b0a60671",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:71b87827b2375cd91a39e5d534e3682eaca33756b9ff00cf86b9fcdc2fc0a26b",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm",
+        "checksum": "sha256:ff2f6fed64555c4e83e5433d6845ece042cc1ee113e96ff94148baa1f4c820bd",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/lua-libs-5.4.4-9.fc38.aarch64.rpm",
+        "checksum": "sha256:26c04558f99ff8754be611a90a35570fab09d06514464c569272b3601bc55b4d",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/l/lz4-libs-1.9.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:aefcc29050240901824da737ea2ddcf0cc171d4654338c916578bfdfec148207",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:02c4d78eb71234579a540d0627c3606fa63e3ee8d49463063b9480370c1c4030",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm",
+        "checksum": "sha256:6eed553d444dd0eb0a1a3cb4fc504874fab9a979a5ef941d29c8c61c91cafbf9",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:831b1874f0d5aa14267d32a38da4d866bb04d43d692403ecb155218e9846d12d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ab5bf07996f81efd15640f421a14bbe25e25f04f14347c5f37d70c84f298ba4c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm",
+        "checksum": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/ncurses-libs-6.4-3.20230114.fc38.aarch64.rpm",
+        "checksum": "sha256:1afa90119a69b82ad57fab9e6851731cefa502338f717d89fec76aae964d3b5b",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/nettle-3.8-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d29f6773d1b36fd44e670d561c7dbf96039029fed355c144eef50e022047655b",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/n/npth-1.6-12.fc38.aarch64.rpm",
+        "checksum": "sha256:3acb1eed119d43ed430c233816fb9d2d53b190376dc682face5193e0c6828c47",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openldap-2.6.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:51aebc456415ed90d74d36c76782523e0eec59a30be6b98f7f17fb5ca2b99f29",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openssl-libs-3.0.8-2.fc38.aarch64.rpm",
+        "checksum": "sha256:4d80b199b45bd2b852098348cc89cc48afd31c4450fd0e2972e202f42f813547",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:0a38cda530b79c2861fc2a3a9739db5fb63209be65b1a7b22ad35f6d354ba4ce",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm",
+        "checksum": "sha256:3275be80093f05657e49df1a80a60005e433d76c7a35be9f1934f9ee83de178d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d2071c518e33f57812786511e1bf83095881ab5b6d2a527f8f3b379d847f4556",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:3f6bc8e3c61c85080715058c008f72bf155213495c41e0c553d8a375020be108",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pam-1.5.2-16.fc38.aarch64.rpm",
+        "checksum": "sha256:55474a91a1cc3dfe11f030309bdba48d042800d5a4ee37f0ca169b1ef6fcbc10",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pam-libs-1.5.2-16.fc38.aarch64.rpm",
+        "checksum": "sha256:06e7bf833445e81b5fb0a3e768b8b628ce18c3432bf0c3abc3298c0a3e05affc",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm",
+        "checksum": "sha256:791336f5d0ad956b83bfa52d8acb2f27e47ce91aa3b0574daf6bce5a20fa81e9",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d45ee3d12d376b288196c952d68e4e4d74d156a4fb0c3542438a56b35d701d39",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a14a5c269f0fcd145837e945b97ded6e14d05917eb5b3678f47524d1fdf06ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fb5f1a3d96ef70ed49d52f76f9a03ea480ceb4e18f4528c71176f11adc280a53",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pigz-2.7-3.fc38.aarch64.rpm",
+        "checksum": "sha256:5cf5dfb205d86080627e39b7c355af3f31b5503bfdf7a3c67af417836b6b17cf",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2f0902a9eb84cb0a2c312932145fa12dc9736cb232870a79ee61f3fc5ec89f6f",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/policycoreutils-3.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:978fc89869fce9ba0d7298776da75c64c4fbe207e8473ba23c216fde4ea9d128",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm",
+        "checksum": "sha256:f09c95b8ea14475abc705f3ec58c2bac9cc12627b1eb2bde8df0bf9922e5f011",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/popt-1.19-2.fc38.aarch64.rpm",
+        "checksum": "sha256:6a2422b58950e753123232fc22b33cd9c3ef50bb054cc457d275d33aa8f5fe88",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm",
+        "checksum": "sha256:3b9250302db0ca1ae1544766f751919b7e9ef08f7fc14c224e035334d7d18253",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/publicsuffix-list-dafsa-20230318-1.fc38.noarch.rpm",
+        "checksum": "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.3.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.5.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:41122a51c47efb38e63e992a6997a99dc14739df4081d3ce581cb6166e7ca0fd",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/r/readline-8.2-3.fc38.aarch64.rpm",
+        "checksum": "sha256:5d94cb7b257e67e63e1ac1646a3388df3d8687aa7589141e9d88575dbc6ad87c",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/sed-4.8-12.fc38.aarch64.rpm",
+        "checksum": "sha256:622a80c09665eccc5c8ff7d397b76fae41a074ac7a5bcd55f0f12f2b0a8401f6",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/setup-2.14.3-2.fc38.noarch.rpm",
+        "checksum": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/shadow-utils-4.13-6.fc38.aarch64.rpm",
+        "checksum": "sha256:cb45d1114ed97e2e375607df27bbca890eefaa43c8d0887ea861de12c24739ea",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/s/sqlite-libs-3.40.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:3094eda7a013a532d6651ef0efaa66162f52baaf60fc0dd5cdeea0f957ba8ee4",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c80f68f0b194af9be448d69cffbe4b4dc387e8be803f28368aa1b24192a5dcaf",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/t/tzdata-2023c-1.fc38.noarch.rpm",
+        "checksum": "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/u/util-linux-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:d035427c1831cd1f3a87cea493d693e231193d597ae4fd5da9dbfe54745c79a2",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/u/util-linux-core-2.38.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5b58fccbaffa23cbd78a393ac2f0d51bd9d15d43c8433501195499e6526e2db1",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/w/which-2.21-39.fc38.aarch64.rpm",
+        "checksum": "sha256:dcc0aacff8ded1d0cfcc997dcefe2b954527242996368ecd753c97878164ec91",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xz-5.4.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e041dc0000070f0954178eb808cfd6be2daa5ef0cc4656fbd2b68eaf3b3318bd",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/x/xz-libs-5.4.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:d7308dd3715530ebc6f3a8b86939936056815e6929ee0a7abca1d07bcab9e73f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-fedora-20230413/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ab05c8b70d12d454fb87e9282e689c222e7f1e2b4e69ae6bdd8b8d3324ba6b77",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8946cab1baa41f4818935b151292647d9a96942acb3de1126335cdfb8c42170f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:40261aa7487e1c7f0b8a529e7e2d2efdb79bb8b22fb684cdff92b52e85e6947c",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc38.noarch.rpm",
+        "checksum": "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "89.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/containers-common-1-89.fc38.noarch.rpm",
+        "checksum": "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/coreutils-9.1-12.fc38.aarch64.rpm",
+        "checksum": "sha256:86c6766a94b65c0a251c346de4cc1501cdbe827e01dd0be5c9ebf726271cf684",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/coreutils-common-9.1-12.fc38.aarch64.rpm",
+        "checksum": "sha256:09f1937630234f9c42b969a9f81791a7e6f0f2972c4ec392c8e383054acaa69b",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "8.0.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/c/curl-8.0.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8c08cbed9d20cd2a49bbead543ac83358298f895c6ca7f5a51309b4943e8403d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/d/dracut-059-3.fc38.aarch64.rpm",
+        "checksum": "sha256:4a1f6fca9921d7e90113208c3fb379604eee9d9794467e2f652c74ceb9c3a980",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/d/dracut-config-generic-059-3.fc38.aarch64.rpm",
+        "checksum": "sha256:233abea1b68904e73177df5a7bff96d8d0238053e6061225e4df05d5f8f205d5",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc38.aarch64.rpm",
+        "checksum": "sha256:c7fd4ae63cc37207d3a4bcb6b7ec58e8d07cb67b55fb6a85f0aa7ebbbe92e861",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc38.noarch.rpm",
+        "checksum": "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b4e7be00dc6494d236494f1fe6bf8961781f82939422322d80bcb74ef14a5ad0",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc38.aarch64.rpm",
+        "checksum": "sha256:bbbf6a8e693bc019dc0dd5c40da8c4c6c5523cb160e840c52bc7e4f541e1bb87",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-38-36.noarch.rpm",
+        "checksum": "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-common-38-36.noarch.rpm",
+        "checksum": "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fedora-release-identity-basic-38-36.noarch.rpm",
+        "checksum": "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse-common-3.14.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:1d8b1d1ab3effd4bc07accb16dcabe0538a7f8c2daeabf8bfe9f18208a32b8a0",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e05908892b57924e187e9e457b8d2b5a8226883403ed6e6559fa131b4541af07",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse3-3.14.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:a54f778abf552a8421d764495a6ce189bda7a8c51665da04b420bc89a6ab541b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/f/fuse3-libs-3.14.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:13b3f5fbda0609542288be20e45f4b8711d6d5939135e0879205c13163af08f2",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.76.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glib2-2.76.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e71bec04105d4a92bbecabc588ddadf8193df6fa9a982a83d60838a2e7460d03",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-2.37-4.fc38.aarch64.rpm",
+        "checksum": "sha256:78b890d9e481435aa36684c8a041384ca7dcbe7e9da75e3d9d08903f6aca2d20",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-common-2.37-4.fc38.aarch64.rpm",
+        "checksum": "sha256:4a45da92d5b0fb12397ddb256777003c763a6d9e9951b571dc3d1fbb48a70288",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.37-4.fc38.aarch64.rpm",
+        "checksum": "sha256:3ba6cb03a91d937283f6c083ce9de087b816c3f091baeab1d2e762ca6353a74b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.37-4.fc38.aarch64.rpm",
+        "checksum": "sha256:dcd7fa64243f3038d8e638bf23d0ce02e95a0f844220ab2d12d65495e522740f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-common-2.06-95.fc38.noarch.rpm",
+        "checksum": "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-efi-aa64-2.06-95.fc38.aarch64.rpm",
+        "checksum": "sha256:a1f0ee8dbaa9b71dfb26d11856744ef74376ff90c476b9cec89b9c93c8fe2059",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-tools-2.06-95.fc38.aarch64.rpm",
+        "checksum": "sha256:622fd85b30c27fa16d056acd9c25a9b65a34791601e96390cecf25e19e0a317d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc38.aarch64.rpm",
+        "checksum": "sha256:74d642136ebb3ea38de7dfe8f7b74f03467b72135ae8af8ff58b6a45dfef9046",
+        "check_gpg": true
+      },
+      {
+        "name": "libatomic",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libatomic-13.1.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:f78f1e088792b93081bd6a2b9575e3ae9306ff1c12696f21d77eb47f9f8cc0f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "8.0.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libcurl-8.0.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5341c12b3f09067d29901363dab407ed8bab66167befa89bdef255bd8b82d8a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgcc-13.1.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:d796836566b74c929e97126fd90a348bab6ef931a64aac2ceb2812b1fc82311e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgcrypt-1.10.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3481c41cb8d785ac8ced947802a7bc543b3a409e5257020380263301f3a0296a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgomp-13.1.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:5331eab8bace52c93fe3758f7e6cb343461073c20d16c94d642cdd201e647b21",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libgpg-error-1.47-1.fc38.aarch64.rpm",
+        "checksum": "sha256:3df21bcafa4efa4183efa60ae50d4ffe4a52e67868ab2375df2b274aa4d3e5c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2dcc2a3b5f06dd6a2abc1f945113b6277b4ebb9eddfc505dc5c02e16c0180eb6",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:56d32b932a3fb88fe551d4ec69f017d561d003a429b5ba63e03ae1567459f154",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc38.noarch.rpm",
+        "checksum": "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libstdc++-13.1.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:cfb6f3ee7a456e97bc807ff6b06a49a018ce28f94cf85e126cc1a794acbb4ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc38.aarch64.rpm",
+        "checksum": "sha256:5010c732079d3fdca7c81569386643773157c0b1da936eaa37bd292d7cdef7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:b001adb81776dfa1c755aa566466cca29d33c7608a1c410f63de5f3ffaacdaf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ec00f8c51ee6b1eb5434d1a5812a933a12989a53aebacc1a7d3c60258c8bd8d9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc38.aarch64.rpm",
+        "checksum": "sha256:7b28da4db47c11a4757e5f26ff5d3ee72298126e077580a3540e3cc94d5543a5",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/o/ostree-2023.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:2e4c3823de7003d3240ca75802a111fa4a17fbc09c710a33a3b9990fa815b017",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/o/ostree-libs-2023.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5985b3157536a8d2b42ac0b75027603ddbeddc20d3137e6e1638c7319bf8669a",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/polkit-122-3.fc38.1.aarch64.rpm",
+        "checksum": "sha256:626d715912b0dd188fcd105c4ed1b63d6d3c8de87f955f95138eb03b589a96a4",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/polkit-libs-122-3.fc38.1.aarch64.rpm",
+        "checksum": "sha256:8fa18a2010fb71a7ac93c11757fa484c3bacb4cfec575bb03ea965169dafc64e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc38.noarch.rpm",
+        "checksum": "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc38.aarch64.rpm",
+        "checksum": "sha256:f89d0b33f9d1de26706e014bf5c6564099af9df35a493b0220d3500800fe73d2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc38.aarch64.rpm",
+        "checksum": "sha256:45935cafe28c0238d0c8f17f547032a3401b4009465ee751994f9c88ef659469",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-4.18.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d8a06fcbf4164a2cfb5c9e212eb5c895f5fcdf3a72b862f70f01a85340a93b4b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:61e2f6d7365e54d6eb1a9a9ad3f0660e41005c42d4a0679a206dcbaab88f9d2c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:ff9544d1a2170e48bdc7ff941cc70c3321aaf2f6b2e2922444d4fb4811dc6a94",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:345d91cc09459265a9d90c5b6ab527b7614122529ccaafcd0b09f62dcc8643eb",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:13ffb19e7a8899022cc6c3b7a8b8d757dbb379a744f470385f81bde9fb04883d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f013ff26865de9ee898cb247f2ca6512f3ac0c65ad124b9e09322989494da6ca",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.15",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/selinux-policy-38.15-1.fc38.noarch.rpm",
+        "checksum": "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.15",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/selinux-policy-targeted-38.15-1.fc38.noarch.rpm",
+        "checksum": "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:12bcbf92f0264dfa83fb5ac63cae5d0c312a26df05e4ecc2e69d94a86072a8dc",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:cacc4a03ba6f6d19f4944834c74ad3eac09642d1323bba14f01e313d26f71cf7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-libs-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:db529f9292f84096bec3ade8fa0b7669ba16da2b5b55d65590e768aabf506cfa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-networkd-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:da868912dec8c24eb697f4c2aeeb6eb884c23279b89948ef241c3c67e11e34a2",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-pam-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0cd60382cbbcefc2b991949c32a76a52750df1728224914d3a8dd67440f809c8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-resolved-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ade1f69a89cedf340edfaee70b8b8e4d19d291dd0a95dca4ee8fd8b3f4361c0d",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/s/systemd-udev-253.4-1.fc38.aarch64.rpm",
+        "checksum": "sha256:fc062d2cf09a2338039b339c22fcab84f09fe8aa248ac623afdfacea363b18c9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/t/tpm2-tools-5.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:6b33122476fcc97589761d93a1054dea77c886b0e27164e78e47c86544cdf645",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc38.noarch.rpm",
+        "checksum": "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bae80ceb03683e5480064137c192e4b4fcba1d744b0940ae990511bbdb65e3f9",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_38-x86_64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_ami-boot.json
@@ -1,0 +1,5233 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "x86_64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-modular-20230413/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:196b3612e50069c68d67ffaf3081d25923e2b4ca7e1bad8f124515b3fa472d4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83bb8576a018ae028ff1434c32e1f3dfab66a781e1af9057862a2d7f3d725f58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940192d99005896a29de3c682259b3505652778d58ec74a003639f3ba3193a1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd41c94b8c668602f7fb5eae595e5d5c34bd1b91690b5cc06f4c8c199794dfa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6170bb84006ad1d74202125a21308b15be0b36ec95e9dbb6552aa35026e966ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a3a4007d921c6a9b372e4573520866b445c18476f907b023ea19b436436ec33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:790c6d821ff575ad51242ec6832ed61c8a3c4e0ece245c3dee3292d19acb23b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78a15621e7e3dfb5a65b8b8aa482cf5b07f08bcef217ad29435e299d6c8aec74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b6b7ad33391919a3315e398d737a764121e2fc9581f75318a999e02bfc0c7c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15ec70665f200a5423589539c3253677eb3c15d7d620fd9bdfe2d1e429735198",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13509309959035c338299a33985d56f10896466367e1f62d4fea98123e74bfc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6deb22c3ea0b8f291140f1dc74ef885f5dba97f9bda32257ef48e1790f7dcb4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440fc5c6e6a37c47f13d1fb53a03f5cb0155592a5bcf9312e2d083d4bed0ad40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8be96e09e2e44491b287be44b2b6be0c9f8aeab75fe061d3e8a28b9be19144ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c8b143f3cb83efa5a31c85bea1da3164ca2dde5e2d75d25115f3e21ef98b4e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96a7e71271d334497b5f108f8aaadb4210e488948947b108375eb8636e7118f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49e693f6812e04450b0c98a108f302a799f5ee21f8000675f59d47e097ad24c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea77373517525f6e976fe9c062274b176e86eb378ed82e72a76854c741b2c25e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e873cefdeee846f6d1d7e8f00c60bd1714cb2b9d26572d9bf43ea0ce15fd0d75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9c6ada24ecb197e6902b6c9454867973a68ec5a531df651729a811924ed8e5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a19f14b4776a70fed369c279df99fe65a73b9928c23cc443c51e5353fc549080",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cff3e219caab04a0cacd2b9139ec5bdee8b6d7d95d63276477e5a882b649c89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c873b53bb08ddd23c149bccdb4e366faa92bac10bd15699d9c57b22d499e272",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98427b7229a862d099d43f798547ae713f041698c1b274481bf2377afef8fafd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5bc7ddd4b7dcd305f96bf0c160e78d181629405d97f3c7505c815767b51862",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5ae6a7d99826a17d163d9846c2705442b5792a7ccacc5169e4986cdf4b6bae2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e9e8b6447c2650a306e8d107dbdcdaa4f81d4175012eea0c87846faecd64c70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55ca555fe815bd360b08500889b652f50fe4c56dfafbed0cc459f2362641f1a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54340fec047cc359a6a164a1ce88d0d7ffcd8f7d6334b50dc5b3d234e3a19ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05571a68f7dabff1ba50c42145f51ed4011c70d77ea9b4879f6759ffe837e215",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d17f327a83ccb5ec42f412c78ae6aaf787bd46f10645b65af43f6f5ae9d8c15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82f7c74c4f31dad16dec9fc52556f76051979b8dea69877b71aa0ac3060c25d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a37d38ffe36c63ab5ef58c41101cb7b2b17b3d8c954fc5e25b25a1cc82c9d7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3418df9795e4d82bbdd906c94dc4a86bb67e92760875eda33d21dd0379c66fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b41f1f364f53aa4b8cfb7cc45171cd9afc734b1988f941efc701ac683ff05a11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:405e237a7852b763a3a7ebde766103a007975a9bd8f8443f721e384a237344db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54f80d720b6656ae12c37ff54143da540f464822ec86c8fed5f0122e5834dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c30f707e681358ab19bd95cbe65477ba47743609ea0fd5939d024bb225116db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3e7c19626666ff545cd74c0cd854696005f3d7d0b4eb1d1c1ac60404188d981",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef4b2686134e6be036755ee093aad43eb0ce4a4c84c93a2defb755cfeb398754",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b72fe2b2c48226ef90c88920d64a734df584c68d04d10b48bc8a67471a8a627",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b98bdd00b44fbf808df1d653ecf0f0ed8549643d52b68da2455c5a878f0021",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5edeec0be1144c7eea7040a8232b08add6b1b319a0ec2cf3d13f7e1c2da2cfd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a383d65f22be848a24bc8e328d136260f15dd8b0401da273bb27e18228bada4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17b1caf2274070cab464dbbe8aa307678df13937f2f315af4bc2eaeffd5915c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13941f4a922a76da599fb0e00884e530d9ed8ce5145fb5a54f7337a6af5085e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13f2ec62e10333000a13123a4cae5ebbda270c32ece03247e45bd2b244e7bba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9a98372505c9c1dff7dfea558b20a44820fda416a609467790577a848de110",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b74224b3f6669c1e2c17c371a411d350e120c1ba2080ff2009e1b47b3c2563",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71f6397b0c264dab7a94f0461251593b5fae068b154299f949dacfe8d6bed7cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eccf03e76c219c2bc0a6cec352e5c0be12041ffbb5e2be736f19bedfbd8ed077",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:716096df1b34d768c3e6a5985de8e1ee58b2183ad9f987aa754e592bd2793c70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56705b6a1526960d534b0d3e4247deb4eef2b5fa64ceb03544281b8e9bdc4597",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f6acd253d7c2dd0df445d321ac9df3a2870781cfac6837ba424a7aa0f24b469",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2656094a2199cb34ffd66c00051e93a15b742bc618bf02b1f5886ea3560e8a6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd827a4f95db14a707bc604efac1db86973eaa97bd8bf9f78c37a925c09a297",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10196a125eccfe91f3eb187be4e07d7a7d9304f738c3feed087b6f8c4375f305",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebbd35c8b39a71ffd82bfcdd6a908c024fed56d27ecfa26ed6b8d1aa0ba4170a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbc243a16c7775d825b8729a4b6627a50fca4297bc624aace55f9ec07453993d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edc3846d881c4ad341c5e97f7a2b7ec8f5164c26e73839449374b3c6fc2483fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae40c78ba1b3d44bda453048fa602bb2cbfef08f5873e3cc268490d5a68d24b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:161f1eaec1112bc47a11c3cb77542ad50108160ec8944618d88ae88e1f33e15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:221f9fb2407208c40962ff030de372e3b74e69471e558b858ca51f0a196cd3c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7eb37e1dc5d15eb05dfc2481ed9de694d64459296d3005b8415fa741af0d5f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a0d1472b2d48964b4ecdeda9bee15b6fd66f9b321c74d0b4acfe85cdfb2bb6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c7442e6c8761f473c675ebfd2b3c9f6ec2c5adbf32f5e029d512da6190a499c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e122069483cb322a66d0c05b405b5e37784bee86135418c356dccf49618ee1df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebd8002b78f3495135813c05ba753c2214cdfa7a9c18411a1438f6fe49e7b925",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cc364cad8cb613a0ec68076f7f8e10b72ef2e266a10d2463bf548b2b0abd13e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dca922285b9f680f084fef9c5b48096574313a0f7ae41ef8251e018c5df8dbda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGIC2cYBEADJye1aE0AR17qwj6wsHWlCQlcihmqkL8s4gbOk1IevBbH4iXJx\nlu6bN+NhTcCCX6eHmaL5Pwb/bpkMmLR+/r1D2cLDK24YzvN6kJnwRQUTf2dbqYmg\nmNBgIMm+kAabBZPwUHUzyQ9CT/WJpYr1OYu8JIkdxF35nrPewnnOUUqxqbi8fXRQ\ngskSLF8UveiOjFIqmWwlPwT1UtnevAaF80UGQlkwFvqjjh4b9vKY2gHMAQwt+wg5\nHFFCSwSrnd88ZoDb3pKvDMeurYUiPzF5f2r+ziVkMuaSNckvp58uge7HvyqQPAdJ\nZRswCCxhUAo9VqkNfB4Ud25ASyalk9jOE3HB8E35gFfPXvuX1n15THXNcwMEiybk\nOmne2YwXL8ShGNr5otjqywThMrrqcl2g/pJVTcpDHTR5Hn9YRp+GHlYLjyEr+/x7\nxM19y9ca9GUiJqDbEREHcKKIhYiGmcIjjcJvei/3C/aM4pqeGFJBbVSnw3qeMxH/\n6ArAMA1sAdShCkv2YjlcF0r4uoCjXdS3xrKLz9PSCquot7RySnOE9TZ7flfJll7Z\nq+lNaSeJg7FK8VWSUb9Lit6VEYVbzWKzespDDbujrHbFpydyq8gXurk7bSR2w0te\ngsmytQqT/w1z2bydgGF6SfY9Px0wuA8GQKr48l5Bhdc6+vHHFqPKzz0PVQARAQAB\ntDFGZWRvcmEgKDM4KSA8ZmVkb3JhLTM4LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEalG7q7o9VGe2FxIhgJqNfOsQtGQFAmIC2cYCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQgJqNfOsQtGScyw/7BLmD4Fwi4QZY94zl\nvlJdNufZRavOemSIVVDHoCr8pQBAdrvoMypxJd5zM4ODIqFsjdYpFti+Tkeq4/4U\n25UoLPEOtU8UDt2uq7LqfdCxspaj7VyXAJIkpf7wEvLS4Jzo+YaMIlsd0dCrMXTM\nvhu4gKpBFW6C+gGlmuDyTJbyrf7ilytgVzVtIfRrT7XffylviIlZHwKm43UDjvzX\nYEl3EAFR1RjATwXMy2aJh7GCNsz+fKs+7YRKQUhpMF5un/2pyNJO+LbVGGwGZvga\nK9Kfsg/4r1ync4nDDD1dadKIHhobDeiJ9uZLoBvvVDz7Ywu7q/vv4zIPxstYBNq4\n6fLKDtYXuJCK0EV9Qy4ox67t0UGlaRGH8y5YUqOI10xH7iQej0xWlSc8w2dKhPz8\nz9XLv2OMK+PvqvflhFHhWkqEoQRqTu0TVD0fLLe4lqieJlqZcJqW0F9G/vNSSWmf\nPOLa/Nim71gL2fPjCJOIRV4K/cJSyBmu5NchG7dHD5sUtJxZ4TFSuepaBZ8cPK1x\ne26TaCBqoUWgUXWmw+P89aOpYOJYEFfT/VAm2Ywn+c1EFUmD+30wQ7aP/RUFl94z\nn0BjqsWDnCKVFHydZ0TZSpeADmXMg2VYZPcp/cQR1KjoBoDxAscis7b1XPQUg7CB\nzquq5jBVAnsNIhs7g47GWKyDUJM=\n=aCLl\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 17846239,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/t/tzdata-2023c-1.fc38.noarch.rpm"
+          },
+          "sha256:05571a68f7dabff1ba50c42145f51ed4011c70d77ea9b4879f6759ffe837e215": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glib2-2.76.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pam-1.5.2-16.fc38.x86_64.rpm"
+          },
+          "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm"
+          },
+          "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cryptsetup-libs-2.6.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libfido2-1.12.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libarchive-3.6.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:10196a125eccfe91f3eb187be4e07d7a7d9304f738c3feed087b6f8c4375f305": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:13509309959035c338299a33985d56f10896466367e1f62d4fea98123e74bfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openldap-2.6.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:13f2ec62e10333000a13123a4cae5ebbda270c32ece03247e45bd2b244e7bba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:15ec70665f200a5423589539c3253677eb3c15d7d620fd9bdfe2d1e429735198": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsepol-3.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:161f1eaec1112bc47a11c3cb77542ad50108160ec8944618d88ae88e1f33e15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gzip-1.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:17b1caf2274070cab464dbbe8aa307678df13937f2f315af4bc2eaeffd5915c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libstdc++-13.1.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:196b3612e50069c68d67ffaf3081d25923e2b4ca7e1bad8f124515b3fa472d4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/file-5.44-3.fc38.x86_64.rpm"
+          },
+          "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:1b6b7ad33391919a3315e398d737a764121e2fc9581f75318a999e02bfc0c7c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsemanage-3.5-2.fc38.x86_64.rpm"
+          },
+          "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:1cff3e219caab04a0cacd2b9139ec5bdee8b6d7d95d63276477e5a882b649c89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/d/dracut-config-generic-059-3.fc38.x86_64.rpm"
+          },
+          "sha256:1d17f327a83ccb5ec42f412c78ae6aaf787bd46f10645b65af43f6f5ae9d8c15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-2.37-4.fc38.x86_64.rpm"
+          },
+          "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm"
+          },
+          "sha256:1e9e8b6447c2650a306e8d107dbdcdaa4f81d4175012eea0c87846faecd64c70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc38.x86_64.rpm"
+          },
+          "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:221f9fb2407208c40962ff030de372e3b74e69471e558b858ca51f0a196cd3c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc38.noarch.rpm"
+          },
+          "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:2656094a2199cb34ffd66c00051e93a15b742bc618bf02b1f5886ea3560e8a6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
+          },
+          "sha256:2a0d1472b2d48964b4ecdeda9bee15b6fd66f9b321c74d0b4acfe85cdfb2bb6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-networkd-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc38.noarch.rpm"
+          },
+          "sha256:2c8b143f3cb83efa5a31c85bea1da3164ca2dde5e2d75d25115f3e21ef98b4e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/w/which-2.21-39.fc38.x86_64.rpm"
+          },
+          "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-misc-2.5.1-5.fc38.noarch.rpm"
+          },
+          "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libnghttp2-1.52.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc38.noarch.rpm"
+          },
+          "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/diffutils-3.9-1.fc38.x86_64.rpm"
+          },
+          "sha256:3b72fe2b2c48226ef90c88920d64a734df584c68d04d10b48bc8a67471a8a627": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgomp-13.1.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:405e237a7852b763a3a7ebde766103a007975a9bd8f8443f721e384a237344db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-tools-2.06-95.fc38.x86_64.rpm"
+          },
+          "sha256:40b98bdd00b44fbf808df1d653ecf0f0ed8549643d52b68da2455c5a878f0021": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgpg-error-1.47-1.fc38.x86_64.rpm"
+          },
+          "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-38-36.noarch.rpm"
+          },
+          "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxcrypt-compat-4.4.33-7.fc38.x86_64.rpm"
+          },
+          "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/device-mapper-libs-1.02.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:440fc5c6e6a37c47f13d1fb53a03f5cb0155592a5bcf9312e2d083d4bed0ad40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/policycoreutils-3.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:49e693f6812e04450b0c98a108f302a799f5ee21f8000675f59d47e097ad24c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:4c30f707e681358ab19bd95cbe65477ba47743609ea0fd5939d024bb225116db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libcurl-8.0.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc38.noarch.rpm"
+          },
+          "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:54f80d720b6656ae12c37ff54143da540f464822ec86c8fed5f0122e5834dba9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc38.x86_64.rpm"
+          },
+          "sha256:55ca555fe815bd360b08500889b652f50fe4c56dfafbed0cc459f2362641f1a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse3-3.14.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:56705b6a1526960d534b0d3e4247deb4eef2b5fa64ceb03544281b8e9bdc4597": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/polkit-libs-122-3.fc38.1.x86_64.rpm"
+          },
+          "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm"
+          },
+          "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcbor-0.7.0-9.fc38.x86_64.rpm"
+          },
+          "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxcrypt-4.4.33-7.fc38.x86_64.rpm"
+          },
+          "sha256:5ae40c78ba1b3d44bda453048fa602bb2cbfef08f5873e3cc268490d5a68d24b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:5c7442e6c8761f473c675ebfd2b3c9f6ec2c5adbf32f5e029d512da6190a499c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-pam-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:5c873b53bb08ddd23c149bccdb4e366faa92bac10bd15699d9c57b22d499e272": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:5cc364cad8cb613a0ec68076f7f8e10b72ef2e266a10d2463bf548b2b0abd13e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/t/tpm2-tools-5.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:5edeec0be1144c7eea7040a8232b08add6b1b319a0ec2cf3d13f7e1c2da2cfd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm"
+          },
+          "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/nettle-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/grep-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:6170bb84006ad1d74202125a21308b15be0b36ec95e9dbb6552aa35026e966ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnutls-3.8.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pam-libs-1.5.2-16.fc38.x86_64.rpm"
+          },
+          "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm"
+          },
+          "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/device-mapper-1.02.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm"
+          },
+          "sha256:6deb22c3ea0b8f291140f1dc74ef885f5dba97f9bda32257ef48e1790f7dcb4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openssl-libs-3.0.8-2.fc38.x86_64.rpm"
+          },
+          "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:716096df1b34d768c3e6a5985de8e1ee58b2183ad9f987aa754e592bd2793c70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/polkit-122-3.fc38.1.x86_64.rpm"
+          },
+          "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:71f6397b0c264dab7a94f0461251593b5fae068b154299f949dacfe8d6bed7cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/o/ostree-2023.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/j/json-c-0.16-4.fc38.x86_64.rpm"
+          },
+          "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm"
+          },
+          "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kmod-30-4.fc38.x86_64.rpm"
+          },
+          "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cpio-2.13-14.fc38.x86_64.rpm"
+          },
+          "sha256:77b74224b3f6669c1e2c17c371a411d350e120c1ba2080ff2009e1b47b3c2563": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc38.x86_64.rpm"
+          },
+          "sha256:78a15621e7e3dfb5a65b8b8aa482cf5b07f08bcef217ad29435e299d6c8aec74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libselinux-utils-3.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:790c6d821ff575ad51242ec6832ed61c8a3c4e0ece245c3dee3292d19acb23b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libselinux-3.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gpgme-1.17.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:7d9a98372505c9c1dff7dfea558b20a44820fda416a609467790577a848de110": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fedora-gpg-keys-38-1.noarch.rpm"
+          },
+          "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm"
+          },
+          "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm"
+          },
+          "sha256:82f7c74c4f31dad16dec9fc52556f76051979b8dea69877b71aa0ac3060c25d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-common-2.37-4.fc38.x86_64.rpm"
+          },
+          "sha256:83bb8576a018ae028ff1434c32e1f3dfab66a781e1af9057862a2d7f3d725f58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/file-libs-5.44-3.fc38.x86_64.rpm"
+          },
+          "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:8a3a4007d921c6a9b372e4573520866b445c18476f907b023ea19b436436ec33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-2.5.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:8be96e09e2e44491b287be44b2b6be0c9f8aeab75fe061d3e8a28b9be19144ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/shadow-utils-4.13-6.fc38.x86_64.rpm"
+          },
+          "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/selinux-policy-targeted-38.15-1.fc38.noarch.rpm"
+          },
+          "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fedora-repos-38-1.noarch.rpm"
+          },
+          "sha256:940192d99005896a29de3c682259b3505652778d58ec74a003639f3ba3193a1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnupg2-2.4.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm"
+          },
+          "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:96a7e71271d334497b5f108f8aaadb4210e488948947b108375eb8636e7118f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc38.x86_64.rpm"
+          },
+          "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-legacy-2.5.1-5.fc38.noarch.rpm"
+          },
+          "sha256:98427b7229a862d099d43f798547ae713f041698c1b274481bf2377afef8fafd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm"
+          },
+          "sha256:9f6acd253d7c2dd0df445d321ac9df3a2870781cfac6837ba424a7aa0f24b469": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:a19f14b4776a70fed369c279df99fe65a73b9928c23cc443c51e5353fc549080": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/d/dracut-059-3.fc38.x86_64.rpm"
+          },
+          "sha256:a37d38ffe36c63ab5ef58c41101cb7b2b17b3d8c954fc5e25b25a1cc82c9d7d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.37-4.fc38.x86_64.rpm"
+          },
+          "sha256:a383d65f22be848a24bc8e328d136260f15dd8b0401da273bb27e18228bada4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc38.noarch.rpm"
+          },
+          "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/sed-4.8-12.fc38.x86_64.rpm"
+          },
+          "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/r/readline-8.2-3.fc38.x86_64.rpm"
+          },
+          "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/selinux-policy-38.15-1.fc38.noarch.rpm"
+          },
+          "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/publicsuffix-list-dafsa-20230318-1.fc38.noarch.rpm"
+          },
+          "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm"
+          },
+          "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-common-38-36.noarch.rpm"
+          },
+          "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/filesystem-3.18-3.fc38.x86_64.rpm"
+          },
+          "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:b41f1f364f53aa4b8cfb7cc45171cd9afc734b1988f941efc701ac683ff05a11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-efi-x64-2.06-95.fc38.x86_64.rpm"
+          },
+          "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm"
+          },
+          "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcap-2.48-6.fc38.x86_64.rpm"
+          },
+          "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-identity-basic-38-36.noarch.rpm"
+          },
+          "sha256:bbc243a16c7775d825b8729a4b6627a50fca4297bc624aace55f9ec07453993d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bubblewrap-0.7.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm"
+          },
+          "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm"
+          },
+          "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm"
+          },
+          "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/setup-2.14.3-2.fc38.noarch.rpm"
+          },
+          "sha256:c9c6ada24ecb197e6902b6c9454867973a68ec5a531df651729a811924ed8e5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/curl-8.0.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/npth-1.6-12.fc38.x86_64.rpm"
+          },
+          "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm"
+          },
+          "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:cd41c94b8c668602f7fb5eae595e5d5c34bd1b91690b5cc06f4c8c199794dfa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnupg2-smime-2.4.0-3.fc38.x86_64.rpm"
+          },
+          "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/containers-common-1-89.fc38.noarch.rpm"
+          },
+          "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm"
+          },
+          "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-common-2.06-95.fc38.noarch.rpm"
+          },
+          "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/grubby-8.40-69.fc38.x86_64.rpm"
+          },
+          "sha256:d5ae6a7d99826a17d163d9846c2705442b5792a7ccacc5169e4986cdf4b6bae2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse-common-3.14.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm"
+          },
+          "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:d7eb37e1dc5d15eb05dfc2481ed9de694d64459296d3005b8415fa741af0d5f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-libs-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm"
+          },
+          "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm"
+          },
+          "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:dc5bc7ddd4b7dcd305f96bf0c160e78d181629405d97f3c7505c815767b51862": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc38.x86_64.rpm"
+          },
+          "sha256:dca922285b9f680f084fef9c5b48096574313a0f7ae41ef8251e018c5df8dbda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm"
+          },
+          "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm"
+          },
+          "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm"
+          },
+          "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:e122069483cb322a66d0c05b405b5e37784bee86135418c356dccf49618ee1df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-resolved-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:e13941f4a922a76da599fb0e00884e530d9ed8ce5145fb5a54f7337a6af5085e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc38.x86_64.rpm"
+          },
+          "sha256:e3418df9795e4d82bbdd906c94dc4a86bb67e92760875eda33d21dd0379c66fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.37-4.fc38.x86_64.rpm"
+          },
+          "sha256:e3e7c19626666ff545cd74c0cd854696005f3d7d0b4eb1d1c1ac60404188d981": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgcc-13.1.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm"
+          },
+          "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pigz-2.7-3.fc38.x86_64.rpm"
+          },
+          "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/krb5-libs-1.20.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:e873cefdeee846f6d1d7e8f00c60bd1714cb2b9d26572d9bf43ea0ce15fd0d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/coreutils-common-9.1-12.fc38.x86_64.rpm"
+          },
+          "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm"
+          },
+          "sha256:ea77373517525f6e976fe9c062274b176e86eb378ed82e72a76854c741b2c25e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/coreutils-9.1-12.fc38.x86_64.rpm"
+          },
+          "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm"
+          },
+          "sha256:ebbd35c8b39a71ffd82bfcdd6a908c024fed56d27ecfa26ed6b8d1aa0ba4170a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:ebd8002b78f3495135813c05ba753c2214cdfa7a9c18411a1438f6fe49e7b925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-udev-253.4-1.fc38.x86_64.rpm"
+          },
+          "sha256:eccf03e76c219c2bc0a6cec352e5c0be12041ffbb5e2be736f19bedfbd8ed077": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/o/ostree-libs-2023.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:edc3846d881c4ad341c5e97f7a2b7ec8f5164c26e73839449374b3c6fc2483fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm"
+          },
+          "sha256:ef4b2686134e6be036755ee093aad43eb0ce4a4c84c93a2defb755cfeb398754": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgcrypt-1.10.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/lua-libs-5.4.4-9.fc38.x86_64.rpm"
+          },
+          "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:f54340fec047cc359a6a164a1ce88d0d7ffcd8f7d6334b50dc5b3d234e3a19ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse3-libs-3.14.1-1.fc38.x86_64.rpm"
+          },
+          "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm"
+          },
+          "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/popt-1.19-2.fc38.x86_64.rpm"
+          },
+          "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm"
+          },
+          "sha256:fcd827a4f95db14a707bc604efac1db86973eaa97bd8bf9f78c37a925c09a297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-4.18.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:66604d04522a860a1c755a9629b0cb1e25a2c24747945f1f69b41ab8522787b3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4dc70c4a90ddede4f38d96e8184da5d3113f9404d3cd4b98b45ffd40cc503249",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:718d95c40b41c2f0ecc8dc2290ebb91b529ba3be7accbad9c30c88e9ce408349",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:961883b6ac18ca54b525209adce0c593f81fd8a7e71bb75bc07724e4ef72bc5f",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bubblewrap-0.7.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bbe3eb89df059162bda14c6f0c06e6251984d79502806c87ae4c6befc4e392ab",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm",
+        "checksum": "sha256:95273426afa05a81e6cf77f941e1156f6a0a3305a7768a02c04a4164280cf876",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:738f573c50a537b556e2fbb8fa4a2c0d22fc2ce4a67344f89d478989cc323ab3",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "14.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cpio-2.13-14.fc38.x86_64.rpm",
+        "checksum": "sha256:75ecf8c60bea53432b973d9391e3bdb1b6cdc1f1cad0a7b56aabfb8b70252832",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:1262de076983a540ed42a33160a61cd2723a662c1680935379ccdb0894f60cee",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:f289b7726320f275730e28e3891a6f3fda76941876de4f643d486f3265a0a074",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/crypto-policies-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:6809fe060dc93dfed723bd8faca0f5d65e4f6c62aebd2f9f39f679413b260539",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230301",
+        "release": "1.gita12f7b2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/crypto-policies-scripts-20230301-1.gita12f7b2.fc38.noarch.rpm",
+        "checksum": "sha256:d1880b8f3e8a5fa943ba033c96dc964fac3e07c34cbd0bb8ac2b0fdcb57abcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cryptsetup-libs-2.6.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:070d86aca4548e9148901881a4ef64d98c5dfd4ea158e9208c650c7f4b225c47",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/c/cyrus-sasl-lib-2.1.28-9.fc38.x86_64.rpm",
+        "checksum": "sha256:b570b4857289cf32ed57d0d84cb861677a649cef7c5cc2498a249d6593eb3614",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:1812689be8bbc4ef39718dbb8ef862105225348310052ddaf0b1cb0f0a1bf296",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm",
+        "checksum": "sha256:6652f5d40acfaeda20555bdd63e964f123e8ab4a52f8c8890e749e06b6bae3e0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:41cd0821eaa5887eab973a969bd1c8928567e655aacd851f37fd2026d95c7e4d",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/device-mapper-1.02.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:695aab11fda4b6a396c3ca141fb3ccc48af757a70f36ea3a1be2292e90c40d6f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/device-mapper-libs-1.02.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:42e8600a8d7e7109de32df6cb6a619b9805f9335bf467a085009f6b82dda6e22",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/diffutils-3.9-1.fc38.x86_64.rpm",
+        "checksum": "sha256:38c134f1c688e9c33ced36cf623e6ce1b0802ff0623b42c69b1cdffb5bea1b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm",
+        "checksum": "sha256:e0a6768f0ca08572b79a265ba0d3fdeba09408431d9e717b8d45af9e1ae67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/d/duktape-2.7.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8bcdb9b5ce9b5e19c4f772f52c2c40712491d2a953496e415c380a21a792b050",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/e2fsprogs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b25a042f52c8cdc1ddab56fc726d98789ff902d5264d9835f5b910db3e565213",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/e2fsprogs-libs-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:1ca049bff926a8ec9b6e0e69f23662934eab96c35d8eda1cf429a2a31f186045",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:a007fe955a4fba751f211b4e8e16f916e9b7ba1c020b69d62ccb4d437a3ddd1d",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:575ba7ab8e3b6d5b7508a505694a37c390a64ec070659b9393c1a5283c19ce90",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm",
+        "checksum": "sha256:fbeb7a7a95051df0dfeb7c4ab379b77ccfb0bf0174a39dae4a423b9108627771",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6c64fea958acfb77da5ee23ec1e8d0916c7809ce39987f219927e8f94e5f2755",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fedora-gpg-keys-38-1.noarch.rpm",
+        "checksum": "sha256:7f7c78f598f7ff131bbe77913b9fc6b7b49d1fce30f2d8505b2d8a85458f519a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fedora-repos-38-1.noarch.rpm",
+        "checksum": "sha256:916b75b58e9a2afe5d53cb73fdabea4d0cd8b1eba9f1213754384d0ccd531e57",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/file-5.44-3.fc38.x86_64.rpm",
+        "checksum": "sha256:196b3612e50069c68d67ffaf3081d25923e2b4ca7e1bad8f124515b3fa472d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/file-libs-5.44-3.fc38.x86_64.rpm",
+        "checksum": "sha256:83bb8576a018ae028ff1434c32e1f3dfab66a781e1af9057862a2d7f3d725f58",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/filesystem-3.18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:b0fc6c55f5989aebf6e71279541206070b32b3b28b708a249bd3bdeaa6c088a4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/findutils-4.9.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:79986f917ef1bae7ca2378b16515ba44c19160f5a5eae4f6b697eda160bc26c1",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:8c70948b04d05290d6441359d461d9f7ec45439b3c97430c41b8a862d59e7b60",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:56df47937646df892dad25c6b9ae63d111328febfe86eb93096b8b0a11700b60",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gawk-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e607df61803999da46a199d23d4acadb45b290f29b5b644e583c5526d8081178",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gawk-all-langpacks-5.1.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:254c6789b4a98b96a53172e1b3fb866f71ea29a5b5fa7b39f072f33c27d897bc",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm",
+        "checksum": "sha256:eb376264750aae673aa2a3218c291756023dea980640b30a3efe0f2199ff3889",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-envsubst-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:276c7af4b13262c0307cf2528c6d79c859ed348db68c0d2780869ea4b179dd02",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-libs-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4fb6fcf7eef64a48666ff9fe5a46344087979d9e8fd87be4d58a17cf9c3ef108",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gettext-runtime-0.21.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:3837cbe450ceb59e1f9e7469aeb6ec98e08150773b83463725acfb2ebb77a98a",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:69e48c73d962e3798fbc84150dfd79258b32a4f9250ee801d8cdb9540edfc21a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnupg2-2.4.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:940192d99005896a29de3c682259b3505652778d58ec74a003639f3ba3193a1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnupg2-smime-2.4.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:cd41c94b8c668602f7fb5eae595e5d5c34bd1b91690b5cc06f4c8c199794dfa8",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gnutls-3.8.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6170bb84006ad1d74202125a21308b15be0b36ec95e9dbb6552aa35026e966ea",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gpgme-1.17.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:7d5eb1e8f80ae1dddc082b58c387f8d7b66d48dbf1d9ab4bcf9c9c138996085b",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/grep-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:60ed241ec381a23d03fac733a72132dbdc4ba04c412add78bfc67f1b9f1b4daa",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "69.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/grubby-8.40-69.fc38.x86_64.rpm",
+        "checksum": "sha256:d48579aa97fba34dc3a4c4dd3fb10e8fd66186d970e37c2f7fc28bebbc2d31eb",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/g/gzip-1.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:166e842798813a72e4d075dcd9b6e814d7ad3fc8d1b5860281cffe7a68784b25",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/j/json-c-0.16-4.fc38.x86_64.rpm",
+        "checksum": "sha256:736182ae69e03a19be60ed57486990f9b88cd06eeecb5e06cebc7f4b64ab0f5d",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm",
+        "checksum": "sha256:c2ae86002363a331661c72eec5cad90a100216e46176d4bdbe2c20e465c1d73c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-2.5.1-5.fc38.x86_64.rpm",
+        "checksum": "sha256:8a3a4007d921c6a9b372e4573520866b445c18476f907b023ea19b436436ec33",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-legacy-2.5.1-5.fc38.noarch.rpm",
+        "checksum": "sha256:97fcab8f93c5213714e0a9d15e48440c567d2ac39e4ed12743198268082f0583",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kbd-misc-2.5.1-5.fc38.noarch.rpm",
+        "checksum": "sha256:2ea5dfd9d8c8fe7f61022b41fd6f8a2653692acf30253f45e1dc67def1648f32",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:b66376e78fe54024531d94036d10b22b5050d52a9e65682b36dc7fdf24405997",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kmod-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:7419671c64795b96be18231e2f5d3f95eca8e6a71771863ac035f961041c1d7c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kmod-libs-30-4.fc38.x86_64.rpm",
+        "checksum": "sha256:19f873b67f23362074c03d5825e709ad521278c02e44bdeb30eba6d3bb3a8e0f",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/kpartx-0.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:ac8a7628a2a4b1f742fc90719145f50cfad9ecf67e3309fcf623fb3d82c2a768",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/k/krb5-libs-1.20.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e779fca5e3be85efabe2132bdaf87ac852d78187fbbb9e3d9b37eabccafb4e85",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libacl-2.3.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9b093be8a99bfbae03c2f3dd5435fc9508003f7ef21e4280ff72fe814c1d794e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libarchive-3.6.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:0d0890dba8274458d068b981164111f554b47632bf9c82d1ec41c14697f2b4af",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm",
+        "checksum": "sha256:dd044973c572e64f505f3d00482249b2b4d71369babb5395a22861fd55b21d79",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:8b4892a7d8ff6e913ea16e1b26c4a3f7dd2bbed5893895b34ef3f02553be1a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libattr-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:d78d7bc485f099bb08c9de55dd12ea6a984b948face1f947de6ec805663a96c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:9e73a2b591ebf2915bfbe7f9479498a73c982a4c74e96cc555930022e3ef0aba",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libblkid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:21b5a1a024c2d1877d2b7271fd3f82424eb0bd6b95395ad3a3dae5776eec8714",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm",
+        "checksum": "sha256:bdd3f5e8edc77ce3e183134535ec838f033ed3bf0e6802e864c0a6c5fc94b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcap-2.48-6.fc38.x86_64.rpm",
+        "checksum": "sha256:b6a2b3872182fe877fcd1dd85ef66282fdeec79fab87157327c9fc6cbd80ab15",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm",
+        "checksum": "sha256:1e0bee6fd4e234796795cd45185b250d8cf894aef0bb95f2793d9453246e1a4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcbor-0.7.0-9.fc38.x86_64.rpm",
+        "checksum": "sha256:5922028bb5642faf00d781f34bf105ef30f1988932b4b80f6bb54e9f6eed0fd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libcom_err-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:4ed3e7b6b0727b86ae9af17bd4839c06762a417a263a5d22eb7fcb39714bb480",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm",
+        "checksum": "sha256:d7030af9e9e0dd9afc5b9ee02839c94757d6a4f8ebd3b21e6d81ba6141a76d46",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:6e57ebf25ad25e7a6809aa0d99b5692598fb009a5438e90a2005f9fae5fd3b13",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm",
+        "checksum": "sha256:e9741c40e94cf45bdc699b950c238646c2d56b3ee7984e748b94d8e6f87ba3cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libfdisk-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:2fb7ee2d94f7ee34cff49ab28659c07b075ed67ac147f817e19d8ee8e0adbc9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:098e8ba05482205c70c3510907da71819faf5d40b588f865ad2a77d6eaf4af09",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.12.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libfido2-1.12.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:0a30628b39d9c5ca81c4e073dfbf64d543284f17d4ae1325e23e3eda55f92fd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:d3416e2b6c7565d7a607225d86b556398827316ae7ce43280b82630f0a022bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:75c0097330fa3c995e80b7791cbe7baf75d86f3523f67b3becaf37360fdb4b16",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e552fae193775507d8264f7a856fbdc51f7e594d7d8726f181312aeb9cf8b973",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:34446f36355b415633037cdb983677288e4fb70b68d70a509fa2081b6b6e9f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libmount-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:14541cda2a4516ad6a17f46be6b7ad85ef5f6508d36f209f2ba7bd45bc1504e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.52.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libnghttp2-1.52.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:33631973ecf9e6b23e0b7d07d61100fdc2db33261f4a6c43b5a09791b9455291",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:28697cf1b5cb4d62c3bd154fc24a23d91a84a5bda2f974fb64bdd04e91b6cec5",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e0bccc94a740acf317caa4fa1fae6b0d57442ef4be36341472b7db93d588ec13",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:aefb7d2d96af03f4d7ac5a132138d383faf858011b1740c48fcd152000f3c617",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:845f6731b9e784784494fe9711c116631fc9ceede2fd0fa15b5f9575dee25e10",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm",
+        "checksum": "sha256:dec378b594b79258dd8b44836c5371f316bcf5e4596d53dd84badcb6d00090df",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:46ed6b8fee11c16bb8b58f698dfba9874a8f393c1e72eb7f9a7b6802ac68dd1a",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libselinux-3.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:790c6d821ff575ad51242ec6832ed61c8a3c4e0ece245c3dee3292d19acb23b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libselinux-utils-3.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:78a15621e7e3dfb5a65b8b8aa482cf5b07f08bcef217ad29435e299d6c8aec74",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsemanage-3.5-2.fc38.x86_64.rpm",
+        "checksum": "sha256:1b6b7ad33391919a3315e398d737a764121e2fc9581f75318a999e02bfc0c7c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsepol-3.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:15ec70665f200a5423589539c3253677eb3c15d7d620fd9bdfe2d1e429735198",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm",
+        "checksum": "sha256:ac0a6bf295151973d2e34392a134e246560b19b7351ced244abc1ed81dfe5b8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsmartcols-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:dbf5c73c71c798533cbecfa54ba28c42878c455df8cb382087d8a758c3ffe290",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libsolv-0.7.22-4.fc38.x86_64.rpm",
+        "checksum": "sha256:db9229087c86f9d5725daf2066e3a52c84dc44bb31ac940461fc8d7510681297",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libss-1.46.5-4.fc38.x86_64.rpm",
+        "checksum": "sha256:faccff819eecffcee9dad49bda930a007e78b905b775b4ac0103121d7a8100db",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8b49dd88579f1c37e05780202e81022c9400422b830d9bdd9087161683628b22",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:c4012952872a08b9662963b13e29f89388ce6e695e68fa8c37eb6e62bad62441",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:cd0e8eb5d983a985f7df99718fde6245997bdf088fb6086442a883ddb9ed03e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm",
+        "checksum": "sha256:805da27b46f0d8cca2cf21a30e52401ae61ca472ae7c2d096de1cfb4b7a0d15c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libutempter-1.2.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:c5c409a2d5f8890eeab48b27b9f4f02925a6bbabeb21ee5e45694c7c9009f037",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libuuid-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:876ef0556ddeca2c8f56536c80a2f6e0f64357f40bacb92f483adb8a0ff29af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:292791eb37bc312e845e777b2e0e3173e2d951c2bfbbda125bc619dced7f40bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxcrypt-4.4.33-7.fc38.x86_64.rpm",
+        "checksum": "sha256:5ac3b50011adb56391125a3b60bf05ae578af7209788cfdbfcf0ddc37d7b0ba2",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxcrypt-compat-4.4.33-7.fc38.x86_64.rpm",
+        "checksum": "sha256:4170497dedcf53248c18f7963b911aed445d8bc02a33aa27aadf3354b8dfd8ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:507ffdb912296768699a70c30169077b531b1612e47041551bfe523a4b7b6c7d",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm",
+        "checksum": "sha256:9f531fbcc52871aace8fdcdb816207c4196d5ab30ba233c71adb41371fa47e19",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/lua-libs-5.4.4-9.fc38.x86_64.rpm",
+        "checksum": "sha256:f0a48ec36269d83120425b269e47ba5c86d5a9a44e0de2665c1d55c10732d25b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/l/lz4-libs-1.9.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:96a8f495896c0ff7520c2cc5c9c173d134efc9ef6c6b0364bc7533aefb578d41",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:36a1f0412e495e618ccd8636de3dcac9ad37d5d4c287a1acf2c9af4baa7745e0",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm",
+        "checksum": "sha256:d9196608152ec34832cc82d3cefa90748f30c75986f2250d8cd0fabc3d0ceba2",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:22f217f91fc2d2a666304c0b360520b13adde47761baa6fed1663bb514b6faf5",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:e7c9b0c39f77c6fdf68ff04d8714c10532907a8a9c3e76fb377afe546247737f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/ncurses-base-6.4-3.20230114.fc38.noarch.rpm",
+        "checksum": "sha256:602145f27fd017858256c6ee880863ef5be17c6d3c6c1354f7f16f6f6348db57",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "3.20230114.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/ncurses-libs-6.4-3.20230114.fc38.x86_64.rpm",
+        "checksum": "sha256:6ce309d9fd208bfff831981ee4298ccb25fa72363cb7464f1da03b8214d4351f",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/nettle-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:605d6710ba42104ce0434bb37b0ca9a922a8392c14175bc782f8acb70b94c3aa",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/n/npth-1.6-12.fc38.x86_64.rpm",
+        "checksum": "sha256:c9e8b62c6af7a60a505f881d3cc35294d8b4f51c671c05401133b02ab229c2a7",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openldap-2.6.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:13509309959035c338299a33985d56f10896466367e1f62d4fea98123e74bfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openssl-libs-3.0.8-2.fc38.x86_64.rpm",
+        "checksum": "sha256:6deb22c3ea0b8f291140f1dc74ef885f5dba97f9bda32257ef48e1790f7dcb4e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:cfa3d6feba480abdeb425bc045b525c641c7a864625b1864c2f5721903e364d8",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm",
+        "checksum": "sha256:06d2101874ea4d14b4c73131c5c359d1a2e0ebe0c36a501250026e7b867a0a86",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:8e4afbcb9488d9c6a9bf7d0739173b8757ce33a6f5e00f0ab7ccfcf605ed9273",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9030a26ff737b7bbb71d5208feebba1a0b2774d58dfb6016824a042e059642d8",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pam-1.5.2-16.fc38.x86_64.rpm",
+        "checksum": "sha256:065b99f3541fd5f1281be2082b77e48b835a591776e92f2327bb0462c67baed0",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pam-libs-1.5.2-16.fc38.x86_64.rpm",
+        "checksum": "sha256:63e970f7b3f8c54e1dff90661c26519f32a4bf7486c40f2dd38d55e40660230e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm",
+        "checksum": "sha256:cb1caf3e9a4ddc8343c0757c7a2730bf5de2b5f0b4c9ee7d928609566f64f010",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:756f64de1e4673f0f617a9f3f12f74cceef5fc093e309d1b1d5dffef287b7d67",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:48efa34ce50ae936ab9fe437aa59396d4557ff39fa22cf36c5460d3a986e502f",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:aa02afed121e9f5fa9590d75c0b237b6c497ae58c91e0022844b38f594feaeb7",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:07dc5536982278f38c89517465384ef9f376cd27f0b200806268723993da01ad",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pigz-2.7-3.fc38.x86_64.rpm",
+        "checksum": "sha256:e7509cf0ec99ce89e8e88e9352f733eb9ad14a9c77e0bbfd64826a3de0e4a150",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e521385a42b3350c0d17e3cbddc0b69c9cf4052d1b77cc8bea2179e05b7d374a",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/policycoreutils-3.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:440fc5c6e6a37c47f13d1fb53a03f5cb0155592a5bcf9312e2d083d4bed0ad40",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm",
+        "checksum": "sha256:7ffa0438229228bf5ba18945936d52c3620c95f4a3ffc5c5f0f8774fececac0a",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/popt-1.19-2.fc38.x86_64.rpm",
+        "checksum": "sha256:fb3fabd657b8f8603c6e19858beb0d506cf957bbca2f3feb827b64c94563b31f",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm",
+        "checksum": "sha256:fdb3e6e4578d8bb90f1f917edf5a7f52432df2eb5b0fab000eab662b15476479",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/publicsuffix-list-dafsa-20230318-1.fc38.noarch.rpm",
+        "checksum": "sha256:abddab3b7b1f90a3146eeed9e5178d884112932fa8110d1a9a1cfe4584f53cb9",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.3.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/python-pip-wheel-22.3.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:ee100ea7fe8bf26d44df719283554a36398d484eee28682694c9e7a249c2d49c",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "65.5.1",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/p/python-setuptools-wheel-65.5.1-2.fc38.noarch.rpm",
+        "checksum": "sha256:7417816bd96d7b49e5a98c85eba313afaa8b8802458d7cd9f5ba72ecc31933e3",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:49ec489f168c1671a2babb690edfb020a5252f38e8d0b2d96465070abd2b0d70",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/r/readline-8.2-3.fc38.x86_64.rpm",
+        "checksum": "sha256:a7099c322c45030738bdd90e3de4402c0c80c6ebd993a1749c2e582cf33ee6f2",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/sed-4.8-12.fc38.x86_64.rpm",
+        "checksum": "sha256:a6e01b89e814ec42d1c2c6be79240a97a9bd151c857f82a11e129547e069e27f",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/setup-2.14.3-2.fc38.noarch.rpm",
+        "checksum": "sha256:c7efb8634b62cdab9e8894174a8c70d20eb431482277231bc54fa8ca8c3681e3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/shadow-utils-4.13-6.fc38.x86_64.rpm",
+        "checksum": "sha256:8be96e09e2e44491b287be44b2b6be0c9f8aeab75fe061d3e8a28b9be19144ef",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:85bb1aa32f6345349c9cf09c35217caae441dca6b2be8f21619ea6808d3c5af6",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.40.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/s/sqlite-libs-3.40.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:be6d9e9b98733494ee5901d45b849e2dc012a6b41c3ff09d0d212002dbe15dce",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:8adf29af85920514902bc4332ceb896a54f9cf89e08993c9345b62c4140f91d9",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/t/tzdata-2023c-1.fc38.noarch.rpm",
+        "checksum": "sha256:041e8b9be8a87757da8d5b8a2ced4b5aec8bcafd1c0747234cdfe10206eae27b",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/u/util-linux-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:f0f8e33332df97afd911093f28c487bc84cbe4dcc7bb468eac5551d235acee62",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/u/util-linux-core-2.38.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b57dbbbee14301e89df618b398ef39b7fc841eaba6be1b6346cf37ed7695c26a",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/w/which-2.21-39.fc38.x86_64.rpm",
+        "checksum": "sha256:2c8b143f3cb83efa5a31c85bea1da3164ca2dde5e2d75d25115f3e21ef98b4e0",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:59a7a5a775c196961cdc51fb89440a055295c767a632bfa684760e73650aa9a0",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xz-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e911703ffceee37ec1066344820ab0cf9ba8e43d7957395981ba68c4d411a0a4",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/x/xz-libs-5.4.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:bfce8ac2a2a78a23fb931531fb3d8f530a78f4d5b17f6199bf99b93ca21858c0",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-fedora-20230413/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
+        "checksum": "sha256:c26d4d161f8eddd7cb794075e383d0f4d3a77aa88e453a2db51e53346981f04c",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/a/alternatives-1.24-1.fc38.x86_64.rpm",
+        "checksum": "sha256:96a7e71271d334497b5f108f8aaadb4210e488948947b108375eb8636e7118f5",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/a/audit-libs-3.1.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:49e693f6812e04450b0c98a108f302a799f5ee21f8000675f59d47e097ad24c7",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/container-selinux-2.215.0-2.fc38.noarch.rpm",
+        "checksum": "sha256:34648048bf2329590f819b6582658a6a53fbea24ab177a4f32be290f9af83608",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "89.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/containers-common-1-89.fc38.noarch.rpm",
+        "checksum": "sha256:cd9583500892b5f50f51167f5c4b16855e15808a79e5137e0c6674e19f305930",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/coreutils-9.1-12.fc38.x86_64.rpm",
+        "checksum": "sha256:ea77373517525f6e976fe9c062274b176e86eb378ed82e72a76854c741b2c25e",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/coreutils-common-9.1-12.fc38.x86_64.rpm",
+        "checksum": "sha256:e873cefdeee846f6d1d7e8f00c60bd1714cb2b9d26572d9bf43ea0ce15fd0d75",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "8.0.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/c/curl-8.0.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:c9c6ada24ecb197e6902b6c9454867973a68ec5a531df651729a811924ed8e5e",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/d/dracut-059-3.fc38.x86_64.rpm",
+        "checksum": "sha256:a19f14b4776a70fed369c279df99fe65a73b9928c23cc443c51e5353fc549080",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/d/dracut-config-generic-059-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1cff3e219caab04a0cacd2b9139ec5bdee8b6d7d95d63276477e5a882b649c89",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:5c873b53bb08ddd23c149bccdb4e366faa92bac10bd15699d9c57b22d499e272",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc38.noarch.rpm",
+        "checksum": "sha256:4cf1366fcdd86b911fdfab09fd2e87b9334854b666a47199d81db5e3f9caa635",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-libelf-0.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:98427b7229a862d099d43f798547ae713f041698c1b274481bf2377afef8fafd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/e/elfutils-libs-0.189-2.fc38.x86_64.rpm",
+        "checksum": "sha256:dc5bc7ddd4b7dcd305f96bf0c160e78d181629405d97f3c7505c815767b51862",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-38-36.noarch.rpm",
+        "checksum": "sha256:40f7d64e38ae31dcb3e7273c7e089705e816dc131ae87c176e2c1aad02d5b510",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-common-38-36.noarch.rpm",
+        "checksum": "sha256:ac9ede79357b33f0d0c9087333b0dd3e3fd1cf5ccab5c36310b0ec446390e0c7",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fedora-release-identity-basic-38-36.noarch.rpm",
+        "checksum": "sha256:bacf386d747343cb10a2c3847c426d3e044b7de1742b4918e3b1b78cc1b54bc4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse-common-3.14.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d5ae6a7d99826a17d163d9846c2705442b5792a7ccacc5169e4986cdf4b6bae2",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse-overlayfs-1.12-1.fc38.x86_64.rpm",
+        "checksum": "sha256:1e9e8b6447c2650a306e8d107dbdcdaa4f81d4175012eea0c87846faecd64c70",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse3-3.14.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:55ca555fe815bd360b08500889b652f50fe4c56dfafbed0cc459f2362641f1a0",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/f/fuse3-libs-3.14.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f54340fec047cc359a6a164a1ce88d0d7ffcd8f7d6334b50dc5b3d234e3a19ac",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.76.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glib2-2.76.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:05571a68f7dabff1ba50c42145f51ed4011c70d77ea9b4879f6759ffe837e215",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-2.37-4.fc38.x86_64.rpm",
+        "checksum": "sha256:1d17f327a83ccb5ec42f412c78ae6aaf787bd46f10645b65af43f6f5ae9d8c15",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-common-2.37-4.fc38.x86_64.rpm",
+        "checksum": "sha256:82f7c74c4f31dad16dec9fc52556f76051979b8dea69877b71aa0ac3060c25d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-gconv-extra-2.37-4.fc38.x86_64.rpm",
+        "checksum": "sha256:a37d38ffe36c63ab5ef58c41101cb7b2b17b3d8c954fc5e25b25a1cc82c9d7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/glibc-minimal-langpack-2.37-4.fc38.x86_64.rpm",
+        "checksum": "sha256:e3418df9795e4d82bbdd906c94dc4a86bb67e92760875eda33d21dd0379c66fd",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-common-2.06-95.fc38.noarch.rpm",
+        "checksum": "sha256:d40c9b41e9b45492e3d7ad37334ea19faac35b9117a0274ad21384f1cf6dc412",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-efi-x64-2.06-95.fc38.x86_64.rpm",
+        "checksum": "sha256:b41f1f364f53aa4b8cfb7cc45171cd9afc734b1988f941efc701ac683ff05a11",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-tools-2.06-95.fc38.x86_64.rpm",
+        "checksum": "sha256:405e237a7852b763a3a7ebde766103a007975a9bd8f8443f721e384a237344db",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc38.x86_64.rpm",
+        "checksum": "sha256:54f80d720b6656ae12c37ff54143da540f464822ec86c8fed5f0122e5834dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "8.0.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libcurl-8.0.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:4c30f707e681358ab19bd95cbe65477ba47743609ea0fd5939d024bb225116db",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgcc-13.1.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e3e7c19626666ff545cd74c0cd854696005f3d7d0b4eb1d1c1ac60404188d981",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgcrypt-1.10.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:ef4b2686134e6be036755ee093aad43eb0ce4a4c84c93a2defb755cfeb398754",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgomp-13.1.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:3b72fe2b2c48226ef90c88920d64a734df584c68d04d10b48bc8a67471a8a627",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libgpg-error-1.47-1.fc38.x86_64.rpm",
+        "checksum": "sha256:40b98bdd00b44fbf808df1d653ecf0f0ed8549643d52b68da2455c5a878f0021",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libmodulemd-2.15.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:5edeec0be1144c7eea7040a8232b08add6b1b319a0ec2cf3d13f7e1c2da2cfd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libssh-0.10.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:a383d65f22be848a24bc8e328d136260f15dd8b0401da273bb27e18228bada4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libssh-config-0.10.5-1.fc38.noarch.rpm",
+        "checksum": "sha256:2aefc576f770dc60682929c5de6a80b3c6adbe596398f8d5a1fb89ef7070a1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libstdc++-13.1.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:17b1caf2274070cab464dbbe8aa307678df13937f2f315af4bc2eaeffd5915c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc38.x86_64.rpm",
+        "checksum": "sha256:e13941f4a922a76da599fb0e00884e530d9ed8ce5145fb5a54f7337a6af5085e",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libxml2-2.10.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:13f2ec62e10333000a13123a4cae5ebbda270c32ece03247e45bd2b244e7bba5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/l/libzstd-1.5.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:7d9a98372505c9c1dff7dfea558b20a44820fda416a609467790577a848de110",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/m/mkpasswd-5.5.17-1.fc38.x86_64.rpm",
+        "checksum": "sha256:77b74224b3f6669c1e2c17c371a411d350e120c1ba2080ff2009e1b47b3c2563",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/o/ostree-2023.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:71f6397b0c264dab7a94f0461251593b5fae068b154299f949dacfe8d6bed7cc",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/o/ostree-libs-2023.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:eccf03e76c219c2bc0a6cec352e5c0be12041ffbb5e2be736f19bedfbd8ed077",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/polkit-122-3.fc38.1.x86_64.rpm",
+        "checksum": "sha256:716096df1b34d768c3e6a5985de8e1ee58b2183ad9f987aa754e592bd2793c70",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "3.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/polkit-libs-122-3.fc38.1.x86_64.rpm",
+        "checksum": "sha256:56705b6a1526960d534b0d3e4247deb4eef2b5fa64ceb03544281b8e9bdc4597",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc38.noarch.rpm",
+        "checksum": "sha256:a5fb69a68f91a82695c40bc489c41075a771aae47b34713e806a3db568d02ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python3-3.11.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:9f6acd253d7c2dd0df445d321ac9df3a2870781cfac6837ba424a7aa0f24b469",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/p/python3-libs-3.11.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:2656094a2199cb34ffd66c00051e93a15b742bc618bf02b1f5886ea3560e8a6d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-4.18.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:fcd827a4f95db14a707bc604efac1db86973eaa97bd8bf9f78c37a925c09a297",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-libs-4.18.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:10196a125eccfe91f3eb187be4e07d7a7d9304f738c3feed087b6f8c4375f305",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-ostree-2023.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:ebbd35c8b39a71ffd82bfcdd6a908c024fed56d27ecfa26ed6b8d1aa0ba4170a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-ostree-libs-2023.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:bbc243a16c7775d825b8729a4b6627a50fca4297bc624aace55f9ec07453993d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-plugin-selinux-4.18.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:edc3846d881c4ad341c5e97f7a2b7ec8f5164c26e73839449374b3c6fc2483fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc38.x86_64.rpm",
+        "checksum": "sha256:5ae40c78ba1b3d44bda453048fa602bb2cbfef08f5873e3cc268490d5a68d24b",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.15",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/selinux-policy-38.15-1.fc38.noarch.rpm",
+        "checksum": "sha256:a95a13f416c14a654a3571f229f9b39dfa8c32dd330de620ae08ad359eb317c0",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.15",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/selinux-policy-targeted-38.15-1.fc38.noarch.rpm",
+        "checksum": "sha256:8d8005d2b7945473754dbd39f63e549bfcab3c49f39fee4ab3f96b3843851a8b",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/skopeo-1.12.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:161f1eaec1112bc47a11c3cb77542ad50108160ec8944618d88ae88e1f33e15f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:221f9fb2407208c40962ff030de372e3b74e69471e558b858ca51f0a196cd3c0",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-libs-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d7eb37e1dc5d15eb05dfc2481ed9de694d64459296d3005b8415fa741af0d5f8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-networkd-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:2a0d1472b2d48964b4ecdeda9bee15b6fd66f9b321c74d0b4acfe85cdfb2bb6b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-pam-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:5c7442e6c8761f473c675ebfd2b3c9f6ec2c5adbf32f5e029d512da6190a499c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-resolved-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:e122069483cb322a66d0c05b405b5e37784bee86135418c356dccf49618ee1df",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/s/systemd-udev-253.4-1.fc38.x86_64.rpm",
+        "checksum": "sha256:ebd8002b78f3495135813c05ba753c2214cdfa7a9c18411a1438f6fe49e7b925",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/t/tpm2-tools-5.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:5cc364cad8cb613a0ec68076f7f8e10b72ef2e266a10d2463bf548b2b0abd13e",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/w/whois-nls-5.5.17-1.fc38.noarch.rpm",
+        "checksum": "sha256:23555f58d70d04c3bdf94efee8b829e0cbb2aba38f78fe6d76b8e19aa5058e52",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-updates-released-20230601/Packages/z/zchunk-libs-1.3.1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:dca922285b9f680f084fef9c5b48096574313a0f7ae41ef8251e018c5df8dbda",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_39-aarch64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_39-aarch64-iot_ami-boot.json
@@ -1,0 +1,5420 @@
+{
+  "compose-request": {
+    "distro": "fedora-39",
+    "arch": "aarch64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora39",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:976b142af334f9c6ba1628644f6813f3a3430a88aa587730b87b9b089696282b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ceccc96466a361367f3261f28d499a66352e1db542f438f8817c2af14f90ffd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc18d3853ef814d567b957e1c4953b943a7a880b5350ec1086709cdebd0d16fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9abca4e85b76573ea2b7820010c5a58f400da7827a69077fb743b59a6c46c1e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03eb4d450417c93f1c2a17445a2de2969b336627bd0b040943b4113afb51bd4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ed5a106eee1e7a989edc1b3ce77d5427a4dc65838d39b8ea54b08a2068dcd0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b56f0b6c588281e943d385b964a0b438665b20d788c8bda693ea15cdcd903ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b51ff56010da4f23cee3f26d20709c24ee734d6724c5ea36f38b373ea355d197",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5778296ce75acf9bccfeccb8c8523631688853a7b96afdaebd0d01942133ed28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49269349d89a078dfde1b8f554cc7c120ecb752f9f6ad45c4ac6ac209104d793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c4a8f2a564c6ddece43ce0b8024fcea80b113998bb065b5605ba12c4b17cb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fb3ea3b2dde5b93d8be282a05004e08a47c0e5a1b10bb9c4456ddb88535d7ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82bb3f6e46507218289ee3d3182cb3e9a4523421820b566f548207cb39a3c59a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ae01f19f8b329789f73a46dd14214abf5aa39145828a4770ec6eebf8c40a2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbaaa06edeae9f50a8b6f52146323fec10e3964bb8a1eb9bd732ebab0e058975",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:451e5bb2d20d50eae10522013a4424cbc7bac6999c4ceae27a38b0c448910e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bea1d50c06fa159694effca510bdd198fe83a19d1bb3220f965202cfc5aff3a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8728ca911b70128b09cb146ac73c32f4044f993af673992ce44a40904657140c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71eac25d7f85ff1385f96b3280afa27b78add13638d30732e0c7da6122421e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7e6b99d46f9cc9255bdf01882340c3895fa09f47e3f05abc29d437c28c4357a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c675f9f21a9900c464debbc176e4f233fd5e466f85790caf475223334ce5da96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe917739d7381b94752d7d476b76dc5a05a4f1a2ad9d05c14b087dac6fe98730",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93c3236764ad57a7a33ead9c4792c5c848edb96d4a39cad322599d3af52664bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5478886debdc0fb0bd6f1d0b805111fc7918f0feb6fd6e3137695ee042c7e23d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30788cfa0c4dc4bf0e33eec7e877ad5afd88b3c0e7473db70f2b54f16c31a99b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61edb46efb85114d43ee214b000e7c5db8ba7539d52c15ab38c4588b2f1fe5d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b36d5758200da8c1ee7523981f7fba880cfcb7a8769172cfe40a582aa6ab9e3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:406c6dbc6e205f1b7763f1b3ab048e064e29b816679d6f18e807b10ba41dcc2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4ebd8344a8482ba36ffe8afa0654d8eb7f1fd468abae636bdb085904c80cbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f689a925a6e63fb8b32408e025d0bc7da594d9bd200f1b88bb805f775c8d4e46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:658f0b386e6a0edc0469072d2cd4750abad8d0d6b011a4e1c9b4ebe4f6a9eb87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2db92cf3f65d9ef14b03c11cd2301cbf65fd692b7323187fc636d812f154494b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:396e75106880ff1d7b6c7f66bb927481c949e73774111cacf31bc478258fb88e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bb4b2bf19ace59f2c02b41a00901ba37f7f312ae4cadecf2a0a9fff94140058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d1b2728f17bb7c53f68f8547c7b03586004720d0f18d9e60224250bef5676c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6daae60db3c69acbae9af383361def2a60eb6390b5886047ab4dcf56b77a0db7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd03862127458c02ef877a04e63c08763bf10331dd991dc5ab190561b0152ac5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60ef3cc7834a626eb304f47bac126a3b6cb5647b4dcf7cdf661e0f7110af90c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e358e157e98656fbc589d39107e16963148493cc84c73fd93a607adaf89abb68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65ad6c461025296532c50c1d458331f5d393c1e8eedf283fe8a23539a214ba29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60c3efc646ad20b074ab678847163ddef263eb2ee2275c53fb6814a042179638",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa743bf4a3ad980024226c2a5bf9aa308e3bb3e03530949472def8deb24f1054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5c54db2fcceb2cd653ec1f3b5fea6528fdae323f4549da331f849d032ef333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:120fc3fe006a858c3fe057177d44315e00050f9d7018f0d47bd88468ee7e05fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5efbe3456fe059cd18ef8e817906643fe9662af6d1fe9b8ea61c83a8e784d99e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c46bafc42e8cf25dc337578ca9f72171cc9b4645c10f90a78cf2d5bce8d63f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981546716f608e3bc71acfe84c0b055b4766a6d93e077d493ab2539d781ba301",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25c7f03c48523be077cbd1d5fed464831cac630d0b3ed14ebf68e08e55ac60df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b697b29c175dc6e97365a7402633f96d27653027dd77ed953a3e1e64803d8030",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80bf6d3fef106b3e83d48ab9e2f652e6d047b8e2b417d63bb96feffcd307fb59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5440e014627696f18230e1d77d0bd20053146a3fdffee0ad635686924328bbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660790f98821df598f931f837f3d45e1a79b66cd38b95eeb53082986acc66011",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4b47b784c71f0cb115017555b6daa52478515dbd0aa235889fd1d458c191db6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de0b885172739cbedad5683de66a2f517160f05d14842221d9a54ac704ef7fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5da86e8d4f12e9479d42dca504572a0eba5a55d4f09f3192d4377470abf8ed12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ba57af1907ac668cd5bdc43c5f4489fe32ceda2fec83c3f1a4dd21f066a20fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c541e2f6bb2d321434b1d604ff5e780aa76a8dcaf20197f0fcb9af2a267c5b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a557fa7e1ca46052ecedb24229019c2535a4ac39cd6eadbfbd1afb1d34613ec8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29d18439c82b2f2c50453678ebac290aed38da4c0a28ca0c4a1e37770ebf68ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4256996dd6840434459d050607a33b531e7ed8fca509c342b516bad7de897c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50777dbdd32ca74d206b209f5ae00686e7bd438adc0fe4763280eaa081dbb032",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01070876d0648658d4c3385d3687b21033e63fc6a58131c4f3e52692fdbb1472",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c2b5e81381a3b227fc66a85d6ab73cff91df9ab0c760ca0717045db97876202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa4169e7b45c1d268dcd53f85c75ab2f4ee59a7e95be0fabf323dd43e6022009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96a7944d2e9e5f7e41d460df3459f0224ed05f947ab31e19be4804b5469f9614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e67a7322914a6645e40ae31150b78fe57f212ae88bc27c605d604cdc4f27544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71d7e33f852749c12ded02d3388763c779850adb86b1b735211f464bac24f7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a406d5e0419f1c3897d8d2ac11a1466bd3ef03d436f42b38694c7f193a9acd93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:644f8deb2dd807002251cdcbfa66cba6f02740714179053f476f27beed224fd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231c7aa7fe4695b397096592e84075eda254df293b0a624810e9019854fec31c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df3ae62a5b60510dcf3896476b87d1c07b77dadc69502732c9639ee35336d6fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08d7ac543203a93295e50f9f6b9da97439e51e5dfb30aceafdb965a231b979a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e592f6c8307ddb40fc007f8d2a66867f8c7d0f4beff76880f84cf11654ccda9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44258e878350ae92392dbe8059fb37cc8276398008b050b796aa07d8308fdbd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ceefa62cc568c3ef9ac83aad5cce73779b704984b1b19eb193faf72e80869d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea5fc45daec89695603baf7ce3a2fe202dae1b5c2aa2d8749995c1472020b19f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:273e95c71b2deaad08ffc79486c429a3008354de7f4739ff8a9082ec9c69819e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f6c05c7fbc07059b053200250836e745bdfddb60e2080adb9154e4e47e0e393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3a003543ae0de3221f099f04b7720fb759839de4597a9d603cb59be37aedef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e6bc9de30ef54a9b915e68c2a34f194ed2d15638f8cc8d4c56c82ab2fbad828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de06d8c6c6188b1dc0d5ef97ee9780a50265d48a25d6fddccdca996599137abc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8e48d8c81206cc915270325b984b169b9319bf3928c46e05abedeeaf7cc25c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c8f26cd60c01a43d312e1dfd9b0d50db0d99154df1d48e7ef1b0796a0221df7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cf858d84c2b6f5563dbca1aac7500332c99320eb83a23190dea52883aa5957b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8dc38fce5d8b82bd87434b34985642228f96d612ef67a1c1aed4ea608a6f925",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c3ed639a78cb7aec8265d14b75a9a675b96aa818ec175e02feb8b427deda54b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9eb779798d0ec3ec6e7e1635ae1231bb4666f1594f4e104ef415f350ab05117",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31cc0e25f01f007595ded4f88367c0a6665051bb55604cb8d38c3e5b21811a8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b0899b800d2111f81ad70de0b66e1cf5bcf9529f94c1cd57f351099d2d25de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e302f3b841687d1d0bdfcb9b4c4c56331ac7f940f267088d397a238ec084f425",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec8932ca9d5106ef75eaaea3ce932eee3d7fd347b8242f9e80e70aa4794aed22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffa28f03275f88006907086f85035eefc0ff79af114ce4b31aa5ba29c9a64e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d91507b30c43820983784533d836280798ffc48e8b942351cbbbdc8eba20f6c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccff5d87998f1b30b5c4376cb43635d5ff9f2df94095a3892c19dbbf5d9415a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:071ef2a9dce484dc161c53dfe150904b16058a31786d0297e3802c0b28cf5198",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98a6695dc599b83dea78722586367b0bc13760df4f06d007bcb25c545b7f4ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb6fb86dcdfc4bffe551077c93cb0d2dc47d5453800ead4b46d031aa65bbafc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19be41de3f2c3ef0ac08dfc1d65231fbec2ce7f3f9c8772bcb7e0571a752f560",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2df334506379fcba46765e606dd407c364601b8fd649082a45d4159baf46872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76f00363e7c06687f5636484049ec75c8f910a25d80c2344318f2a8c769ec7e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e3d599c52c8ae682e56b0b8f680019673f165bf6e1ed3486b323ed786fa1a0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a93ca420f4dfc0f66af6c3755911fb163dc6025c6f68243a9b522d6cfa82ccec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00c38983f8630cbcbe7a433439d0bcbf8886530451ad46604b3fec3844b33216",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c386e29f37a3a5e3f7ee54964f9d815df83ea7f714e7f1a862590f18209ce0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "dos",
+              "uuid": "0xc1748067",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "06"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "83"
+                },
+                {
+                  "size": 17846272,
+                  "start": 3125248,
+                  "type": "83"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "ostree-tree": {
+                "type": "org.osbuild.ostree.checkout",
+                "origin": "org.osbuild.source",
+                "references": [
+                  ""
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-2-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b-plus.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-3-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-cm3.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2-w.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2710-rpi-zero-2.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-4-b.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-400.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bcm2711-rpi-cm4s.dtb",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/bootcode.bin",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/config.txt",
+                  "to": "mount://root/boot/efi/config.txt"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup4x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_cd.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_db.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/fixup_x.dat",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/overlays",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/share/uboot/rpi_arm64/u-boot.bin",
+                  "to": "mount://root/boot/efi/rpi-u-boot.bin"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start4x.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_cd.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_db.elf",
+                  "to": "mount://root/boot/efi/"
+                },
+                {
+                  "from": "input://ostree-tree//usr/lib/ostree-boot/efi/start_x.elf",
+                  "to": "mount://root/boot/efi/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846272
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm"
+          },
+          "sha256:00c38983f8630cbcbe7a433439d0bcbf8886530451ad46604b3fec3844b33216": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xz-libs-5.4.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:01070876d0648658d4c3385d3687b21033e63fc6a58131c4f3e52692fdbb1472": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsolv-0.7.24-4.fc39.aarch64.rpm"
+          },
+          "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/crypto-policies-scripts-20230420-1.git3d08ae7.fc39.noarch.rpm"
+          },
+          "sha256:03eb4d450417c93f1c2a17445a2de2969b336627bd0b040943b4113afb51bd4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cpio-2.14-2.fc39.aarch64.rpm"
+          },
+          "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bubblewrap-0.7.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm"
+          },
+          "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/w/whois-nls-5.5.17-1.fc39.noarch.rpm"
+          },
+          "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libselinux-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/sed-4.8-12.fc38.aarch64.rpm"
+          },
+          "sha256:071ef2a9dce484dc161c53dfe150904b16058a31786d0297e3802c0b28cf5198": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-networkd-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:08d7ac543203a93295e50f9f6b9da97439e51e5dfb30aceafdb965a231b979a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mkpasswd-5.5.17-1.fc39.aarch64.rpm"
+          },
+          "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm"
+          },
+          "sha256:120fc3fe006a858c3fe057177d44315e00050f9d7018f0d47bd88468ee7e05fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kmod-libs-30-5.fc39.aarch64.rpm"
+          },
+          "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxcrypt-4.4.33-7.fc39.aarch64.rpm"
+          },
+          "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc39.noarch.rpm"
+          },
+          "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:19be41de3f2c3ef0ac08dfc1d65231fbec2ce7f3f9c8772bcb7e0571a752f560": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-udev-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm"
+          },
+          "sha256:1c2b5e81381a3b227fc66a85d6ab73cff91df9ab0c760ca0717045db97876202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libss-1.47.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:1c386e29f37a3a5e3f7ee54964f9d815df83ea7f714e7f1a862590f18209ce0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/z/zchunk-libs-1.3.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libarchive-3.6.1-5.fc39.aarch64.rpm"
+          },
+          "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gzip-1.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:231c7aa7fe4695b397096592e84075eda254df293b0a624810e9019854fec31c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libzstd-1.5.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:25c7f03c48523be077cbd1d5fed464831cac630d0b3ed14ebf68e08e55ac60df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libattr-2.5.1-7.fc39.aarch64.rpm"
+          },
+          "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/lua-libs-5.4.4-9.fc39.aarch64.rpm"
+          },
+          "sha256:273e95c71b2deaad08ffc79486c429a3008354de7f4739ff8a9082ec9c69819e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/ostree-2023.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm"
+          },
+          "sha256:29d18439c82b2f2c50453678ebac290aed38da4c0a28ca0c4a1e37770ebf68ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libnghttp2-1.53.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm"
+          },
+          "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm"
+          },
+          "sha256:2d1b2728f17bb7c53f68f8547c7b03586004720d0f18d9e60224250bef5676c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-minimal-langpack-2.37.9000-10.fc39.aarch64.rpm"
+          },
+          "sha256:2db92cf3f65d9ef14b03c11cd2301cbf65fd692b7323187fc636d812f154494b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-2.37.9000-10.fc39.aarch64.rpm"
+          },
+          "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libssh-config-0.10.5-1.fc39.noarch.rpm"
+          },
+          "sha256:2ed5a106eee1e7a989edc1b3ce77d5427a4dc65838d39b8ea54b08a2068dcd0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/curl-8.1.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:2f6c05c7fbc07059b053200250836e745bdfddb60e2080adb9154e4e47e0e393": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/ostree-libs-2023.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:30788cfa0c4dc4bf0e33eec7e877ad5afd88b3c0e7473db70f2b54f16c31a99b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse3-libs-3.14.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/containers-common-1-90.fc39.noarch.rpm"
+          },
+          "sha256:31cc0e25f01f007595ded4f88367c0a6665051bb55604cb8d38c3e5b21811a8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-ostree-libs-2023.4-4.fc39.aarch64.rpm"
+          },
+          "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grep-3.9-1.fc39.aarch64.rpm"
+          },
+          "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm"
+          },
+          "sha256:396e75106880ff1d7b6c7f66bb927481c949e73774111cacf31bc478258fb88e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-common-2.37.9000-10.fc39.aarch64.rpm"
+          },
+          "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:3c46bafc42e8cf25dc337578ca9f72171cc9b4645c10f90a78cf2d5bce8d63f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libacl-2.3.1-7.fc39.aarch64.rpm"
+          },
+          "sha256:3cf858d84c2b6f5563dbca1aac7500332c99320eb83a23190dea52883aa5957b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python3-libs-3.11.3-2.fc39.aarch64.rpm"
+          },
+          "sha256:3e67a7322914a6645e40ae31150b78fe57f212ae88bc27c605d604cdc4f27544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc39.aarch64.rpm"
+          },
+          "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-legacy-2.5.1-6.fc39.noarch.rpm"
+          },
+          "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:406c6dbc6e205f1b7763f1b3ab048e064e29b816679d6f18e807b10ba41dcc2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-envsubst-0.21.1-3.fc39.aarch64.rpm"
+          },
+          "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:44258e878350ae92392dbe8059fb37cc8276398008b050b796aa07d8308fdbd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/npth-1.6-13.fc39.aarch64.rpm"
+          },
+          "sha256:451e5bb2d20d50eae10522013a4424cbc7bac6999c4ceae27a38b0c448910e1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc39.aarch64.rpm"
+          },
+          "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm"
+          },
+          "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-setuptools-wheel-67.7.2-2.fc39.noarch.rpm"
+          },
+          "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/j/json-c-0.16-4.fc38.aarch64.rpm"
+          },
+          "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm"
+          },
+          "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:49269349d89a078dfde1b8f554cc7c120ecb752f9f6ad45c4ac6ac209104d793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/diffutils-3.9-4.fc39.aarch64.rpm"
+          },
+          "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm"
+          },
+          "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:4ba57af1907ac668cd5bdc43c5f4489fe32ceda2fec83c3f1a4dd21f066a20fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgpg-error-1.47-1.fc39.aarch64.rpm"
+          },
+          "sha256:4bb4b2bf19ace59f2c02b41a00901ba37f7f312ae4cadecf2a0a9fff94140058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-gconv-extra-2.37.9000-10.fc39.aarch64.rpm"
+          },
+          "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:4e592f6c8307ddb40fc007f8d2a66867f8c7d0f4beff76880f84cf11654ccda9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/ncurses-libs-6.4-4.20230520.fc39.aarch64.rpm"
+          },
+          "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:50777dbdd32ca74d206b209f5ae00686e7bd438adc0fe4763280eaa081dbb032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsmartcols-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:51b0899b800d2111f81ad70de0b66e1cf5bcf9529f94c1cd57f351099d2d25de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-plugin-selinux-4.18.90-9.fc39.aarch64.rpm"
+          },
+          "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-misc-2.5.1-6.fc39.noarch.rpm"
+          },
+          "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsepol-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/w/which-2.21-39.fc39.aarch64.rpm"
+          },
+          "sha256:5478886debdc0fb0bd6f1d0b805111fc7918f0feb6fd6e3137695ee042c7e23d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse3-3.14.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:5778296ce75acf9bccfeccb8c8523631688853a7b96afdaebd0d01942133ed28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/device-mapper-libs-1.02.195-1.fc39.aarch64.rpm"
+          },
+          "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm"
+          },
+          "sha256:5c541e2f6bb2d321434b1d604ff5e780aa76a8dcaf20197f0fcb9af2a267c5b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libmodulemd-2.15.0-3.fc39.aarch64.rpm"
+          },
+          "sha256:5c8f26cd60c01a43d312e1dfd9b0d50db0d99154df1d48e7ef1b0796a0221df7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python3-3.11.3-2.fc39.aarch64.rpm"
+          },
+          "sha256:5da86e8d4f12e9479d42dca504572a0eba5a55d4f09f3192d4377470abf8ed12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgomp-13.1.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:5efbe3456fe059cd18ef8e817906643fe9662af6d1fe9b8ea61c83a8e784d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kpartx-0.9.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:60c3efc646ad20b074ab678847163ddef263eb2ee2275c53fb6814a042179638": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc39.aarch64.rpm"
+          },
+          "sha256:60ef3cc7834a626eb304f47bac126a3b6cb5647b4dcf7cdf661e0f7110af90c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnutls-3.8.0-3.fc39.aarch64.rpm"
+          },
+          "sha256:61edb46efb85114d43ee214b000e7c5db8ba7539d52c15ab38c4588b2f1fe5d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gawk-5.2.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:644f8deb2dd807002251cdcbfa66cba6f02740714179053f476f27beed224fd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxml2-2.10.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:658f0b386e6a0edc0469072d2cd4750abad8d0d6b011a4e1c9b4ebe4f6a9eb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glib2-2.76.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:65ad6c461025296532c50c1d458331f5d393c1e8eedf283fe8a23539a214ba29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-tools-2.06-95.fc39.aarch64.rpm"
+          },
+          "sha256:660790f98821df598f931f837f3d45e1a79b66cd38b95eeb53082986acc66011": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libfdisk-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/selinux-policy-38.14-1.fc39.noarch.rpm"
+          },
+          "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/popt-1.19-2.fc38.aarch64.rpm"
+          },
+          "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-common-39-0.14.noarch.rpm"
+          },
+          "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm"
+          },
+          "sha256:6daae60db3c69acbae9af383361def2a60eb6390b5886047ab4dcf56b77a0db7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnupg2-2.4.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm"
+          },
+          "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/selinux-policy-targeted-38.14-1.fc39.noarch.rpm"
+          },
+          "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm"
+          },
+          "sha256:71d7e33f852749c12ded02d3388763c779850adb86b1b735211f464bac24f7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libutempter-1.2.1-9.fc39.aarch64.rpm"
+          },
+          "sha256:71eac25d7f85ff1385f96b3280afa27b78add13638d30732e0c7da6122421e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/file-5.44-3.fc39.aarch64.rpm"
+          },
+          "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm"
+          },
+          "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:76f00363e7c06687f5636484049ec75c8f910a25d80c2344318f2a8c769ec7e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/u/util-linux-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/policycoreutils-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm"
+          },
+          "sha256:7c3ed639a78cb7aec8265d14b75a9a675b96aa818ec175e02feb8b427deda54b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-libs-4.18.90-9.fc39.aarch64.rpm"
+          },
+          "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:7e6bc9de30ef54a9b915e68c2a34f194ed2d15638f8cc8d4c56c82ab2fbad828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pam-libs-1.5.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm"
+          },
+          "sha256:80bf6d3fef106b3e83d48ab9e2f652e6d047b8e2b417d63bb96feffcd307fb59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcom_err-1.47.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:82bb3f6e46507218289ee3d3182cb3e9a4523421820b566f548207cb39a3c59a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/duktape-2.7.0-4.fc39.aarch64.rpm"
+          },
+          "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-pip-wheel-23.1.2-1.fc39.noarch.rpm"
+          },
+          "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:8728ca911b70128b09cb146ac73c32f4044f993af673992ce44a40904657140c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-libs-0.189-2.fc39.aarch64.rpm"
+          },
+          "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm"
+          },
+          "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm"
+          },
+          "sha256:8e3d599c52c8ae682e56b0b8f680019673f165bf6e1ed3486b323ed786fa1a0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/u/util-linux-core-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm"
+          },
+          "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-repos-39-0.1.noarch.rpm"
+          },
+          "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gpgme-1.17.1-5.fc39.aarch64.rpm"
+          },
+          "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grubby-8.40-70.fc39.aarch64.rpm"
+          },
+          "sha256:93c3236764ad57a7a33ead9c4792c5c848edb96d4a39cad322599d3af52664bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-overlayfs-1.12-1.fc39.aarch64.rpm"
+          },
+          "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm"
+          },
+          "sha256:96a7944d2e9e5f7e41d460df3459f0224ed05f947ab31e19be4804b5469f9614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libstdc++-13.1.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:976b142af334f9c6ba1628644f6813f3a3430a88aa587730b87b9b089696282b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/alternatives-1.24-1.fc39.aarch64.rpm"
+          },
+          "sha256:981546716f608e3bc71acfe84c0b055b4766a6d93e077d493ab2539d781ba301": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libatomic-13.1.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:98a6695dc599b83dea78722586367b0bc13760df4f06d007bcb25c545b7f4ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-pam-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:9abca4e85b76573ea2b7820010c5a58f400da7827a69077fb743b59a6c46c1e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/coreutils-common-9.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:9ceefa62cc568c3ef9ac83aad5cce73779b704984b1b19eb193faf72e80869d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openldap-2.6.4-2.fc39.aarch64.rpm"
+          },
+          "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm"
+          },
+          "sha256:9fb3ea3b2dde5b93d8be282a05004e08a47c0e5a1b10bb9c4456ddb88535d7ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dracut-config-generic-059-7.fc39.aarch64.rpm"
+          },
+          "sha256:a3a003543ae0de3221f099f04b7720fb759839de4597a9d603cb59be37aedef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pam-1.5.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:a406d5e0419f1c3897d8d2ac11a1466bd3ef03d436f42b38694c7f193a9acd93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libuuid-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:a557fa7e1ca46052ecedb24229019c2535a4ac39cd6eadbfbd1afb1d34613ec8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libmount-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/krb5-libs-1.20.1-9.fc39.aarch64.rpm"
+          },
+          "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcap-2.48-6.fc38.aarch64.rpm"
+          },
+          "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-identity-basic-39-0.14.noarch.rpm"
+          },
+          "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libselinux-utils-3.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:a8dc38fce5d8b82bd87434b34985642228f96d612ef67a1c1aed4ea608a6f925": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-4.18.90-9.fc39.aarch64.rpm"
+          },
+          "sha256:a93ca420f4dfc0f66af6c3755911fb163dc6025c6f68243a9b522d6cfa82ccec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xz-5.4.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm"
+          },
+          "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/ncurses-base-6.4-4.20230520.fc39.noarch.rpm"
+          },
+          "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/filesystem-3.18-4.fc39.aarch64.rpm"
+          },
+          "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm"
+          },
+          "sha256:b2ae01f19f8b329789f73a46dd14214abf5aa39145828a4770ec6eebf8c40a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/e2fsprogs-1.47.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:b36d5758200da8c1ee7523981f7fba880cfcb7a8769172cfe40a582aa6ab9e3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gawk-all-langpacks-5.2.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:b51ff56010da4f23cee3f26d20709c24ee734d6724c5ea36f38b373ea355d197": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/device-mapper-1.02.195-1.fc39.aarch64.rpm"
+          },
+          "sha256:b56f0b6c588281e943d385b964a0b438665b20d788c8bda693ea15cdcd903ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cyrus-sasl-lib-2.1.28-10.fc39.aarch64.rpm"
+          },
+          "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:b697b29c175dc6e97365a7402633f96d27653027dd77ed953a3e1e64803d8030": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libblkid-2.39-4.fc39.aarch64.rpm"
+          },
+          "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcbor-0.10.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm"
+          },
+          "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:bc18d3853ef814d567b957e1c4953b943a7a880b5350ec1086709cdebd0d16fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/coreutils-9.3-1.fc39.aarch64.rpm"
+          },
+          "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc39.noarch.rpm"
+          },
+          "sha256:bea1d50c06fa159694effca510bdd198fe83a19d1bb3220f965202cfc5aff3a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-libelf-0.189-2.fc39.aarch64.rpm"
+          },
+          "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm"
+          },
+          "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/container-selinux-2.215.0-2.fc39.noarch.rpm"
+          },
+          "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm"
+          },
+          "sha256:c675f9f21a9900c464debbc176e4f233fd5e466f85790caf475223334ce5da96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/findutils-4.9.0-4.fc39.aarch64.rpm"
+          },
+          "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm"
+          },
+          "sha256:c7e6b99d46f9cc9255bdf01882340c3895fa09f47e3f05abc29d437c28c4357a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/file-libs-5.44-3.fc39.aarch64.rpm"
+          },
+          "sha256:c9eb779798d0ec3ec6e7e1635ae1231bb4666f1594f4e104ef415f350ab05117": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-ostree-2023.4-4.fc39.aarch64.rpm"
+          },
+          "sha256:cbaaa06edeae9f50a8b6f52146323fec10e3964bb8a1eb9bd732ebab0e058975": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/e2fsprogs-libs-1.47.0-1.fc39.aarch64.rpm"
+          },
+          "sha256:ccff5d87998f1b30b5c4376cb43635d5ff9f2df94095a3892c19dbbf5d9415a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-libs-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-39-0.14.noarch.rpm"
+          },
+          "sha256:ceccc96466a361367f3261f28d499a66352e1db542f438f8817c2af14f90ffd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/audit-libs-3.1.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm"
+          },
+          "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/nettle-3.8-3.fc38.aarch64.rpm"
+          },
+          "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pigz-2.7-3.fc38.aarch64.rpm"
+          },
+          "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm"
+          },
+          "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc39.noarch.rpm"
+          },
+          "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm"
+          },
+          "sha256:d8e48d8c81206cc915270325b984b169b9319bf3928c46e05abedeeaf7cc25c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-libs-122-5.fc39.aarch64.rpm"
+          },
+          "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/crypto-policies-20230420-1.git3d08ae7.fc39.noarch.rpm"
+          },
+          "sha256:d91507b30c43820983784533d836280798ffc48e8b942351cbbbdc8eba20f6c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm"
+          },
+          "sha256:da5c54db2fcceb2cd653ec1f3b5fea6528fdae323f4549da331f849d032ef333": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kmod-30-5.fc39.aarch64.rpm"
+          },
+          "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm"
+          },
+          "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm"
+          },
+          "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm"
+          },
+          "sha256:de06d8c6c6188b1dc0d5ef97ee9780a50265d48a25d6fddccdca996599137abc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-122-5.fc39.aarch64.rpm"
+          },
+          "sha256:de0b885172739cbedad5683de66a2f517160f05d14842221d9a54ac704ef7fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgcrypt-1.10.2-1.fc39.aarch64.rpm"
+          },
+          "sha256:df3ae62a5b60510dcf3896476b87d1c07b77dadc69502732c9639ee35336d6fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/lz4-libs-1.9.4-3.fc39.aarch64.rpm"
+          },
+          "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/setup-2.14.3-3.fc39.noarch.rpm"
+          },
+          "sha256:e2df334506379fcba46765e606dd407c364601b8fd649082a45d4159baf46872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tpm2-tools-5.5-3.fc39.aarch64.rpm"
+          },
+          "sha256:e302f3b841687d1d0bdfcb9b4c4c56331ac7f940f267088d397a238ec084f425": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc39.aarch64.rpm"
+          },
+          "sha256:e358e157e98656fbc589d39107e16963148493cc84c73fd93a607adaf89abb68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-efi-aa64-2.06-95.fc39.aarch64.rpm"
+          },
+          "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm"
+          },
+          "sha256:e4b47b784c71f0cb115017555b6daa52478515dbd0aa235889fd1d458c191db6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgcc-13.1.1-2.fc39.aarch64.rpm"
+          },
+          "sha256:e5440e014627696f18230e1d77d0bd20053146a3fdffee0ad635686924328bbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcurl-8.1.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:e5c4a8f2a564c6ddece43ce0b8024fcea80b113998bb065b5605ba12c4b17cb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dracut-059-7.fc39.aarch64.rpm"
+          },
+          "sha256:ea5fc45daec89695603baf7ce3a2fe202dae1b5c2aa2d8749995c1472020b19f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openssl-libs-3.0.8-2.fc39.aarch64.rpm"
+          },
+          "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm"
+          },
+          "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm"
+          },
+          "sha256:ec8932ca9d5106ef75eaaea3ce932eee3d7fd347b8242f9e80e70aa4794aed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/skopeo-1.12.0-2.fc39.aarch64.rpm"
+          },
+          "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/readline-8.2-3.fc38.aarch64.rpm"
+          },
+          "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm"
+          },
+          "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libfido2-1.13.0-2.fc39.aarch64.rpm"
+          },
+          "sha256:f4256996dd6840434459d050607a33b531e7ed8fca509c342b516bad7de897c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsemanage-3.5-2.fc39.aarch64.rpm"
+          },
+          "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-common-2.06-95.fc39.noarch.rpm"
+          },
+          "sha256:f689a925a6e63fb8b32408e025d0bc7da594d9bd200f1b88bb805f775c8d4e46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-runtime-0.21.1-3.fc39.aarch64.rpm"
+          },
+          "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:fa4169e7b45c1d268dcd53f85c75ab2f4ee59a7e95be0fabf323dd43e6022009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libssh-0.10.5-1.fc39.aarch64.rpm"
+          },
+          "sha256:fa743bf4a3ad980024226c2a5bf9aa308e3bb3e03530949472def8deb24f1054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-2.5.1-6.fc39.aarch64.rpm"
+          },
+          "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/shadow-utils-4.13-6.fc39.aarch64.rpm"
+          },
+          "sha256:fb6fb86dcdfc4bffe551077c93cb0d2dc47d5453800ead4b46d031aa65bbafc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-resolved-253.4-1.fc39.aarch64.rpm"
+          },
+          "sha256:fc4ebd8344a8482ba36ffe8afa0654d8eb7f1fd468abae636bdb085904c80cbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-libs-0.21.1-3.fc39.aarch64.rpm"
+          },
+          "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm"
+          },
+          "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tzdata-2023c-1.fc39.noarch.rpm"
+          },
+          "sha256:fd03862127458c02ef877a04e63c08763bf10331dd991dc5ab190561b0152ac5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnupg2-smime-2.4.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm"
+          },
+          "sha256:fe917739d7381b94752d7d476b76dc5a05a4f1a2ad9d05c14b087dac6fe98730": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-common-3.14.1-1.fc39.aarch64.rpm"
+          },
+          "sha256:ffa28f03275f88006907086f85035eefc0ff79af114ce4b31aa5ba29c9a64e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/sqlite-libs-3.41.2-2.fc39.aarch64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/alternatives-1.24-1.fc39.aarch64.rpm",
+        "checksum": "sha256:976b142af334f9c6ba1628644f6813f3a3430a88aa587730b87b9b089696282b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/audit-libs-3.1.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:ceccc96466a361367f3261f28d499a66352e1db542f438f8817c2af14f90ffd3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/authselect-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:db7a0a01b05d540e8f7f4bc9e967ceb27647f710beff3a33bceeba56381517f3",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/a/authselect-libs-1.4.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:41a149bfa3edb610eb47716c7e433cade50e898bc71ef0dac39f5390916eb500",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bash-5.2.15-3.fc38.aarch64.rpm",
+        "checksum": "sha256:743c19b00671966ad2f10a08127e52f865e66318e2e538a17afe0de30b5a021d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bubblewrap-0.7.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:047b9b3feb3a7c8f4fd26ddd908e6c0a436827b7e73a3fe7af6a0bac9857887c",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/b/bzip2-libs-1.0.8-13.fc38.aarch64.rpm",
+        "checksum": "sha256:8d071598ec4b502e566d62d160b0f62f2c97a6cd1c9b14a8a238358ae3efc169",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/container-selinux-2.215.0-2.fc39.noarch.rpm",
+        "checksum": "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "90.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/containers-common-1-90.fc39.noarch.rpm",
+        "checksum": "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/coreutils-9.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:bc18d3853ef814d567b957e1c4953b943a7a880b5350ec1086709cdebd0d16fe",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/coreutils-common-9.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:9abca4e85b76573ea2b7820010c5a58f400da7827a69077fb743b59a6c46c1e7",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cpio-2.14-2.fc39.aarch64.rpm",
+        "checksum": "sha256:03eb4d450417c93f1c2a17445a2de2969b336627bd0b040943b4113afb51bd4d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cracklib-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:759661a23273cb8a1fbfd9885aa8e596b4787431701cd2cda75ed91d184ec4c0",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cracklib-dicts-2.9.7-31.fc38.aarch64.rpm",
+        "checksum": "sha256:dcb34a02699a1d5363abfe91b6f485c58fbf11bd4b67ae7c94779972156d8d2b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230420",
+        "release": "1.git3d08ae7.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/crypto-policies-20230420-1.git3d08ae7.fc39.noarch.rpm",
+        "checksum": "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230420",
+        "release": "1.git3d08ae7.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/crypto-policies-scripts-20230420-1.git3d08ae7.fc39.noarch.rpm",
+        "checksum": "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:aefb3f2011381702ef4f32b6c0f7fcdd44b81fea883fea01f514d0219f6f2447",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "8.1.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/curl-8.1.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:2ed5a106eee1e7a989edc1b3ce77d5427a4dc65838d39b8ea54b08a2068dcd0f",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "10.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/c/cyrus-sasl-lib-2.1.28-10.fc39.aarch64.rpm",
+        "checksum": "sha256:b56f0b6c588281e943d385b964a0b438665b20d788c8bda693ea15cdcd903ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-1.14.6-1.fc38.aarch64.rpm",
+        "checksum": "sha256:4a1609cfe80410fe13237771548eea4631ccbac69f6915e4d21918016f8a8677",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-broker-33-1.fc38.aarch64.rpm",
+        "checksum": "sha256:e44b1735f41ec275ccf5c8718c1cc718f2cb7ff7c16d1868fb0521d862a407fb",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.195",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/device-mapper-1.02.195-1.fc39.aarch64.rpm",
+        "checksum": "sha256:b51ff56010da4f23cee3f26d20709c24ee734d6724c5ea36f38b373ea355d197",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.195",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/device-mapper-libs-1.02.195-1.fc39.aarch64.rpm",
+        "checksum": "sha256:5778296ce75acf9bccfeccb8c8523631688853a7b96afdaebd0d01942133ed28",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/diffutils-3.9-4.fc39.aarch64.rpm",
+        "checksum": "sha256:49269349d89a078dfde1b8f554cc7c120ecb752f9f6ad45c4ac6ac209104d793",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dosfstools-4.2-6.fc38.aarch64.rpm",
+        "checksum": "sha256:0c11e634fc2571a811eded10a912538838093706011e1785b9cc7b17a940b432",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dracut-059-7.fc39.aarch64.rpm",
+        "checksum": "sha256:e5c4a8f2a564c6ddece43ce0b8024fcea80b113998bb065b5605ba12c4b17cb6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/dracut-config-generic-059-7.fc39.aarch64.rpm",
+        "checksum": "sha256:9fb3ea3b2dde5b93d8be282a05004e08a47c0e5a1b10bb9c4456ddb88535d7ea",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/d/duktape-2.7.0-4.fc39.aarch64.rpm",
+        "checksum": "sha256:82bb3f6e46507218289ee3d3182cb3e9a4523421820b566f548207cb39a3c59a",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/e2fsprogs-1.47.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:b2ae01f19f8b329789f73a46dd14214abf5aa39145828a4770ec6eebf8c40a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/e2fsprogs-libs-1.47.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:cbaaa06edeae9f50a8b6f52146323fec10e3964bb8a1eb9bd732ebab0e058975",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efibootmgr-18-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c01590f3d237e302c0a9b8dac586469d1b58f37da29b1b815b1b2ae083944470",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/efivar-libs-38-7.fc38.aarch64.rpm",
+        "checksum": "sha256:2bab8311915e4fdfcc2749558770cfbe63c7a1fad686094d116301c2b42a8109",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc39.aarch64.rpm",
+        "checksum": "sha256:451e5bb2d20d50eae10522013a4424cbc7bac6999c4ceae27a38b0c448910e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc39.noarch.rpm",
+        "checksum": "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-libelf-0.189-2.fc39.aarch64.rpm",
+        "checksum": "sha256:bea1d50c06fa159694effca510bdd198fe83a19d1bb3220f965202cfc5aff3a6",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/elfutils-libs-0.189-2.fc39.aarch64.rpm",
+        "checksum": "sha256:8728ca911b70128b09cb146ac73c32f4044f993af673992ce44a40904657140c",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/e/expat-2.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:7d7d603328d401296327ee05b8fc308cd7a781f71188f6c0e0e4bb3b967624fd",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm",
+        "checksum": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-39-0.14.noarch.rpm",
+        "checksum": "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-common-39-0.14.noarch.rpm",
+        "checksum": "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-release-identity-basic-39-0.14.noarch.rpm",
+        "checksum": "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-repos-39-0.1.noarch.rpm",
+        "checksum": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm",
+        "checksum": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/file-5.44-3.fc39.aarch64.rpm",
+        "checksum": "sha256:71eac25d7f85ff1385f96b3280afa27b78add13638d30732e0c7da6122421e67",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/file-libs-5.44-3.fc39.aarch64.rpm",
+        "checksum": "sha256:c7e6b99d46f9cc9255bdf01882340c3895fa09f47e3f05abc29d437c28c4357a",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/filesystem-3.18-4.fc39.aarch64.rpm",
+        "checksum": "sha256:afe5493369ba96307895e423c10e3c6689a56541c7cc794f5ccd0e79387d8220",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/findutils-4.9.0-4.fc39.aarch64.rpm",
+        "checksum": "sha256:c675f9f21a9900c464debbc176e4f233fd5e466f85790caf475223334ce5da96",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:3aa089143e2c45970439dc09f3cfc3c4500319a2f5785b6068899cdb02a1f83f",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-common-3.14.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:fe917739d7381b94752d7d476b76dc5a05a4f1a2ad9d05c14b087dac6fe98730",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-libs-2.9.9-16.fc38.aarch64.rpm",
+        "checksum": "sha256:ebde9d7dd013fdb8e8f3ffa45638f394de1202facbbe81eac6c23c1dec068c85",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse-overlayfs-1.12-1.fc39.aarch64.rpm",
+        "checksum": "sha256:93c3236764ad57a7a33ead9c4792c5c848edb96d4a39cad322599d3af52664bc",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse3-3.14.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:5478886debdc0fb0bd6f1d0b805111fc7918f0feb6fd6e3137695ee042c7e23d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/f/fuse3-libs-3.14.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:30788cfa0c4dc4bf0e33eec7e877ad5afd88b3c0e7473db70f2b54f16c31a99b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gawk-5.2.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:61edb46efb85114d43ee214b000e7c5db8ba7539d52c15ab38c4588b2f1fe5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gawk-all-langpacks-5.2.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:b36d5758200da8c1ee7523981f7fba880cfcb7a8769172cfe40a582aa6ab9e3f",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gdbm-libs-1.23-3.fc38.aarch64.rpm",
+        "checksum": "sha256:70a8414ed24797eba9fa8cde6224ac222774ce808537abd5bdc8763484d6c146",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-envsubst-0.21.1-3.fc39.aarch64.rpm",
+        "checksum": "sha256:406c6dbc6e205f1b7763f1b3ab048e064e29b816679d6f18e807b10ba41dcc2a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-libs-0.21.1-3.fc39.aarch64.rpm",
+        "checksum": "sha256:fc4ebd8344a8482ba36ffe8afa0654d8eb7f1fd468abae636bdb085904c80cbd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gettext-runtime-0.21.1-3.fc39.aarch64.rpm",
+        "checksum": "sha256:f689a925a6e63fb8b32408e025d0bc7da594d9bd200f1b88bb805f775c8d4e46",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.76.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glib2-2.76.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:658f0b386e6a0edc0469072d2cd4750abad8d0d6b011a4e1c9b4ebe4f6a9eb87",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-2.37.9000-10.fc39.aarch64.rpm",
+        "checksum": "sha256:2db92cf3f65d9ef14b03c11cd2301cbf65fd692b7323187fc636d812f154494b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-common-2.37.9000-10.fc39.aarch64.rpm",
+        "checksum": "sha256:396e75106880ff1d7b6c7f66bb927481c949e73774111cacf31bc478258fb88e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-gconv-extra-2.37.9000-10.fc39.aarch64.rpm",
+        "checksum": "sha256:4bb4b2bf19ace59f2c02b41a00901ba37f7f312ae4cadecf2a0a9fff94140058",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/glibc-minimal-langpack-2.37.9000-10.fc39.aarch64.rpm",
+        "checksum": "sha256:2d1b2728f17bb7c53f68f8547c7b03586004720d0f18d9e60224250bef5676c0",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gmp-6.2.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:1fce9ea5c004b04b39bceb83069c2791f4f725639be52f94a0eb438bd1087be3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnupg2-2.4.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:6daae60db3c69acbae9af383361def2a60eb6390b5886047ab4dcf56b77a0db7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnupg2-smime-2.4.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:fd03862127458c02ef877a04e63c08763bf10331dd991dc5ab190561b0152ac5",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gnutls-3.8.0-3.fc39.aarch64.rpm",
+        "checksum": "sha256:60ef3cc7834a626eb304f47bac126a3b6cb5647b4dcf7cdf661e0f7110af90c0",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gpgme-1.17.1-5.fc39.aarch64.rpm",
+        "checksum": "sha256:8fb14724ad07464e9da98e15badb7523c299f6188a39bf65e02bbccfde8b44a5",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grep-3.9-1.fc39.aarch64.rpm",
+        "checksum": "sha256:37bbecfe2755c8fe18722b8ce7a939bbaad2e9d1bf21e4d74b81041ca64df00f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-common-2.06-95.fc39.noarch.rpm",
+        "checksum": "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-efi-aa64-2.06-95.fc39.aarch64.rpm",
+        "checksum": "sha256:e358e157e98656fbc589d39107e16963148493cc84c73fd93a607adaf89abb68",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-tools-2.06-95.fc39.aarch64.rpm",
+        "checksum": "sha256:65ad6c461025296532c50c1d458331f5d393c1e8eedf283fe8a23539a214ba29",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc39.aarch64.rpm",
+        "checksum": "sha256:60c3efc646ad20b074ab678847163ddef263eb2ee2275c53fb6814a042179638",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "70.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/grubby-8.40-70.fc39.aarch64.rpm",
+        "checksum": "sha256:91a4beb90b9cd9bfcc46d5262116e682ffe2be99591759a2a0437bfd3c9b394e",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/g/gzip-1.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:1ff4a903b24533b661ca8d5f40d1fc0087da8de2cfad3a544adeb8037ae7e8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/j/json-c-0.16-4.fc38.aarch64.rpm",
+        "checksum": "sha256:47edf9a5d80e60334b0523f36a86b40b430a55c1afc91232181961152a3c8f25",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/j/json-glib-1.6.6-4.fc38.aarch64.rpm",
+        "checksum": "sha256:7b91df9b6fbeec00604181db29069eda114926e290e0acc3cfc8d7f74118db0c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-2.5.1-6.fc39.aarch64.rpm",
+        "checksum": "sha256:fa743bf4a3ad980024226c2a5bf9aa308e3bb3e03530949472def8deb24f1054",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-legacy-2.5.1-6.fc39.noarch.rpm",
+        "checksum": "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kbd-misc-2.5.1-6.fc39.noarch.rpm",
+        "checksum": "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/keyutils-libs-1.6.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:a6810adc621e586b0cefd779767e2a962ed18f4f1267a05fab8a94a1593e12be",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kmod-30-5.fc39.aarch64.rpm",
+        "checksum": "sha256:da5c54db2fcceb2cd653ec1f3b5fea6528fdae323f4549da331f849d032ef333",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kmod-libs-30-5.fc39.aarch64.rpm",
+        "checksum": "sha256:120fc3fe006a858c3fe057177d44315e00050f9d7018f0d47bd88468ee7e05fc",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/kpartx-0.9.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:5efbe3456fe059cd18ef8e817906643fe9662af6d1fe9b8ea61c83a8e784d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/k/krb5-libs-1.20.1-9.fc39.aarch64.rpm",
+        "checksum": "sha256:a5d131c1a4b194e5aab7e7925c524562d20b6e7b08a0e24045b0d11634c59c12",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libacl-2.3.1-7.fc39.aarch64.rpm",
+        "checksum": "sha256:3c46bafc42e8cf25dc337578ca9f72171cc9b4645c10f90a78cf2d5bce8d63f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libarchive-3.6.1-5.fc39.aarch64.rpm",
+        "checksum": "sha256:1c49f0eb53cb43c935cc6d155ebd3d6353d17b23e0e8f69f8a984d7dc65f6ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libargon2-20190702-2.fc38.aarch64.rpm",
+        "checksum": "sha256:0061480328390c3954b9e497aa6ab8bc62eb279e6efd050965661fd79a70e3b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libassuan-2.5.5-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d164fbd54f9921913cc39b71fc00d2a27b24f796e385e6e6a86502f6357958da",
+        "check_gpg": true
+      },
+      {
+        "name": "libatomic",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libatomic-13.1.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:981546716f608e3bc71acfe84c0b055b4766a6d93e077d493ab2539d781ba301",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libattr-2.5.1-7.fc39.aarch64.rpm",
+        "checksum": "sha256:25c7f03c48523be077cbd1d5fed464831cac630d0b3ed14ebf68e08e55ac60df",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libb2-0.98.1-8.fc38.aarch64.rpm",
+        "checksum": "sha256:9e9cec829b408d471e732cd8a9e54babefded5234a31b2b6e81b8907e9bd9fd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libblkid-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:b697b29c175dc6e97365a7402633f96d27653027dd77ed953a3e1e64803d8030",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libbrotli-1.0.9-11.fc38.aarch64.rpm",
+        "checksum": "sha256:ea903340bb561eb07e43a9d3659badceb2992696015f1869b42e2c8932158d5c",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcap-2.48-6.fc38.aarch64.rpm",
+        "checksum": "sha256:a63abb2c9c20877409f8b7a74c7fef52c8ad701219a206e52ba20c9fe03da376",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcap-ng-0.8.3-5.fc38.aarch64.rpm",
+        "checksum": "sha256:487fb0cea28d207da310d7d8e7e298ed4784e21bc198cf44b4f8ae1303c9abe7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.10.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcbor-0.10.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:b799e33ca82fca0be8ffe86202c725912e46ea61d160a957502424a40f095e1f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcom_err-1.47.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:80bf6d3fef106b3e83d48ab9e2f652e6d047b8e2b417d63bb96feffcd307fb59",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "8.1.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libcurl-8.1.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:e5440e014627696f18230e1d77d0bd20053146a3fdffee0ad635686924328bbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libdb-5.3.28-55.fc38.aarch64.rpm",
+        "checksum": "sha256:db3f92441621b09e664be6790e6a279c036688093e7a5175927cda394756c214",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libeconf-0.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:9bcccd2b110d8a6a3d07a7aeed82b4416db762a22239346839838445a0a870d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libevent-2.1.12-8.fc38.aarch64.rpm",
+        "checksum": "sha256:c7a71bdfdb966bbc2166e214aca99d324e16e8a0623246ed8664be8be7a56aa0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libfdisk-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:660790f98821df598f931f837f3d45e1a79b66cd38b95eeb53082986acc66011",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libffi-3.4.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:fdcd3745c2206fed259467bd49a96344c15a192952bc6f04b070e8b2995085dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libfido2-1.13.0-2.fc39.aarch64.rpm",
+        "checksum": "sha256:f3b9a49762bbfa7832b11514eaf441eec3431a174ec257607cbb221d7014cf44",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgcc-13.1.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:e4b47b784c71f0cb115017555b6daa52478515dbd0aa235889fd1d458c191db6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgcrypt-1.10.2-1.fc39.aarch64.rpm",
+        "checksum": "sha256:de0b885172739cbedad5683de66a2f517160f05d14842221d9a54ac704ef7fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgomp-13.1.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:5da86e8d4f12e9479d42dca504572a0eba5a55d4f09f3192d4377470abf8ed12",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libgpg-error-1.47-1.fc39.aarch64.rpm",
+        "checksum": "sha256:4ba57af1907ac668cd5bdc43c5f4489fe32ceda2fec83c3f1a4dd21f066a20fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libidn2-2.3.4-2.fc38.aarch64.rpm",
+        "checksum": "sha256:55756638296d53fdc9dd8c6b46c29bac98c890cfd9d558fec3aefa3406b358a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libkcapi-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:b676e51dda545d40276b27e5b39adb68a26611ee2f2881efca9a63a99dbc5674",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:d79bd2d236c80c08037c820c56ecfd85faaa227af10b08ef96540e1fbb5623b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libksba-1.6.3-2.fc38.aarch64.rpm",
+        "checksum": "sha256:19ca5402cac14d896f0422469446a4ad2157909ac383d611918f0436be1aa7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libmodulemd-2.15.0-3.fc39.aarch64.rpm",
+        "checksum": "sha256:5c541e2f6bb2d321434b1d604ff5e780aa76a8dcaf20197f0fcb9af2a267c5b3",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libmount-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:a557fa7e1ca46052ecedb24229019c2535a4ac39cd6eadbfbd1afb1d34613ec8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libnghttp2-1.53.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:29d18439c82b2f2c50453678ebac290aed38da4c0a28ca0c4a1e37770ebf68ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libnsl2-2.0.0-5.fc38.aarch64.rpm",
+        "checksum": "sha256:4b9f156faebae07f512e2e22a6d104e86bc9fc86056dcde54ae1eb87ca057eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libpsl-0.21.2-2.fc38.aarch64.rpm",
+        "checksum": "sha256:4e266ae94a5854f59791cb040dd6e3ecc89a7c87590122a5161991b351d5408b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libpwquality-1.4.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:52b8c81f48a48855c95c65eb166dff0130d80948d3128ad3cd295e643b278d74",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/librepo-1.15.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:8e7220bd2de39708cd2be2788c4c3bd95bf12590260ced37673849b892dec309",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libseccomp-2.5.3-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5bb6e5af81ec4523bda8aa99eff6940eec288d9e45ed354796a1aba58a8f531d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsecret-0.20.5-3.fc38.aarch64.rpm",
+        "checksum": "sha256:6dd14c7a6678bca18e33694e37d8e26cd6cb165165a4acb04fbeb019d0edf05f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libselinux-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:0667adcc1838d0193392fbded9d354955b2c591d5526930e30f2b083215975af",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libselinux-utils-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a78cc23b4f327c88acfe7a57fc24419563efd94e44987ed7b23ffaad3c0cfea7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsemanage-3.5-2.fc39.aarch64.rpm",
+        "checksum": "sha256:f4256996dd6840434459d050607a33b531e7ed8fca509c342b516bad7de897c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsepol-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:529bcb4c6d2060c8fce9b52bd8fb4cfbb807df374281a4e0d69e7c905df662e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsigsegv-2.14-4.fc38.aarch64.rpm",
+        "checksum": "sha256:6b1a20e0fc39a72fd9e555ee7aa9975276427524508d48250d0bcf1f8f8de0f7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsmartcols-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:50777dbdd32ca74d206b209f5ae00686e7bd438adc0fe4763280eaa081dbb032",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.24",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libsolv-0.7.24-4.fc39.aarch64.rpm",
+        "checksum": "sha256:01070876d0648658d4c3385d3687b21033e63fc6a58131c4f3e52692fdbb1472",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libss-1.47.0-1.fc39.aarch64.rpm",
+        "checksum": "sha256:1c2b5e81381a3b227fc66a85d6ab73cff91df9ab0c760ca0717045db97876202",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libssh-0.10.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:fa4169e7b45c1d268dcd53f85c75ab2f4ee59a7e95be0fabf323dd43e6022009",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libssh-config-0.10.5-1.fc39.noarch.rpm",
+        "checksum": "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libstdc++-13.1.1-2.fc39.aarch64.rpm",
+        "checksum": "sha256:96a7944d2e9e5f7e41d460df3459f0224ed05f947ab31e19be4804b5469f9614",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libtasn1-4.19.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:301dfc48d40ab87f54178c1805bc3ddf40daa666f72a9c986442dd3e3febe657",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc39.aarch64.rpm",
+        "checksum": "sha256:3e67a7322914a6645e40ae31150b78fe57f212ae88bc27c605d604cdc4f27544",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libunistring-1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:45ad13f2e16525392a44e438a549c2244b0ed6f91f8053c7780bd381a3448c25",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libunistring1.0-1.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:342b090523748dbd93de4d39adc5b059f388893bd086b3c11f1c3dc16770a520",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libusb1-1.0.26-2.fc38.aarch64.rpm",
+        "checksum": "sha256:a9f260ba16734b6d1be9672e6fe2c7b77f6e868a627d56e0c0664bf32388dfad",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libutempter-1.2.1-9.fc39.aarch64.rpm",
+        "checksum": "sha256:71d7e33f852749c12ded02d3388763c779850adb86b1b735211f464bac24f7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libuuid-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:a406d5e0419f1c3897d8d2ac11a1466bd3ef03d436f42b38694c7f193a9acd93",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libverto-0.3.2-5.fc38.aarch64.rpm",
+        "checksum": "sha256:f1bfcaeb6e03a843aa6a06c064737c4a3e48ace9e5353328aea3754eb0d489bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxcrypt-4.4.33-7.fc39.aarch64.rpm",
+        "checksum": "sha256:141e746033217535d30b989e20cb565aad275e05e7971067f4a11913d2fc499d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxkbcommon-1.5.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:86aa1169ef9757e59ca01b1557482b04d08d9436ac08e880c81efda71a26f346",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libxml2-2.10.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:644f8deb2dd807002251cdcbfa66cba6f02740714179053f476f27beed224fd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libyaml-0.2.5-9.fc38.aarch64.rpm",
+        "checksum": "sha256:4644a24bef92e3c236f2273a2771e6172ad32a6ef23e274aed537285ff934cd5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/libzstd-1.5.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:231c7aa7fe4695b397096592e84075eda254df293b0a624810e9019854fec31c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/lua-libs-5.4.4-9.fc39.aarch64.rpm",
+        "checksum": "sha256:267735e6b9efc4cc058fa926a9e432fb6c44b97b0c6e5037e24ae7bab75fa53a",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/l/lz4-libs-1.9.4-3.fc39.aarch64.rpm",
+        "checksum": "sha256:df3ae62a5b60510dcf3896476b87d1c07b77dadc69502732c9639ee35336d6fb",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/memstrack-0.2.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:5f2f2310459ef50d0bb8504f6744608abd949c46f7d798937bc129ef5153d647",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mkpasswd-5.5.17-1.fc39.aarch64.rpm",
+        "checksum": "sha256:08d7ac543203a93295e50f9f6b9da97439e51e5dfb30aceafdb965a231b979a7",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mokutil-0.6.0-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d63c198d35e144112b2bb3fff5918c56967a1a764478584e79be0967c71c35d2",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mpdecimal-2.5.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:d94deb4d35588d4c8e91242266b2d7b776b94ecc3234bc7b94ef5ff786bfdad1",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/m/mpfr-4.1.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:ba9f5eeb8b85d79e215f70369aaca0c441073ef0a4bc94833842395c0ea8c8f5",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "4.20230520.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/ncurses-base-6.4-4.20230520.fc39.noarch.rpm",
+        "checksum": "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "4.20230520.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/ncurses-libs-6.4-4.20230520.fc39.aarch64.rpm",
+        "checksum": "sha256:4e592f6c8307ddb40fc007f8d2a66867f8c7d0f4beff76880f84cf11654ccda9",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/nettle-3.8-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d41ee6bf1cf3506dc2e686da05fa297abda41b0aca14c1df121f9e788719ee5c",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/n/npth-1.6-13.fc39.aarch64.rpm",
+        "checksum": "sha256:44258e878350ae92392dbe8059fb37cc8276398008b050b796aa07d8308fdbd0",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openldap-2.6.4-2.fc39.aarch64.rpm",
+        "checksum": "sha256:9ceefa62cc568c3ef9ac83aad5cce73779b704984b1b19eb193faf72e80869d0",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openssl-libs-3.0.8-2.fc39.aarch64.rpm",
+        "checksum": "sha256:ea5fc45daec89695603baf7ce3a2fe202dae1b5c2aa2d8749995c1472020b19f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/openssl-pkcs11-0.4.12-3.fc38.aarch64.rpm",
+        "checksum": "sha256:2a487be4156533f0d60db98bfd3459c2bef15bbf231f9d474d0ebf123d3ddfc0",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/os-prober-1.81-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c500caab153179a9c7c4ecb6defe2d925cac2ba56621541db5afc576ed3230a4",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/ostree-2023.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:273e95c71b2deaad08ffc79486c429a3008354de7f4739ff8a9082ec9c69819e",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/o/ostree-libs-2023.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:2f6c05c7fbc07059b053200250836e745bdfddb60e2080adb9154e4e47e0e393",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/p11-kit-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:5e8458439742e626901956a5c65347e23af571fddca04e2987e1e25320811e31",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/p11-kit-trust-0.24.1-6.fc38.aarch64.rpm",
+        "checksum": "sha256:4883bcb01e87f0dd5182e3200b24640424fdd55c3a18e46b4164eb92af904c3c",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pam-1.5.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a3a003543ae0de3221f099f04b7720fb759839de4597a9d603cb59be37aedef8",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pam-libs-1.5.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:7e6bc9de30ef54a9b915e68c2a34f194ed2d15638f8cc8d4c56c82ab2fbad828",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcre2-10.42-1.fc38.1.aarch64.rpm",
+        "checksum": "sha256:9628ab6436ad123ff03b6d1ba703218604f5f1b9845f8cc835614df30341c678",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:b4a95381f9f9aa1228c429aa9cb25502a448632b344f16bb693e5b8993f4d1c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.aarch64.rpm",
+        "checksum": "sha256:89b0edd10bdd990197605b7a938a0e25070524d83ffd986232817ca436874719",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.aarch64.rpm",
+        "checksum": "sha256:fcd6ad8c1b3550477db0783a1b5e59c74ce21909bae128259f4215aac4b03e9b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pigz-2.7-3.fc38.aarch64.rpm",
+        "checksum": "sha256:d5892ae6b2d9f370615dc668f1b4d4de7fe5067c192939e1f9c5648181198369",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/pinentry-1.2.1-2.fc38.aarch64.rpm",
+        "checksum": "sha256:7787ae522c7e74b912d13598e199c523d7ded171f9bc872f1f2656b393b6db19",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/policycoreutils-3.5-1.fc39.aarch64.rpm",
+        "checksum": "sha256:76fa76c9c989b54d0677e3bb8eb89805083d6c2c4475325fdb57d2db23c45275",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-122-5.fc39.aarch64.rpm",
+        "checksum": "sha256:de06d8c6c6188b1dc0d5ef97ee9780a50265d48a25d6fddccdca996599137abc",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "5.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-libs-122-5.fc39.aarch64.rpm",
+        "checksum": "sha256:d8e48d8c81206cc915270325b984b169b9319bf3928c46e05abedeeaf7cc25c6",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/polkit-pkla-compat-0.1-23.fc38.aarch64.rpm",
+        "checksum": "sha256:7fb924a539d5f6a8d9656886a2ffcc4850e6674e37d427d424623fbbcb64fc65",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/popt-1.19-2.fc38.aarch64.rpm",
+        "checksum": "sha256:67bfe5c18c4eebe6cb28ade72b9af54d0f377b311da527a6cc7d133bf02a5e99",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/procps-ng-3.3.17-9.fc38.aarch64.rpm",
+        "checksum": "sha256:27df4c19fd4e7b72e35493f84f0f79ed809e02e9e628615583fc44973ca2d493",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc39.noarch.rpm",
+        "checksum": "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "23.1.2",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-pip-wheel-23.1.2-1.fc39.noarch.rpm",
+        "checksum": "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "67.7.2",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-setuptools-wheel-67.7.2-2.fc39.noarch.rpm",
+        "checksum": "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc39.noarch.rpm",
+        "checksum": "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python3-3.11.3-2.fc39.aarch64.rpm",
+        "checksum": "sha256:5c8f26cd60c01a43d312e1dfd9b0d50db0d99154df1d48e7ef1b0796a0221df7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/p/python3-libs-3.11.3-2.fc39.aarch64.rpm",
+        "checksum": "sha256:3cf858d84c2b6f5563dbca1aac7500332c99320eb83a23190dea52883aa5957b",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/q/qrencode-libs-4.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:f8b227c1cd6fb8987ef5885853349f2521fa2103c4c8577bbb77893589559a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/readline-8.2-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f198fa50d35112320ae2f81bfe83d4d626160ef3e8dbba16285183a747a96655",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-4.18.90-9.fc39.aarch64.rpm",
+        "checksum": "sha256:a8dc38fce5d8b82bd87434b34985642228f96d612ef67a1c1aed4ea608a6f925",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-libs-4.18.90-9.fc39.aarch64.rpm",
+        "checksum": "sha256:7c3ed639a78cb7aec8265d14b75a9a675b96aa818ec175e02feb8b427deda54b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-ostree-2023.4-4.fc39.aarch64.rpm",
+        "checksum": "sha256:c9eb779798d0ec3ec6e7e1635ae1231bb4666f1594f4e104ef415f350ab05117",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-ostree-libs-2023.4-4.fc39.aarch64.rpm",
+        "checksum": "sha256:31cc0e25f01f007595ded4f88367c0a6665051bb55604cb8d38c3e5b21811a8d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-plugin-selinux-4.18.90-9.fc39.aarch64.rpm",
+        "checksum": "sha256:51b0899b800d2111f81ad70de0b66e1cf5bcf9529f94c1cd57f351099d2d25de",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc39.aarch64.rpm",
+        "checksum": "sha256:e302f3b841687d1d0bdfcb9b4c4c56331ac7f940f267088d397a238ec084f425",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/sed-4.8-12.fc38.aarch64.rpm",
+        "checksum": "sha256:06c58a3605d3cafc7c442d2bb39ed2c944ea988fcdbe9b62dfb0b123f368c7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.14",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/selinux-policy-38.14-1.fc39.noarch.rpm",
+        "checksum": "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.14",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/selinux-policy-targeted-38.14-1.fc39.noarch.rpm",
+        "checksum": "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "3.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/setup-2.14.3-3.fc39.noarch.rpm",
+        "checksum": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/shadow-utils-4.13-6.fc39.aarch64.rpm",
+        "checksum": "sha256:fb3ca377066ec35b4e93c52dd47625dc371d6ebfc5fe1da28b4e6c97186eda67",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:3aa9b7d8bf7c0d00e83d52180b24b2660ab3f4d72b454d82ecd0bc5e5aed4263",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/skopeo-1.12.0-2.fc39.aarch64.rpm",
+        "checksum": "sha256:ec8932ca9d5106ef75eaaea3ce932eee3d7fd347b8242f9e80e70aa4794aed22",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.41.2",
+        "release": "2.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/sqlite-libs-3.41.2-2.fc39.aarch64.rpm",
+        "checksum": "sha256:ffa28f03275f88006907086f85035eefc0ff79af114ce4b31aa5ba29c9a64e47",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:d91507b30c43820983784533d836280798ffc48e8b942351cbbbdc8eba20f6c4",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-libs-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:ccff5d87998f1b30b5c4376cb43635d5ff9f2df94095a3892c19dbbf5d9415a3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-networkd-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:071ef2a9dce484dc161c53dfe150904b16058a31786d0297e3802c0b28cf5198",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-pam-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:98a6695dc599b83dea78722586367b0bc13760df4f06d007bcb25c545b7f4ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-resolved-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:fb6fb86dcdfc4bffe551077c93cb0d2dc47d5453800ead4b46d031aa65bbafc1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/s/systemd-udev-253.4-1.fc39.aarch64.rpm",
+        "checksum": "sha256:19be41de3f2c3ef0ac08dfc1d65231fbec2ce7f3f9c8772bcb7e0571a752f560",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "3.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tpm2-tools-5.5-3.fc39.aarch64.rpm",
+        "checksum": "sha256:e2df334506379fcba46765e606dd407c364601b8fd649082a45d4159baf46872",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tpm2-tss-4.0.1-3.fc38.aarch64.rpm",
+        "checksum": "sha256:33132e2cfc1552b6429ddfde328d8e350294cad519a34860c3021b4e4289bccc",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/t/tzdata-2023c-1.fc39.noarch.rpm",
+        "checksum": "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/u/util-linux-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:76f00363e7c06687f5636484049ec75c8f910a25d80c2344318f2a8c769ec7e1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/u/util-linux-core-2.39-4.fc39.aarch64.rpm",
+        "checksum": "sha256:8e3d599c52c8ae682e56b0b8f680019673f165bf6e1ed3486b323ed786fa1a0f",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/w/which-2.21-39.fc39.aarch64.rpm",
+        "checksum": "sha256:5349c5841c28e67a4f1ac33c0e83ab7029a2aa16ec323dad176b3543e65006e3",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/w/whois-nls-5.5.17-1.fc39.noarch.rpm",
+        "checksum": "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xz-5.4.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:a93ca420f4dfc0f66af6c3755911fb163dc6025c6f68243a9b522d6cfa82ccec",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/x/xz-libs-5.4.3-1.fc39.aarch64.rpm",
+        "checksum": "sha256:00c38983f8630cbcbe7a433439d0bcbf8886530451ad46604b3fec3844b33216",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc39",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/z/zchunk-libs-1.3.1-1.fc39.aarch64.rpm",
+        "checksum": "sha256:1c386e29f37a3a5e3f7ee54964f9d815df83ea7f714e7f1a862590f18209ce0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-aarch64-rawhide-20230601/Packages/z/zlib-1.2.13-3.fc38.aarch64.rpm",
+        "checksum": "sha256:b1f3751a9fdaf0c918bad3ca42a0984bea6d94d382995c3162bf6b391e53e21d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_39-x86_64-iot_ami-boot.json
+++ b/test/data/manifests/fedora_39-x86_64-iot_ami-boot.json
@@ -1,0 +1,5240 @@
+{
+  "compose-request": {
+    "distro": "fedora-39",
+    "arch": "x86_64",
+    "image-type": "iot-ami",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-modular-20230601/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "image.raw",
+    "ostree": {
+      "ref": "test/fedora/iot",
+      "url": "http://fedora.example.com/repo",
+      "parent": "",
+      "rhsm": false
+    },
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora39",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:eb835856d36f045c746ab03243fb969fc5fa1950420e37c3bf9782359a9f3847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cc74cc914879c947f99db519e0501916f298aeb1a4f66dfd3996ad7802d49b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d8ef8fcd46894ff5a251f95f07a1ee87229f994657fb53f0916adc990d51114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57c69aa24e2d6d55c105308b53f43efbfeea4c2db30275f6cd6e3bd4a1ca5543",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea3594b4da09e293128d760f08964ecddbfe56bb37a4c8ca874dc215bc0a6240",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be2f5eac315f6072198d5f87a6037759814bc7264cf94b4bbc8ad66aeaf2ed70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73ee1a84d31b48a42ee6c696d1d667af34f621d6c9219793807a3b6024af6147",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3f8afa97eeb9c4325d3769bb4adb5d8a96368f7d5b1143ae7755781e779642f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e162adb4f6c5086eab94b74195730aeb368f44602113bed28053add9fe4899e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d76577b5519ff6b3f880db9fef7ca75299fb418c8fa56fda0b0c120654347cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20a930701288dcbf5c42d5a04cd0e937def48e58c65cd195d413682ea5e64042",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:006b1170b14abee2bb43f76ffc458c6450c047417835c0d09c281435bc614074",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4928acfd884ee06d6447ff1b91fcd5e0de795e7219fac59a9931a2bbeea0c324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7645bf740146b2077c5acc47a77ba74edf469c5a9fc9b257229eef89e85508e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60fe08cbf73b90659cabe9913c3d5e83319349b535135a38542706f629df1091",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0310624a74bd6b7f44fad718f647c420843644e97016800439e69a299697d309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:955da59fbf469b921a80511276bc9a9700c6cb55e929b35a17011223a319c060",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62d5f343ff9b76505d1d6184b71f581549d2a5de971b55bb1ab261c4ae4072c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ab7064e7397e2b8b9ac22b9d9c897878ff1297848f8cb96b87e9a7b7d9faa55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9837b923649219a283b5bc3d8e47c26b739363c1a523b741bb3b573c687a745f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c09b8baba1b6be5ef2a94c9e3ad07fedb625a411d7a99c669dda0e55c27a736",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aff56649b7b745500a60caa55bd469c201328f1ddfa16f74a23f43a3004bb3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aef8ff2c63a174ef441f8889d795234f320679e50d38b1a6955b6424a6039caf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d5c08d98e74fe1a618c9bea726e78b75b8132d91ef44ebfb3c603377993582b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ff413cc487159e3c2ac31c8c77eddce474f9fe3347b362212ddd463aa274718",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70a7b76c6aa853ef743f3646b0f9a400ad155c78f47507ea400b5537645c8d20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd1a1c800bcc7d0e06d4038c6810600d9e2ff724224d63b26761b9a96b33ac87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa3ee6e85b55d58e59ddc48e2727ed2d06938cca185a75b5e9426987f1a6063",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2ef60c43740b193dd7bdf4795157c10a6838040e674da9daebf9e28747865eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a8262bc8458695f372e2a5055bad29d94c07ac8ebcd91f812ff615287fff523",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:868593df2ef1d2c6cf3f025956ee607935a5c1623065912620c30500c56775c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1f83ecafff885344f8b23836cb14d73ecba9c13a8cd8e9cd723232d02f48ffc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b22a27d3815f9111396d6b2b61606cd84019b845d40c1b8b8aca749a629b9e36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8464e945a2e8bb307adcbca6fcc4e0451703d4883ff4419e0771e8a6e8727de6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ecd54c8a01901840ddae836ac0387ebbad90176412c0793addd80df0f5d1d13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78523ce49fe3674ea56a5003169754f3e50fd9897cd2e5a5204eba2996ddd0cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e9ac2555738ff142d2ddf9d56fc1a3b0d16d9ef72abd7223d3ca7057ef314c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3d7753b1ab0a74908e45a734a5bfd6d4ae646b91a4ea345b7264eb5cdec784d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:767173f9cbfadb1d521f0790c335386d3c78258f9180dfb9e25d2c7b9c196f03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d57d2d449e5a93eb7b30b1b6cc9724f8b688cbaad9a7e36aee19bdd0c85234f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe989073e3aec81cca954445fb43cf13c7fd874c5686f7f695ff06488c1eda33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a89c4d880c7ae63c118f4c0a72045aa1e808d8e18e6073cc9d98827a639308b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8e26fcb8a1f642322fd5376ab4ef7410ad40029f8cdb585991dee4fa8a10691",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2654e400f0593b675018665d85a212c1209045140b26a2484e11b98806e3afba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37e71790208f46ea301306760e10488ef3701968b71c83d87dd78a3f91bb3498",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:181be68c4f916f1c9a3f8f396ef986c51e5c97203ca0b43f63a534755fba9f71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a396dde8ccb97e481d2168db1e86abba8d3f6d34096d8b96596f60ca812d0f37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61f88ec5e6d0c9f31b5357dbb92d6ce3e5600adeb7571d1234bbbb551f053d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1c10202830b213b7e9b9f50102c4748c561a7f5206723b386b802ce8994f954",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d32ed5b5ff107cd1bf19e6b76ba748a037aef62f8e3b5dd3179ea2aa0c74be9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94cbe113d9e38f6470424ec19c2fda59d136b1fee40515e6ad8ed98ee32b37fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:716d341d5a507e1544984a9d6ec78994feefd29b36f4e5f595874e25a644247e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56aed0f06d9ad990a1813d8b9824cb0dcf188934b83054e38028387dc95b39fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0a98adb477555c652bab41d316ec5ec0d0135a5bf1d84c8fc377dbee3505ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:488ec81c9d15610909d7a4c6e2c37ef51b51371185b264c8b11a55deb93dc3b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2c53fedd5371a684d059b939768d09adbf3cba78b6bcc9d0a4914abbcf86006",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:800019fd157eca7e44e83a9c895bbff73f18496d214a119b6bca38af249caba1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7dc459b85d56755c602c468dd1e04a7264a170593d68006ac7c633c13db0be3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:273b7d3fbe2c812d9cf06f24bf3141b02a54fe9b7175ed23838e82fe8852154a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88d19855ca938090164dba958798a20e512d0da888838b6d88aad7ea421a29a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1083fe64f92b2a32b72f14a0555e7784edeccbcdbbff092968811373f1edbea0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b71d508e39018159be171a6ef96a9b155608dd1c137db9920d7d849f24f0c13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa5d460a6e4d0f4e49a06e072c494a10192c081a588d99e573b96ef0cbaa903b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:258f27be13bc01697e7001c58edfacfc3105529b3746edf62028df487ad2e0ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c33edcd3d84366edea3ae382be8ba3fbb212173e9bd6b3e15bd6391918298ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d268e37c04086d3ab838d08773d7e59b8d3cc29468aee480f371f3ca7d344eb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72cd25608a61934f3f05ebf31af5b39337a7301a7cfc55f83f05dcd8f910d101",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:937fab58a2b115f7e5a8d5f7fc3af35d4e62b2ab89979f449704acb10f0041eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37cbb04722c8e82f89705c9a68b0b7f68e0d8dba8ec82c549acee20968f98d84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78f8a5fb4b46794d5d35bdd7a9b23b92a34979594469590d0dd003a7f6811d99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:413818b86694e41fc850a0c1e5ef271a5768abc42ba50896aff6f66a78d9505f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc992a3e8583f101e197c1f399c9cbb3893ea6d2f0e2f1884012ec19458b3afb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:620b8720dbb4379f217ff053e4704ba696c7cbd0653dc27799f5bbd444d09276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ed8a6870e2ea4d8f15c3755826a4960bb4650d4508240920fcc8f9ab584a6fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f665b677b629f2a2071a84aaacc43dfd796f4b754bc7d1a6a07c464d1815e723",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81dcfec54c9a80d975082c81c4499b3cf5d3b274a7abec61120a2618edeb2030",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c33ddd0dc40734dea853bd809911929630b7f6f90e0e1e95998295daa3a43029",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18804fb738573ac3a2ec9a576fad7e64d87a216793ccb5c98037a12ae99d3ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be0e52f22a17bbd964c1c0a0d60e4f69a8950a1f05975fe6a4e18e8cab719304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad4871ba6d81395cbd4817de5b661c7d4262a6f1e8a03511a529f75281ae05e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a67860c7779aa8faffe6df84106d8f1edaa67ac4d52db78f90924ff0cf724d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:787d6dd0b7c35906ced566f5736514fc23bdf1aea2f8d53b373a1e26fb102b93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:297427a147dbfaee9ccf62f5b932c61e20ac1f4c51c59fff08f2bfa7ce8e030b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f8d70087a096464aa39765b43896756bc2fcc240761b20a5ced18b5e8a96eba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87d83fc74ac91caf86d4279b314cf61571db64eb306a966b9b13ed46b144370",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7c75ed0a42709af3f9a106e50b4c7115df6d0e31436e08538526b9bb9a5fc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31954f960d6568c7099e5643df604bae2b8a5cea80964f7f2e38fba33f4282c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71c070018b837af835d854d206763b1e2c7dbd1be174b8af9d2320671ba5f51b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e7c2ace9e7277c41e527ccfe1b2dd7fb2d6e3a551bbe530120c373433f83450",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f492b502b6fcdbfb00da1806098c72fd6c98a933de1da88e6ccb9ab94b3489c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58097fdce516150bfd8672b27bd81216bd53ab8018f641ca589d1b8296bec4ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c50fd2a65b6513c225497edda88cdff2a4fa28b58677547c35854e92f6eb8416",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b31f3c7b4597ee1de8fd41df3eeac17f0c7ce80cf5940175b177c73c5051245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:697b90a3d3df742a19ffbbf1a2b1f3d078555a599948863018358f3e49d34df3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcf6c828babc018410423095e394a1aa7a5413f607baf24abb55b548e33e78cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25fbeb94c8d80e57041fe3ff25ba592f0a493f42c40d5074d3e7ebe8892b5755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9adc6495a79fb9c91da51c4dbeeed3e4065527e1229f8c0e57fae3c6b01898cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b5b235fa0b846542da3d2a3839ce9ecfbb89391dec229863bf44fe452eeab00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aede8d217c8a83c56f09f8383bc214a2a7fac22b5d74f4edf7e25d061e02d69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f500e8074a0efa8ab9eb76113e2d51fdec550534894fbf31d7623c265318b122",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a903aba425eb2316615701eba6fab7de59d7dd4f0ab54f0c256f04445d510e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d578fe4710399df0da61b66274fc6d66e18d9c656e6bbf2172a075075d268f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e84688bf747e9331440d196f59da8f99bebaebc5eb93cb8c061bedf6476ea41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGLykg8BEADURjKtgQpQNoluifXia+U3FuqGCTQ1w7iTqx1UvNhLX6tb9Qjy\nl/vjl1iXxucrd2JBnrT/21BdtaABhu2hPy7bpcGEkG8MDinAMZBzcyzHcS/JiGHZ\nd/YmMWQUgbDlApbxFSGWiXMgT0Js5QdcywHI5oiCmV0lkZ+khZ4PkVWmk6uZgYWf\nJOG5wp5TDPnoYXlA4CLb6hu2691aDm9b99XYqEjhbeIzS9bFQrdrQzRMKyzLr8NW\ns8Pq2tgyzu8txlWdBXJyAMKldTPstqtygLL9UUdo7CIQQzWqeDbAnv+WdOmiI/hR\netbbwNV+thkLJz0WD90C2L3JEeUJX5Qa4oPvfNLDeCKmJFEFUTCEdm0AYoQDjLJQ\n3d3q9M09thXO/jYM0cSnJDclssLNsNWfjJAerLadLwNnYRuralw7f74QSLYdJAJU\nSFShBlctWKnlhQ7ehockqtgXtWckkqPZZjGiMXwHde9b9Yyi+VqtUQWxSWny+9g9\n6tcoa3AdnmpqSTHQxYajD0EGXJ0z0NXfqxkI0lo8UxzypEBy4sARZ4XhTU73Zwk0\nLGhEUHlfyxXgRs6RRvM2UIoo+gou2M9rn/RWkhuHJNSfgrM0BmIBCjhjwGiS33Qh\nysLDWJMdch8lsu1fTmLEFQrOB93oieOJQ0Ysi5gQY8TOT+oZvVi9pSMJuwARAQAB\ntDFGZWRvcmEgKDM5KSA8ZmVkb3JhLTM5LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEE6PI5lvIyGGQMtEy+dc9axBi450wFAmLykg8CGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQdc9axBi450yd4w//ZtghbZX5KFstOdBS\nrcbBfCK9zmRvzeejzGl6lPKfqwx7OOHYxFlRa9MYLl8QG7Aq6yRRWzzEHiSb0wJw\nWXz5tbkAmV/fpS4wnb3FDArD44u317UAnaU+UlhgK1g62lwI2dGpvTSvohMBMeBY\nB5aBd+sLi3UtiSRM2XhxvxaWwr/oFLjKDukgrPQzeV3F/XdxGhSz/GZUVFVprcrB\nh/dIo4k0Za7YVRhlVM0coOIcKbcjxAK9CCZ8+jtdIh3/BN5zJ0RFMgqSsrWYWeft\nBI3KWLbyMfRwEtp7xSi17WXbRfsSoqwIVgP+RCSaAdVuiYs/GCRsT3ydYcDvutuJ\nYZoE53yczemM/1HZZFI04zI7KBsKm9NFH0o4K2nBWuowBm59iFvWHFpX6em54cq4\n45NwY01FkSQUqntfqCWFSowwFHAZM4gblOikq2B5zHoIntCiJlPGuaJiVSw9ZpEc\n+IEQfmXJjKGSkMbU9tmNfLR9skVQJizMTtoUQ12DWC+14anxnnR2hxnhUDAabV6y\nJ5dGeb/ArmxQj3IMrajdNwjuk9GMeMSSS2EMY8ryOuYwRbFhBOLhGAnmM5OOSUxv\nA4ipWraXDW0bK/wXI7yHMkc6WYrdV3SIXEqJBTp7npimv3JC+exWEbTLcgvV70FP\nX55M9nDtzUSayJuEcfFP2c9KQCE=\n=J4qZ\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "ostree-deployment",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.ostree.init-fs"
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "": {
+                    "ref": "test/fedora/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo",
+              "remote": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.os-init",
+            "options": {
+              "osname": "fedora-iot"
+            }
+          },
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "/boot/efi",
+                  "mode": 448
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.deploy",
+            "options": {
+              "osname": "fedora-iot",
+              "ref": "test/fedora/iot",
+              "remote": "fedora-iot",
+              "mounts": [
+                "/boot",
+                "/boot/efi"
+              ],
+              "rootfs": {
+                "label": "root"
+              },
+              "kernel_opts": [
+                "modprobe.blacklist=vc4",
+                "rw"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.remotes",
+            "options": {
+              "repo": "/ostree/repo",
+              "remotes": [
+                {
+                  "name": "fedora-iot",
+                  "url": "https://ostree.fedoraproject.org/iot",
+                  "contenturl": "mirrorlist=https://ostree.fedoraproject.org/iot/mirrorlist",
+                  "gpgkeypaths": [
+                    "/etc/pki/rpm-gpg/"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.fillvar",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 1
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults",
+                  "freq": 1,
+                  "passno": 2
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "umask=0077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.users",
+            "options": {
+              "users": {
+                "root": {
+                  "password": "!locked"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.keymap",
+            "options": {
+              "keymap": "us"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "C.UTF-8"
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "kernel_opts": "modprobe.blacklist=vc4 rw",
+              "uefi": {
+                "vendor": "fedora",
+                "install": true,
+                "unified": true
+              },
+              "greenboot": true,
+              "write_cmdline": false,
+              "config": {
+                "default": "saved",
+                "terminal_output": [
+                  "console"
+                ],
+                "timeout": 1
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.ostree.selinux",
+            "options": {
+              "deployment": {
+                "osname": "fedora-iot",
+                "ref": "test/fedora/iot"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "image.raw",
+              "size": "10737418240"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 1026048,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 2097152,
+                  "start": 1028096,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 17846239,
+                  "start": 3125248,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:ostree-deployment"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 1028096,
+                  "size": 2097152
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 2048,
+                  "size": 1026048
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "image.raw",
+                  "start": 3125248,
+                  "size": 17846239
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:006b1170b14abee2bb43f76ffc458c6450c047417835c0d09c281435bc614074": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dracut-config-generic-059-7.fc39.x86_64.rpm"
+          },
+          "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/popt-1.19-2.fc38.x86_64.rpm"
+          },
+          "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/crypto-policies-scripts-20230420-1.git3d08ae7.fc39.noarch.rpm"
+          },
+          "sha256:0310624a74bd6b7f44fad718f647c420843644e97016800439e69a299697d309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc39.x86_64.rpm"
+          },
+          "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm"
+          },
+          "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/w/whois-nls-5.5.17-1.fc39.noarch.rpm"
+          },
+          "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm"
+          },
+          "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm"
+          },
+          "sha256:0c09b8baba1b6be5ef2a94c9e3ad07fedb625a411d7a99c669dda0e55c27a736": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/findutils-4.9.0-4.fc39.x86_64.rpm"
+          },
+          "sha256:0d8ef8fcd46894ff5a251f95f07a1ee87229f994657fb53f0916adc990d51114": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/coreutils-9.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:0f8d70087a096464aa39765b43896756bc2fcc240761b20a5ced18b5e8a96eba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-4.18.90-9.fc39.x86_64.rpm"
+          },
+          "sha256:1083fe64f92b2a32b72f14a0555e7784edeccbcdbbff092968811373f1edbea0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsolv-0.7.24-4.fc39.x86_64.rpm"
+          },
+          "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/sed-4.8-12.fc38.x86_64.rpm"
+          },
+          "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm"
+          },
+          "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm"
+          },
+          "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc39.noarch.rpm"
+          },
+          "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/basesystem-11-15.fc38.noarch.rpm"
+          },
+          "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/shim-x64-15.6-2.x86_64.rpm"
+          },
+          "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:181be68c4f916f1c9a3f8f396ef986c51e5c97203ca0b43f63a534755fba9f71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libacl-2.3.1-7.fc39.x86_64.rpm"
+          },
+          "sha256:18804fb738573ac3a2ec9a576fad7e64d87a216793ccb5c98037a12ae99d3ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pam-1.5.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/policycoreutils-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/readline-8.2-3.fc38.x86_64.rpm"
+          },
+          "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/nettle-3.8-3.fc38.x86_64.rpm"
+          },
+          "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pigz-2.7-3.fc38.x86_64.rpm"
+          },
+          "sha256:1b31f3c7b4597ee1de8fd41df3eeac17f0c7ce80cf5940175b177c73c5051245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-libs-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:1e162adb4f6c5086eab94b74195730aeb368f44602113bed28053add9fe4899e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/device-mapper-libs-1.02.195-1.fc39.x86_64.rpm"
+          },
+          "sha256:1e9ac2555738ff142d2ddf9d56fc1a3b0d16d9ef72abd7223d3ca7057ef314c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnupg2-smime-2.4.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grep-3.9-1.fc39.x86_64.rpm"
+          },
+          "sha256:1f492b502b6fcdbfb00da1806098c72fd6c98a933de1da88e6ccb9ab94b3489c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/skopeo-1.12.0-2.fc39.x86_64.rpm"
+          },
+          "sha256:20a930701288dcbf5c42d5a04cd0e937def48e58c65cd195d413682ea5e64042": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dracut-059-7.fc39.x86_64.rpm"
+          },
+          "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm"
+          },
+          "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bubblewrap-0.7.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/lua-libs-5.4.4-9.fc39.x86_64.rpm"
+          },
+          "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm"
+          },
+          "sha256:258f27be13bc01697e7001c58edfacfc3105529b3746edf62028df487ad2e0ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libstdc++-13.1.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:25fbeb94c8d80e57041fe3ff25ba592f0a493f42c40d5074d3e7ebe8892b5755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-resolved-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:2654e400f0593b675018665d85a212c1209045140b26a2484e11b98806e3afba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kmod-libs-30-5.fc39.x86_64.rpm"
+          },
+          "sha256:273b7d3fbe2c812d9cf06f24bf3141b02a54fe9b7175ed23838e82fe8852154a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsemanage-3.5-2.fc39.x86_64.rpm"
+          },
+          "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxcrypt-compat-4.4.33-7.fc39.x86_64.rpm"
+          },
+          "sha256:297427a147dbfaee9ccf62f5b932c61e20ac1f4c51c59fff08f2bfa7ce8e030b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python3-libs-3.11.3-2.fc39.x86_64.rpm"
+          },
+          "sha256:2ab7064e7397e2b8b9ac22b9d9c897878ff1297848f8cb96b87e9a7b7d9faa55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/file-5.44-3.fc39.x86_64.rpm"
+          },
+          "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:2b5b235fa0b846542da3d2a3839ce9ecfbb89391dec229863bf44fe452eeab00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tpm2-tools-5.5-3.fc39.x86_64.rpm"
+          },
+          "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libssh-config-0.10.5-1.fc39.noarch.rpm"
+          },
+          "sha256:2ed8a6870e2ea4d8f15c3755826a4960bb4650d4508240920fcc8f9ab584a6fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openldap-2.6.4-2.fc39.x86_64.rpm"
+          },
+          "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gzip-1.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm"
+          },
+          "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grubby-8.40-70.fc39.x86_64.rpm"
+          },
+          "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/containers-common-1-90.fc39.noarch.rpm"
+          },
+          "sha256:31954f960d6568c7099e5643df604bae2b8a5cea80964f7f2e38fba33f4282c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-ostree-libs-2023.4-4.fc39.x86_64.rpm"
+          },
+          "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm"
+          },
+          "sha256:37cbb04722c8e82f89705c9a68b0b7f68e0d8dba8ec82c549acee20968f98d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libzstd-1.5.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:37e71790208f46ea301306760e10488ef3701968b71c83d87dd78a3f91bb3498": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kpartx-0.9.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/filesystem-3.18-4.fc39.x86_64.rpm"
+          },
+          "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm"
+          },
+          "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm"
+          },
+          "sha256:3a89c4d880c7ae63c118f4c0a72045aa1e808d8e18e6073cc9d98827a639308b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-2.5.1-6.fc39.x86_64.rpm"
+          },
+          "sha256:3aede8d217c8a83c56f09f8383bc214a2a7fac22b5d74f4edf7e25d061e02d69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/u/util-linux-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm"
+          },
+          "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-legacy-2.5.1-6.fc39.noarch.rpm"
+          },
+          "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm"
+          },
+          "sha256:413818b86694e41fc850a0c1e5ef271a5768abc42ba50896aff6f66a78d9505f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mkpasswd-5.5.17-1.fc39.x86_64.rpm"
+          },
+          "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm"
+          },
+          "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/w/which-2.21-39.fc39.x86_64.rpm"
+          },
+          "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-setuptools-wheel-67.7.2-2.fc39.noarch.rpm"
+          },
+          "sha256:488ec81c9d15610909d7a4c6e2c37ef51b51371185b264c8b11a55deb93dc3b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgpg-error-1.47-1.fc39.x86_64.rpm"
+          },
+          "sha256:4928acfd884ee06d6447ff1b91fcd5e0de795e7219fac59a9931a2bbeea0c324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/duktape-2.7.0-4.fc39.x86_64.rpm"
+          },
+          "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm"
+          },
+          "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-misc-2.5.1-6.fc39.noarch.rpm"
+          },
+          "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm"
+          },
+          "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm"
+          },
+          "sha256:56aed0f06d9ad990a1813d8b9824cb0dcf188934b83054e38028387dc95b39fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgcrypt-1.10.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:57c69aa24e2d6d55c105308b53f43efbfeea4c2db30275f6cd6e3bd4a1ca5543": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/coreutils-common-9.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:58097fdce516150bfd8672b27bd81216bd53ab8018f641ca589d1b8296bec4ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/sqlite-libs-3.41.2-2.fc39.x86_64.rpm"
+          },
+          "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm"
+          },
+          "sha256:5d5c08d98e74fe1a618c9bea726e78b75b8132d91ef44ebfb3c603377993582b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse3-3.14.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:60fe08cbf73b90659cabe9913c3d5e83319349b535135a38542706f629df1091": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/e2fsprogs-libs-1.47.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:61f88ec5e6d0c9f31b5357dbb92d6ce3e5600adeb7571d1234bbbb551f053d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libblkid-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:620b8720dbb4379f217ff053e4704ba696c7cbd0653dc27799f5bbd444d09276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/npth-1.6-13.fc39.x86_64.rpm"
+          },
+          "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/selinux-policy-38.14-1.fc39.noarch.rpm"
+          },
+          "sha256:697b90a3d3df742a19ffbbf1a2b1f3d078555a599948863018358f3e49d34df3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-networkd-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-common-39-0.14.noarch.rpm"
+          },
+          "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/selinux-policy-targeted-38.14-1.fc39.noarch.rpm"
+          },
+          "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm"
+          },
+          "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm"
+          },
+          "sha256:70a7b76c6aa853ef743f3646b0f9a400ad155c78f47507ea400b5537645c8d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gawk-5.2.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:716d341d5a507e1544984a9d6ec78994feefd29b36f4e5f595874e25a644247e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgcc-13.1.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxcrypt-4.4.33-7.fc39.x86_64.rpm"
+          },
+          "sha256:71c070018b837af835d854d206763b1e2c7dbd1be174b8af9d2320671ba5f51b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-plugin-selinux-4.18.90-9.fc39.x86_64.rpm"
+          },
+          "sha256:72cd25608a61934f3f05ebf31af5b39337a7301a7cfc55f83f05dcd8f910d101": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libuuid-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:73ee1a84d31b48a42ee6c696d1d667af34f621d6c9219793807a3b6024af6147": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cyrus-sasl-lib-2.1.28-10.fc39.x86_64.rpm"
+          },
+          "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:7645bf740146b2077c5acc47a77ba74edf469c5a9fc9b257229eef89e85508e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/e2fsprogs-1.47.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:767173f9cbfadb1d521f0790c335386d3c78258f9180dfb9e25d2c7b9c196f03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-efi-x64-2.06-95.fc39.x86_64.rpm"
+          },
+          "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:78523ce49fe3674ea56a5003169754f3e50fd9897cd2e5a5204eba2996ddd0cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnupg2-2.4.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:787d6dd0b7c35906ced566f5736514fc23bdf1aea2f8d53b373a1e26fb102b93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python3-3.11.3-2.fc39.x86_64.rpm"
+          },
+          "sha256:78f8a5fb4b46794d5d35bdd7a9b23b92a34979594469590d0dd003a7f6811d99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/lz4-libs-1.9.4-3.fc39.x86_64.rpm"
+          },
+          "sha256:7aa3ee6e85b55d58e59ddc48e2727ed2d06938cca185a75b5e9426987f1a6063": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-envsubst-0.21.1-3.fc39.x86_64.rpm"
+          },
+          "sha256:800019fd157eca7e44e83a9c895bbff73f18496d214a119b6bca38af249caba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libmount-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:81dcfec54c9a80d975082c81c4499b3cf5d3b274a7abec61120a2618edeb2030": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/ostree-2023.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-pip-wheel-23.1.2-1.fc39.noarch.rpm"
+          },
+          "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm"
+          },
+          "sha256:8464e945a2e8bb307adcbca6fcc4e0451703d4883ff4419e0771e8a6e8727de6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-gconv-extra-2.37.9000-10.fc39.x86_64.rpm"
+          },
+          "sha256:868593df2ef1d2c6cf3f025956ee607935a5c1623065912620c30500c56775c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glib2-2.76.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:88d19855ca938090164dba958798a20e512d0da888838b6d88aad7ea421a29a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsmartcols-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm"
+          },
+          "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libselinux-utils-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:8a67860c7779aa8faffe6df84106d8f1edaa67ac4d52db78f90924ff0cf724d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-libs-122-5.fc39.x86_64.rpm"
+          },
+          "sha256:8a903aba425eb2316615701eba6fab7de59d7dd4f0ab54f0c256f04445d510e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xz-5.4.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm"
+          },
+          "sha256:8aff56649b7b745500a60caa55bd469c201328f1ddfa16f74a23f43a3004bb3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-common-3.14.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:8b71d508e39018159be171a6ef96a9b155608dd1c137db9920d7d849f24f0c13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libss-1.47.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:8cc74cc914879c947f99db519e0501916f298aeb1a4f66dfd3996ad7802d49b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/audit-libs-3.1.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:8e84688bf747e9331440d196f59da8f99bebaebc5eb93cb8c061bedf6476ea41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/z/zchunk-libs-1.3.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm"
+          },
+          "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-repos-39-0.1.noarch.rpm"
+          },
+          "sha256:8ff413cc487159e3c2ac31c8c77eddce474f9fe3347b362212ddd463aa274718": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse3-libs-3.14.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm"
+          },
+          "sha256:937fab58a2b115f7e5a8d5f7fc3af35d4e62b2ab89979f449704acb10f0041eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxml2-2.10.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:94cbe113d9e38f6470424ec19c2fda59d136b1fee40515e6ad8ed98ee32b37fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libfdisk-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:955da59fbf469b921a80511276bc9a9700c6cb55e929b35a17011223a319c060": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-libelf-0.189-2.fc39.x86_64.rpm"
+          },
+          "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/krb5-libs-1.20.1-9.fc39.x86_64.rpm"
+          },
+          "sha256:9837b923649219a283b5bc3d8e47c26b739363c1a523b741bb3b573c687a745f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/file-libs-5.44-3.fc39.x86_64.rpm"
+          },
+          "sha256:9a8262bc8458695f372e2a5055bad29d94c07ac8ebcd91f812ff615287fff523": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-runtime-0.21.1-3.fc39.x86_64.rpm"
+          },
+          "sha256:9adc6495a79fb9c91da51c4dbeeed3e4065527e1229f8c0e57fae3c6b01898cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-udev-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:9c33edcd3d84366edea3ae382be8ba3fbb212173e9bd6b3e15bd6391918298ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc39.x86_64.rpm"
+          },
+          "sha256:9d578fe4710399df0da61b66274fc6d66e18d9c656e6bbf2172a075075d268f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xz-libs-5.4.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm"
+          },
+          "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm"
+          },
+          "sha256:9e7c2ace9e7277c41e527ccfe1b2dd7fb2d6e3a551bbe530120c373433f83450": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc39.x86_64.rpm"
+          },
+          "sha256:9ecd54c8a01901840ddae836ac0387ebbad90176412c0793addd80df0f5d1d13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-minimal-langpack-2.37.9000-10.fc39.x86_64.rpm"
+          },
+          "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm"
+          },
+          "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsepol-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:a396dde8ccb97e481d2168db1e86abba8d3f6d34096d8b96596f60ca812d0f37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libattr-2.5.1-7.fc39.x86_64.rpm"
+          },
+          "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm"
+          },
+          "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm"
+          },
+          "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-identity-basic-39-0.14.noarch.rpm"
+          },
+          "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libselinux-3.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gpgme-1.17.1-5.fc39.x86_64.rpm"
+          },
+          "sha256:aa5d460a6e4d0f4e49a06e072c494a10192c081a588d99e573b96ef0cbaa903b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libssh-0.10.5-1.fc39.x86_64.rpm"
+          },
+          "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm"
+          },
+          "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/ncurses-base-6.4-4.20230520.fc39.noarch.rpm"
+          },
+          "sha256:ad4871ba6d81395cbd4817de5b661c7d4262a6f1e8a03511a529f75281ae05e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-122-5.fc39.x86_64.rpm"
+          },
+          "sha256:aef8ff2c63a174ef441f8889d795234f320679e50d38b1a6955b6424a6039caf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-overlayfs-1.12-1.fc39.x86_64.rpm"
+          },
+          "sha256:b1c10202830b213b7e9b9f50102c4748c561a7f5206723b386b802ce8994f954": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcom_err-1.47.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:b1f83ecafff885344f8b23836cb14d73ecba9c13a8cd8e9cd723232d02f48ffc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-2.37.9000-10.fc39.x86_64.rpm"
+          },
+          "sha256:b22a27d3815f9111396d6b2b61606cd84019b845d40c1b8b8aca749a629b9e36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-common-2.37.9000-10.fc39.x86_64.rpm"
+          },
+          "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm"
+          },
+          "sha256:bc992a3e8583f101e197c1f399c9cbb3893ea6d2f0e2f1884012ec19458b3afb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/ncurses-libs-6.4-4.20230520.fc39.x86_64.rpm"
+          },
+          "sha256:be0e52f22a17bbd964c1c0a0d60e4f69a8950a1f05975fe6a4e18e8cab719304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pam-libs-1.5.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc39.noarch.rpm"
+          },
+          "sha256:be2f5eac315f6072198d5f87a6037759814bc7264cf94b4bbc8ad66aeaf2ed70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/curl-8.1.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:bf7c75ed0a42709af3f9a106e50b4c7115df6d0e31436e08538526b9bb9a5fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-ostree-2023.4-4.fc39.x86_64.rpm"
+          },
+          "sha256:c2ef60c43740b193dd7bdf4795157c10a6838040e674da9daebf9e28747865eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-libs-0.21.1-3.fc39.x86_64.rpm"
+          },
+          "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/container-selinux-2.215.0-2.fc39.noarch.rpm"
+          },
+          "sha256:c33ddd0dc40734dea853bd809911929630b7f6f90e0e1e95998295daa3a43029": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/ostree-libs-2023.3-1.fc39.x86_64.rpm"
+          },
+          "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libarchive-3.6.1-5.fc39.x86_64.rpm"
+          },
+          "sha256:c50fd2a65b6513c225497edda88cdff2a4fa28b58677547c35854e92f6eb8416": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcbor-0.10.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm"
+          },
+          "sha256:c7dc459b85d56755c602c468dd1e04a7264a170593d68006ac7c633c13db0be3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libnghttp2-1.53.0-1.fc39.x86_64.rpm"
+          },
+          "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/shadow-utils-4.13-6.fc39.x86_64.rpm"
+          },
+          "sha256:c8e26fcb8a1f642322fd5376ab4ef7410ad40029f8cdb585991dee4fa8a10691": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kmod-30-5.fc39.x86_64.rpm"
+          },
+          "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm"
+          },
+          "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-39-0.14.noarch.rpm"
+          },
+          "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/j/json-c-0.16-4.fc38.x86_64.rpm"
+          },
+          "sha256:d268e37c04086d3ab838d08773d7e59b8d3cc29468aee480f371f3ca7d344eb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libutempter-1.2.1-9.fc39.x86_64.rpm"
+          },
+          "sha256:d2c53fedd5371a684d059b939768d09adbf3cba78b6bcc9d0a4914abbcf86006": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libmodulemd-2.15.0-3.fc39.x86_64.rpm"
+          },
+          "sha256:d32ed5b5ff107cd1bf19e6b76ba748a037aef62f8e3b5dd3179ea2aa0c74be9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcurl-8.1.1-1.fc39.x86_64.rpm"
+          },
+          "sha256:d57d2d449e5a93eb7b30b1b6cc9724f8b688cbaad9a7e36aee19bdd0c85234f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-tools-2.06-95.fc39.x86_64.rpm"
+          },
+          "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm"
+          },
+          "sha256:d62d5f343ff9b76505d1d6184b71f581549d2a5de971b55bb1ab261c4ae4072c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-libs-0.189-2.fc39.x86_64.rpm"
+          },
+          "sha256:d76577b5519ff6b3f880db9fef7ca75299fb418c8fa56fda0b0c120654347cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/diffutils-3.9-4.fc39.x86_64.rpm"
+          },
+          "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc39.noarch.rpm"
+          },
+          "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm"
+          },
+          "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:d87d83fc74ac91caf86d4279b314cf61571db64eb306a966b9b13ed46b144370": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-libs-4.18.90-9.fc39.x86_64.rpm"
+          },
+          "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/crypto-policies-20230420-1.git3d08ae7.fc39.noarch.rpm"
+          },
+          "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm"
+          },
+          "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm"
+          },
+          "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm"
+          },
+          "sha256:e0a98adb477555c652bab41d316ec5ec0d0135a5bf1d84c8fc377dbee3505ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgomp-13.1.1-2.fc39.x86_64.rpm"
+          },
+          "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/setup-2.14.3-3.fc39.noarch.rpm"
+          },
+          "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm"
+          },
+          "sha256:e3d7753b1ab0a74908e45a734a5bfd6d4ae646b91a4ea345b7264eb5cdec784d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnutls-3.8.0-3.fc39.x86_64.rpm"
+          },
+          "sha256:e3f8afa97eeb9c4325d3769bb4adb5d8a96368f7d5b1143ae7755781e779642f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/device-mapper-1.02.195-1.fc39.x86_64.rpm"
+          },
+          "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcap-2.48-6.fc38.x86_64.rpm"
+          },
+          "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:ea3594b4da09e293128d760f08964ecddbfe56bb37a4c8ca874dc215bc0a6240": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cpio-2.14-2.fc39.x86_64.rpm"
+          },
+          "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libfido2-1.13.0-2.fc39.x86_64.rpm"
+          },
+          "sha256:eb835856d36f045c746ab03243fb969fc5fa1950420e37c3bf9782359a9f3847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/alternatives-1.24-1.fc39.x86_64.rpm"
+          },
+          "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm"
+          },
+          "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm"
+          },
+          "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm"
+          },
+          "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-common-2.06-95.fc39.noarch.rpm"
+          },
+          "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm"
+          },
+          "sha256:f500e8074a0efa8ab9eb76113e2d51fdec550534894fbf31d7623c265318b122": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/u/util-linux-core-2.39-4.fc39.x86_64.rpm"
+          },
+          "sha256:f665b677b629f2a2071a84aaacc43dfd796f4b754bc7d1a6a07c464d1815e723": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openssl-libs-3.0.8-2.fc39.x86_64.rpm"
+          },
+          "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm"
+          },
+          "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm"
+          },
+          "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tzdata-2023c-1.fc39.noarch.rpm"
+          },
+          "sha256:fcf6c828babc018410423095e394a1aa7a5413f607baf24abb55b548e33e78cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-pam-253.4-1.fc39.x86_64.rpm"
+          },
+          "sha256:fd1a1c800bcc7d0e06d4038c6810600d9e2ff724224d63b26761b9a96b33ac87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gawk-all-langpacks-5.2.2-1.fc39.x86_64.rpm"
+          },
+          "sha256:fe989073e3aec81cca954445fb43cf13c7fd874c5686f7f695ff06488c1eda33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc39.x86_64.rpm"
+          },
+          "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm"
+          }
+        }
+      },
+      "org.osbuild.ostree": {
+        "items": {
+          "": {
+            "remote": {
+              "url": "http://fedora.example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.24",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/alternatives-1.24-1.fc39.x86_64.rpm",
+        "checksum": "sha256:eb835856d36f045c746ab03243fb969fc5fa1950420e37c3bf9782359a9f3847",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.1.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/audit-libs-3.1.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8cc74cc914879c947f99db519e0501916f298aeb1a4f66dfd3996ad7802d49b0",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/authselect-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f4a9066b30983c17036794e7873dcd62acb2559ebd298d00bbf27a555bc1e0db",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/a/authselect-libs-1.4.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:156c71be29a4227e99d5198272a6fdbd38f25884de10bd3b03722602f383e56d",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "15.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/basesystem-11-15.fc38.noarch.rpm",
+        "checksum": "sha256:16d1843cdac488ad04bdc654dd6b8dfbfeafe33a7728695070481302a7e54345",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.2.15",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bash-5.2.15-3.fc38.x86_64.rpm",
+        "checksum": "sha256:aafa892d920ab841a6e6076da3f0bfd4d5783a88927473acb6fd8cdff1686f90",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bubblewrap-0.7.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:228e3e665e38c1e49397b1fe6e1c98aa29b7434e8aa25b39a44b3edc5a362aa9",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/b/bzip2-libs-1.0.8-13.fc38.x86_64.rpm",
+        "checksum": "sha256:e0214026e8899bf3455f97bed98c287644e52f9350ce977fd0ccab05dbb35b77",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2023.2.60",
+        "release": "2.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/ca-certificates-2023.2.60-2.fc38.noarch.rpm",
+        "checksum": "sha256:3ed298c957602edb7ce91e0d06c4cc876c645d5e9848cd9553b5521ab1dba8a0",
+        "check_gpg": true
+      },
+      {
+        "name": "container-selinux",
+        "epoch": 2,
+        "version": "2.215.0",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/container-selinux-2.215.0-2.fc39.noarch.rpm",
+        "checksum": "sha256:c3273470e3aaf6fabed69989b73a88426d24fea8e4d6ae9a3d66800b11570c72",
+        "check_gpg": true
+      },
+      {
+        "name": "containers-common",
+        "epoch": 4,
+        "version": "1",
+        "release": "90.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/containers-common-1-90.fc39.noarch.rpm",
+        "checksum": "sha256:313bd85eacb108ae0b5b978aa06398e124b82edd59882a97f2a3bd77cb4acce4",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/coreutils-9.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:0d8ef8fcd46894ff5a251f95f07a1ee87229f994657fb53f0916adc990d51114",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/coreutils-common-9.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:57c69aa24e2d6d55c105308b53f43efbfeea4c2db30275f6cd6e3bd4a1ca5543",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cpio-2.14-2.fc39.x86_64.rpm",
+        "checksum": "sha256:ea3594b4da09e293128d760f08964ecddbfe56bb37a4c8ca874dc215bc0a6240",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cracklib-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:d792de0f75798996e8cf2851ae04b3a47d3e267bacffbfcfb02a3d9571f9be00",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.7",
+        "release": "31.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cracklib-dicts-2.9.7-31.fc38.x86_64.rpm",
+        "checksum": "sha256:77e278739167196fcbf7b6a538e954dc7857c3ebe1dad36a3940be0128746d60",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20230420",
+        "release": "1.git3d08ae7.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/crypto-policies-20230420-1.git3d08ae7.fc39.noarch.rpm",
+        "checksum": "sha256:d8f4974de342a29c99ce09465fd6981544102cf885555d790f265e140cef267c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20230420",
+        "release": "1.git3d08ae7.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/crypto-policies-scripts-20230420-1.git3d08ae7.fc39.noarch.rpm",
+        "checksum": "sha256:0112597bf263e0f7a574d1ee171757c0dbac23d6b537d1890bd856e01a687cd4",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cryptsetup-libs-2.6.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:80a414135a766a8ca123eb392157e82e837aec38c4d6aec849d62494a1acf28f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "8.1.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/curl-8.1.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:be2f5eac315f6072198d5f87a6037759814bc7264cf94b4bbc8ad66aeaf2ed70",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "10.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/c/cyrus-sasl-lib-2.1.28-10.fc39.x86_64.rpm",
+        "checksum": "sha256:73ee1a84d31b48a42ee6c696d1d667af34f621d6c9219793807a3b6024af6147",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-1.14.6-1.fc38.x86_64.rpm",
+        "checksum": "sha256:0ad0000a318a04be81dc299677f2993b7283c39c5a350a56888c1266194f7602",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "33",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-broker-33-1.fc38.x86_64.rpm",
+        "checksum": "sha256:527026089d1cbf7b681d916a37078e552349c7183df0bc51a37276c330391e22",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.6",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dbus-common-1.14.6-1.fc38.noarch.rpm",
+        "checksum": "sha256:42a6fa3db480f36554e51af9ca2c25a523e005ea09dfe3489403254496934e66",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.195",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/device-mapper-1.02.195-1.fc39.x86_64.rpm",
+        "checksum": "sha256:e3f8afa97eeb9c4325d3769bb4adb5d8a96368f7d5b1143ae7755781e779642f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.195",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/device-mapper-libs-1.02.195-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1e162adb4f6c5086eab94b74195730aeb368f44602113bed28053add9fe4899e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/diffutils-3.9-4.fc39.x86_64.rpm",
+        "checksum": "sha256:d76577b5519ff6b3f880db9fef7ca75299fb418c8fa56fda0b0c120654347cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dosfstools-4.2-6.fc38.x86_64.rpm",
+        "checksum": "sha256:9e25af815ea18afcfe8cab5f50fec3b2c8e602880e912b37dbc07e81e7a48f69",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "059",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dracut-059-7.fc39.x86_64.rpm",
+        "checksum": "sha256:20a930701288dcbf5c42d5a04cd0e937def48e58c65cd195d413682ea5e64042",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "059",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/dracut-config-generic-059-7.fc39.x86_64.rpm",
+        "checksum": "sha256:006b1170b14abee2bb43f76ffc458c6450c047417835c0d09c281435bc614074",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.7.0",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/d/duktape-2.7.0-4.fc39.x86_64.rpm",
+        "checksum": "sha256:4928acfd884ee06d6447ff1b91fcd5e0de795e7219fac59a9931a2bbeea0c324",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/e2fsprogs-1.47.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:7645bf740146b2077c5acc47a77ba74edf469c5a9fc9b257229eef89e85508e6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/e2fsprogs-libs-1.47.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:60fe08cbf73b90659cabe9913c3d5e83319349b535135a38542706f629df1091",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "7.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efi-filesystem-5-7.fc38.noarch.rpm",
+        "checksum": "sha256:bba199cbc2d5363334072bc40d868c9c0ff301d67dddd14a55f032043c9dc824",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efibootmgr-18-3.fc38.x86_64.rpm",
+        "checksum": "sha256:3d57c8a275a9db4aaa234a73685d075b74b00930d7881ed7892748b790773764",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "7.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/efivar-libs-38-7.fc38.x86_64.rpm",
+        "checksum": "sha256:8ff9a034c4cc68941868d2fab9fb0489fb7d2f7667ce3fc645c296b70ecb408d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-debuginfod-client-0.189-2.fc39.x86_64.rpm",
+        "checksum": "sha256:0310624a74bd6b7f44fad718f647c420843644e97016800439e69a299697d309",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-default-yama-scope-0.189-2.fc39.noarch.rpm",
+        "checksum": "sha256:1612ca0d6402f141e2cc0513b6039792f467980391260dd88456e78dd48455e4",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-libelf-0.189-2.fc39.x86_64.rpm",
+        "checksum": "sha256:955da59fbf469b921a80511276bc9a9700c6cb55e929b35a17011223a319c060",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.189",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/elfutils-libs-0.189-2.fc39.x86_64.rpm",
+        "checksum": "sha256:d62d5f343ff9b76505d1d6184b71f581549d2a5de971b55bb1ab261c4ae4072c",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/e/expat-2.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:2af61bff099ba092381fc3bcfad33abeb46e0bbd80d39957160ebeeeae6662af",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-gpg-keys-39-0.1.noarch.rpm",
+        "checksum": "sha256:04db736a77296edd4099a9165d68560d52dbf2484d959f668b3b676d68581f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-39-0.14.noarch.rpm",
+        "checksum": "sha256:cd7883bd98e6fc0f6ddd92c82858a3329d2c59226ae7613d0f418b90fe95a02e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-common-39-0.14.noarch.rpm",
+        "checksum": "sha256:6a6b4fd70ae10b80de13adf540d53eb0c9ef0c2c5a69627f278d4511c4bc4ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.14",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-release-identity-basic-39-0.14.noarch.rpm",
+        "checksum": "sha256:a785601630116025e15e1cdb65ab2a289f3724cedcf76163ab5660688f89e543",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-repos-39-0.1.noarch.rpm",
+        "checksum": "sha256:8ecb72298a8b662ee1a17e7fb4e1d279d7fc64b358c9fdf9a568a965022b3f97",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "39",
+        "release": "0.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fedora-repos-rawhide-39-0.1.noarch.rpm",
+        "checksum": "sha256:3908078cd7debb2b2e081a7ea30fdf598f702ba7e65db7159836403940ed2421",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/file-5.44-3.fc39.x86_64.rpm",
+        "checksum": "sha256:2ab7064e7397e2b8b9ac22b9d9c897878ff1297848f8cb96b87e9a7b7d9faa55",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.44",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/file-libs-5.44-3.fc39.x86_64.rpm",
+        "checksum": "sha256:9837b923649219a283b5bc3d8e47c26b739363c1a523b741bb3b573c687a745f",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/filesystem-3.18-4.fc39.x86_64.rpm",
+        "checksum": "sha256:38e188b7682c3df92bcebd568812b4f0de6f35d785a7d3e568acc3e6e14c28c7",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/findutils-4.9.0-4.fc39.x86_64.rpm",
+        "checksum": "sha256:0c09b8baba1b6be5ef2a94c9e3ad07fedb625a411d7a99c669dda0e55c27a736",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:d949521c5b898a94e9c3e2ffed751671b652687b34016ceca4bef650c68eb3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-common",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-common-3.14.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8aff56649b7b745500a60caa55bd469c201328f1ddfa16f74a23f43a3004bb3c",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "16.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-libs-2.9.9-16.fc38.x86_64.rpm",
+        "checksum": "sha256:9f6c383fa225665fc42dc174762cee30f9ae6ffcc247b324cc3cfa67ff75ba44",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-overlayfs",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse-overlayfs-1.12-1.fc39.x86_64.rpm",
+        "checksum": "sha256:aef8ff2c63a174ef441f8889d795234f320679e50d38b1a6955b6424a6039caf",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse3-3.14.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:5d5c08d98e74fe1a618c9bea726e78b75b8132d91ef44ebfb3c603377993582b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.14.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/f/fuse3-libs-3.14.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8ff413cc487159e3c2ac31c8c77eddce474f9fe3347b362212ddd463aa274718",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gawk-5.2.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:70a7b76c6aa853ef743f3646b0f9a400ad155c78f47507ea400b5537645c8d20",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.2.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gawk-all-langpacks-5.2.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:fd1a1c800bcc7d0e06d4038c6810600d9e2ff724224d63b26761b9a96b33ac87",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gdbm-libs-1.23-3.fc38.x86_64.rpm",
+        "checksum": "sha256:212cb1084c3d5a05d12308d768417dd12678a860ccfc89c2f70dada566e11259",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-envsubst-0.21.1-3.fc39.x86_64.rpm",
+        "checksum": "sha256:7aa3ee6e85b55d58e59ddc48e2727ed2d06938cca185a75b5e9426987f1a6063",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-libs-0.21.1-3.fc39.x86_64.rpm",
+        "checksum": "sha256:c2ef60c43740b193dd7bdf4795157c10a6838040e674da9daebf9e28747865eb",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gettext-runtime-0.21.1-3.fc39.x86_64.rpm",
+        "checksum": "sha256:9a8262bc8458695f372e2a5055bad29d94c07ac8ebcd91f812ff615287fff523",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.76.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glib2-2.76.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:868593df2ef1d2c6cf3f025956ee607935a5c1623065912620c30500c56775c7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-2.37.9000-10.fc39.x86_64.rpm",
+        "checksum": "sha256:b1f83ecafff885344f8b23836cb14d73ecba9c13a8cd8e9cd723232d02f48ffc",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-common-2.37.9000-10.fc39.x86_64.rpm",
+        "checksum": "sha256:b22a27d3815f9111396d6b2b61606cd84019b845d40c1b8b8aca749a629b9e36",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-gconv-extra-2.37.9000-10.fc39.x86_64.rpm",
+        "checksum": "sha256:8464e945a2e8bb307adcbca6fcc4e0451703d4883ff4419e0771e8a6e8727de6",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.37.9000",
+        "release": "10.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/glibc-minimal-langpack-2.37.9000-10.fc39.x86_64.rpm",
+        "checksum": "sha256:9ecd54c8a01901840ddae836ac0387ebbad90176412c0793addd80df0f5d1d13",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gmp-6.2.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b940446486f6dfaa2a7651fd9cf7050cae6171d75b7fca865fa8d58400c1a0c7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnupg2-2.4.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:78523ce49fe3674ea56a5003169754f3e50fd9897cd2e5a5204eba2996ddd0cc",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnupg2-smime-2.4.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1e9ac2555738ff142d2ddf9d56fc1a3b0d16d9ef72abd7223d3ca7057ef314c2",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gnutls-3.8.0-3.fc39.x86_64.rpm",
+        "checksum": "sha256:e3d7753b1ab0a74908e45a734a5bfd6d4ae646b91a4ea345b7264eb5cdec784d",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.1",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gpgme-1.17.1-5.fc39.x86_64.rpm",
+        "checksum": "sha256:a8a381267845f761809f10b8d27db002a1a5c6b2b54bd6720fa0d921439268f1",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.9",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grep-3.9-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1edd6d0c726af868fe64c6fb8e62b72e55dbad94ae0e3a835548aa1160f57bda",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-common-2.06-95.fc39.noarch.rpm",
+        "checksum": "sha256:f4671bf52118b3de4a1d164851d6bfcef188d799398ac1742994fd4719ed8223",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-x64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-efi-x64-2.06-95.fc39.x86_64.rpm",
+        "checksum": "sha256:767173f9cbfadb1d521f0790c335386d3c78258f9180dfb9e25d2c7b9c196f03",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-tools-2.06-95.fc39.x86_64.rpm",
+        "checksum": "sha256:d57d2d449e5a93eb7b30b1b6cc9724f8b688cbaad9a7e36aee19bdd0c85234f3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "95.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grub2-tools-minimal-2.06-95.fc39.x86_64.rpm",
+        "checksum": "sha256:fe989073e3aec81cca954445fb43cf13c7fd874c5686f7f695ff06488c1eda33",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "70.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/grubby-8.40-70.fc39.x86_64.rpm",
+        "checksum": "sha256:30eea609388f8cf3f8418eb7e648262d5053f9171eb627225c89118dda9faa6e",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/g/gzip-1.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2ee988694d3c875dcaa4741453ee07b4dc1da31205abb035065dbc7c8c72c0da",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/j/json-c-0.16-4.fc38.x86_64.rpm",
+        "checksum": "sha256:d06140e05f5d7c831331260a898d83e5079a3ead0f4616925dd94da8a33e5ede",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/j/json-glib-1.6.6-4.fc38.x86_64.rpm",
+        "checksum": "sha256:5540bc7f5d2f38cc82aa329a0c2078060a13dd27096238776f7b063cae7ccd70",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-2.5.1-6.fc39.x86_64.rpm",
+        "checksum": "sha256:3a89c4d880c7ae63c118f4c0a72045aa1e808d8e18e6073cc9d98827a639308b",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-legacy",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-legacy-2.5.1-6.fc39.noarch.rpm",
+        "checksum": "sha256:3e7b0cd5b69b81bf2cf1f1e333dfbfead1b86c887d9fc76ae0ca8e34a6d5deb2",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kbd-misc-2.5.1-6.fc39.noarch.rpm",
+        "checksum": "sha256:51f6c1fe0aa6873903a18bf749e3a859fd5a14a693a7e54082a8c94b752e0bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/keyutils-libs-1.6.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:a8003e886f65342e06c75edaef2bc54b1f313a9b19ba3d8b573b7b72a9583d87",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kmod-30-5.fc39.x86_64.rpm",
+        "checksum": "sha256:c8e26fcb8a1f642322fd5376ab4ef7410ad40029f8cdb585991dee4fa8a10691",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kmod-libs-30-5.fc39.x86_64.rpm",
+        "checksum": "sha256:2654e400f0593b675018665d85a212c1209045140b26a2484e11b98806e3afba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/kpartx-0.9.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:37e71790208f46ea301306760e10488ef3701968b71c83d87dd78a3f91bb3498",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.20.1",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/k/krb5-libs-1.20.1-9.fc39.x86_64.rpm",
+        "checksum": "sha256:96e794f0c3a2d542760e6584f792b76b187699f58e218ea84d1232d1f43ed0fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libacl-2.3.1-7.fc39.x86_64.rpm",
+        "checksum": "sha256:181be68c4f916f1c9a3f8f396ef986c51e5c97203ca0b43f63a534755fba9f71",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libarchive-3.6.1-5.fc39.x86_64.rpm",
+        "checksum": "sha256:c4b337632153e008b8fcd39c5cafedb90fb03c6e765ebc610b0effb6e9409721",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libargon2-20190702-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8a930ab3e11e25093f322f907e1d96cf38d75054b2566611c4414723ac1b5016",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libassuan-2.5.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:13b6ee1aaadee8fc6ad6713f6fcca12d340d8b662c341ef11eb1bbca9f28b1d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libattr-2.5.1-7.fc39.x86_64.rpm",
+        "checksum": "sha256:a396dde8ccb97e481d2168db1e86abba8d3f6d34096d8b96596f60ca812d0f37",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libb2-0.98.1-8.fc38.x86_64.rpm",
+        "checksum": "sha256:9dc90426b66ef657dd666b8cff6a8b79d97049940e04fe432c1679407d7190a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libblkid-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:61f88ec5e6d0c9f31b5357dbb92d6ce3e5600adeb7571d1234bbbb551f053d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "11.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libbrotli-1.0.9-11.fc38.x86_64.rpm",
+        "checksum": "sha256:1437effaa1e9cef61e6d942b5e7e352965d33e44666805fd4107f660d7a825e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcap-2.48-6.fc38.x86_64.rpm",
+        "checksum": "sha256:e848c54481fef3a2afc80a5c38dfd580ec05d821d65361d48a989128c36e5aaf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcap-ng-0.8.3-5.fc38.x86_64.rpm",
+        "checksum": "sha256:5a8b121b402d579ba941a7e47513e68ffce46211b252d022ceef6d38706f7328",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.10.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcbor-0.10.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:c7428fe201f901420f8b84fe5271744d97aa06eff52ebe35b6b1671531e54418",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcom_err-1.47.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:b1c10202830b213b7e9b9f50102c4748c561a7f5206723b386b802ce8994f954",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "8.1.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libcurl-8.1.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:d32ed5b5ff107cd1bf19e6b76ba748a037aef62f8e3b5dd3179ea2aa0c74be9f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "55.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libdb-5.3.28-55.fc38.x86_64.rpm",
+        "checksum": "sha256:24b6237f18f6e0643e96a882d3711b5e7411256fffc547ee1a4daa7da0a62f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libeconf-0.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:ed115185dd2524d6ad37c4e5a7c26c2ef11461ddd2d52a4e0c73c9b61963f709",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libevent-2.1.12-8.fc38.x86_64.rpm",
+        "checksum": "sha256:0bb1b0d7fa1b5107c98636cc9046912b848e770eefa43161127392bb86ab4559",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libfdisk-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:94cbe113d9e38f6470424ec19c2fda59d136b1fee40515e6ad8ed98ee32b37fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libffi-3.4.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4cdee7e7f885d9efe8156bd86e644e2b45f34537870f30c17bbd5113e493b994",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.13.0",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libfido2-1.13.0-2.fc39.x86_64.rpm",
+        "checksum": "sha256:eaec98669b65aa4761783244a9bcbae47dedae32889d1b9cac72ad74fb165951",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgcc-13.1.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:716d341d5a507e1544984a9d6ec78994feefd29b36f4e5f595874e25a644247e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.2",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgcrypt-1.10.2-1.fc39.x86_64.rpm",
+        "checksum": "sha256:56aed0f06d9ad990a1813d8b9824cb0dcf188934b83054e38028387dc95b39fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgomp-13.1.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:e0a98adb477555c652bab41d316ec5ec0d0135a5bf1d84c8fc377dbee3505ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libgpg-error-1.47-1.fc39.x86_64.rpm",
+        "checksum": "sha256:488ec81c9d15610909d7a4c6e2c37ef51b51371185b264c8b11a55deb93dc3b9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libidn2-2.3.4-2.fc38.x86_64.rpm",
+        "checksum": "sha256:e24b40ad581933d9ca22b525c434777d90a46cb4c0b097c497c788e49fd946d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libkcapi-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:0dbf7d0db94a9cf1745aedb5462d6877d82a99f9010f5037c796ba41f5c737ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libkcapi-hmaccalc-1.4.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:96ceddead12aca9f75215a0492c6c0308902a55e1d756267dedc7fa68850aef2",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.3",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libksba-1.6.3-2.fc38.x86_64.rpm",
+        "checksum": "sha256:7036d00dd6f881adb9e4870edfd5a1240f5b647084ed53be464cf8cc6d40c452",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.15.0",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libmodulemd-2.15.0-3.fc39.x86_64.rpm",
+        "checksum": "sha256:d2c53fedd5371a684d059b939768d09adbf3cba78b6bcc9d0a4914abbcf86006",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libmount-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:800019fd157eca7e44e83a9c895bbff73f18496d214a119b6bca38af249caba1",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.53.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libnghttp2-1.53.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:c7dc459b85d56755c602c468dd1e04a7264a170593d68006ac7c633c13db0be3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libnsl2-2.0.0-5.fc38.x86_64.rpm",
+        "checksum": "sha256:e88d40b14861564cbbf640d366076b5b381cc3a30d818930f043dfb3f158e68a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.2",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libpsl-0.21.2-2.fc38.x86_64.rpm",
+        "checksum": "sha256:8cb49ad623d30a9fbe923b31b0413732b22f8763ec719efdcb535a356a9d0d6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libpwquality-1.4.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:893d2125cc10c36b67e5d04544015be0f27d5a99e2ac83ba14904219c5e15d68",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/librepo-1.15.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f18410a0d1d25049f39315372924c318314254cba55f2d3f24d0c28e31cbbbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libseccomp-2.5.3-4.fc38.x86_64.rpm",
+        "checksum": "sha256:843187a57219bd86402b570db6ce0b7ef50e9bd3b7dcf57124542356c85e4c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsecret-0.20.5-3.fc38.x86_64.rpm",
+        "checksum": "sha256:ff4d38483cd963b3f43c45738773b2998257e1cd1ed2b9da1ad3770bf6357edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libselinux-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a861e4c858fb8b7b246c9a5156780ef9188e5058b430a09d5274cf8154e4651b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libselinux-utils-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:89ea4d920d4b97d56fc88c4abcc30454059e2a5698aba86633a29346c4d66d88",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsemanage-3.5-2.fc39.x86_64.rpm",
+        "checksum": "sha256:273b7d3fbe2c812d9cf06f24bf3141b02a54fe9b7175ed23838e82fe8852154a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsepol-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:a119520536c2d78fe4ab09fa36de55321fa5a926aca955640504d6fa7e98790b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsigsegv-2.14-4.fc38.x86_64.rpm",
+        "checksum": "sha256:2f95ec8a9e82166735d2a0dad196caf86d3b03b1d751333664fdc49af04652e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsmartcols-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:88d19855ca938090164dba958798a20e512d0da888838b6d88aad7ea421a29a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.24",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libsolv-0.7.24-4.fc39.x86_64.rpm",
+        "checksum": "sha256:1083fe64f92b2a32b72f14a0555e7784edeccbcdbbff092968811373f1edbea0",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.47.0",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libss-1.47.0-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8b71d508e39018159be171a6ef96a9b155608dd1c137db9920d7d849f24f0c13",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libssh-0.10.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:aa5d460a6e4d0f4e49a06e072c494a10192c081a588d99e573b96ef0cbaa903b",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.10.5",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libssh-config-0.10.5-1.fc39.noarch.rpm",
+        "checksum": "sha256:2ed3d68a5e88b5c3a11f4a4c988d6dd2bcb5c89517d4d27910d0ac2604deddf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "13.1.1",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libstdc++-13.1.1-2.fc39.x86_64.rpm",
+        "checksum": "sha256:258f27be13bc01697e7001c58edfacfc3105529b3746edf62028df487ad2e0ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.19.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libtasn1-4.19.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:755f70836736d33825f0ca0a30966364f9c47f336a9679647806efca38935468",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "1.rc1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libtirpc-1.3.3-1.rc1.fc39.x86_64.rpm",
+        "checksum": "sha256:9c33edcd3d84366edea3ae382be8ba3fbb212173e9bd6b3e15bd6391918298ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libunistring-1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:2cf3c52adb539112d160d78ad0eb0536f41a4fc0087ca74043de59267ae397ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring1.0",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libunistring1.0-1.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:a437f855037feb83c8388e0d7799050d178a0e33b72ca2b2845ade7182ad104a",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.26",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libusb1-1.0.26-2.fc38.x86_64.rpm",
+        "checksum": "sha256:a6e85db2da9cc041eef3c34d38d50ec07e0c71a1c1aff8772296572c987076c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libutempter-1.2.1-9.fc39.x86_64.rpm",
+        "checksum": "sha256:d268e37c04086d3ab838d08773d7e59b8d3cc29468aee480f371f3ca7d344eb1",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libuuid-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:72cd25608a61934f3f05ebf31af5b39337a7301a7cfc55f83f05dcd8f910d101",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libverto-0.3.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:a724e47d0afbe9ea8b8750ac8b1db8e1faad7cb77f7dc1907990789f5f5dec71",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxcrypt-4.4.33-7.fc39.x86_64.rpm",
+        "checksum": "sha256:71a9cbe5c77f55cac9084cbff178924e28b44981a53f82c66c3053521875c39b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.33",
+        "release": "7.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxcrypt-compat-4.4.33-7.fc39.x86_64.rpm",
+        "checksum": "sha256:27a0bdd0cd20b0e73f2285100a00a81eb162687d159f5952dceb8d298e34ef66",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxkbcommon-1.5.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:f9950c21e3c2932edd669e93be82ae8343cc6ec7b0aa2a9e3656b4b449758658",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.10.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libxml2-2.10.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:937fab58a2b115f7e5a8d5f7fc3af35d4e62b2ab89979f449704acb10f0041eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libyaml-0.2.5-9.fc38.x86_64.rpm",
+        "checksum": "sha256:dae1b79663b5e2810668f0b9350e5d62b64af07cf3e6a85da386b4accd08b699",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/libzstd-1.5.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:37cbb04722c8e82f89705c9a68b0b7f68e0d8dba8ec82c549acee20968f98d84",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/lua-libs-5.4.4-9.fc39.x86_64.rpm",
+        "checksum": "sha256:245491bf843da1571cd8b6f16ec3e9569c4b983bef02a28fd53e63a1fac9fa21",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/l/lz4-libs-1.9.4-3.fc39.x86_64.rpm",
+        "checksum": "sha256:78f8a5fb4b46794d5d35bdd7a9b23b92a34979594469590d0dd003a7f6811d99",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/memstrack-0.2.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:d7c0d81cb8f51af66460df06dc8266ca59ba0fe11b9af6649268e3aed51c73b9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mkpasswd-5.5.17-1.fc39.x86_64.rpm",
+        "checksum": "sha256:413818b86694e41fc850a0c1e5ef271a5768abc42ba50896aff6f66a78d9505f",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mokutil-0.6.0-6.fc38.x86_64.rpm",
+        "checksum": "sha256:fa3d842fa6c4670b6157050baddb4f2fbb3145ef6249e12ff4d7a75661e552e7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mpdecimal-2.5.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:c98c47d647f33a5a552c0031d1c7b035a9f54a8a0ba64d220f1b90d4cb990926",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/m/mpfr-4.1.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:4dce785f0955e4bc212f5642fbf76752e8e758fddaf31d423c76064442c382a4",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "4.20230520.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/ncurses-base-6.4-4.20230520.fc39.noarch.rpm",
+        "checksum": "sha256:ab2a8ac0ee9d4915b2bbe7d90c039d43c4bc5b601498d57f7dcada384461ab76",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "4.20230520.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/ncurses-libs-6.4-4.20230520.fc39.x86_64.rpm",
+        "checksum": "sha256:bc992a3e8583f101e197c1f399c9cbb3893ea6d2f0e2f1884012ec19458b3afb",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/nettle-3.8-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1ab436b853babb890810427c0906f401a8778570d9c106aae2a93dd689b56395",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/n/npth-1.6-13.fc39.x86_64.rpm",
+        "checksum": "sha256:620b8720dbb4379f217ff053e4704ba696c7cbd0653dc27799f5bbd444d09276",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.4",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openldap-2.6.4-2.fc39.x86_64.rpm",
+        "checksum": "sha256:2ed8a6870e2ea4d8f15c3755826a4960bb4650d4508240920fcc8f9ab584a6fb",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.8",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openssl-libs-3.0.8-2.fc39.x86_64.rpm",
+        "checksum": "sha256:f665b677b629f2a2071a84aaacc43dfd796f4b754bc7d1a6a07c464d1815e723",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/openssl-pkcs11-0.4.12-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f2f6a4a9a1bdc46e03263959c4a898c29d9873ca2c031a61f365c6842823eef4",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/os-prober-1.81-3.fc38.x86_64.rpm",
+        "checksum": "sha256:9f196c1696af163c77062c566618e52a7df7fe6d0f76744596d00d15a86a3ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/ostree-2023.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:81dcfec54c9a80d975082c81c4499b3cf5d3b274a7abec61120a2618edeb2030",
+        "check_gpg": true
+      },
+      {
+        "name": "ostree-libs",
+        "epoch": 0,
+        "version": "2023.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/o/ostree-libs-2023.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:c33ddd0dc40734dea853bd809911929630b7f6f90e0e1e95998295daa3a43029",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/p11-kit-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:3d099f56457cac6b78d5a7fa1a288449b2fd40940ba79c38f3a8cdf72de08d0b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/p11-kit-trust-0.24.1-6.fc38.x86_64.rpm",
+        "checksum": "sha256:17ccfb5f326ac494420b346b6a19633f6a29666edff3bd2927b24a181c30043d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pam-1.5.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:18804fb738573ac3a2ec9a576fad7e64d87a216793ccb5c98037a12ae99d3ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pam-libs-1.5.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:be0e52f22a17bbd964c1c0a0d60e4f69a8950a1f05975fe6a4e18e8cab719304",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcre2-10.42-1.fc38.1.x86_64.rpm",
+        "checksum": "sha256:8e9d90ae76137486c9584ad0ff007348d83349fe97e29310659b13057dba78b4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.42",
+        "release": "1.fc38.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcre2-syntax-10.42-1.fc38.1.noarch.rpm",
+        "checksum": "sha256:4f19a70d3fbf30ac298700d3918d7fb483a387adf3d08b96efaa07d51dd0b156",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:25a1a5f81238d9ba5b45b29bfec7a842281f7b623d218b0aa2deb5c6ac7e3bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-ccid-1.5.2-1.fc38.x86_64.rpm",
+        "checksum": "sha256:38ff8aa05c220dd39d0c93be24ef211424a04ee3ac3ad9ea67906e38b799bf22",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.9",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pcsc-lite-libs-1.9.9-3.fc38.x86_64.rpm",
+        "checksum": "sha256:35146cabf07ec78d2390120c9bb9e2f5aa35cb8e0bfff84fb748a198b90ce3ac",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pigz-2.7-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1ac270e3158bcf929b5034d3b8e03d28e877e364b9c1d9c769bf54af783973e9",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/pinentry-1.2.1-2.fc38.x86_64.rpm",
+        "checksum": "sha256:72d5ce188da2f45a3450e472bfde16b72d8d881414298ea3cf321628cf1fe646",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/policycoreutils-3.5-1.fc39.x86_64.rpm",
+        "checksum": "sha256:19d52491b049e52228176ecffcedf9a76ddff15bfb2afd8d91aeb76a24b9f277",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "122",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-122-5.fc39.x86_64.rpm",
+        "checksum": "sha256:ad4871ba6d81395cbd4817de5b661c7d4262a6f1e8a03511a529f75281ae05e1",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "122",
+        "release": "5.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-libs-122-5.fc39.x86_64.rpm",
+        "checksum": "sha256:8a67860c7779aa8faffe6df84106d8f1edaa67ac4d52db78f90924ff0cf724d3",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "23.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/polkit-pkla-compat-0.1-23.fc38.x86_64.rpm",
+        "checksum": "sha256:fafbb148be2f9e1e78095899314044e1ee30a14956b38f295a24f32f3832abfe",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/popt-1.19-2.fc38.x86_64.rpm",
+        "checksum": "sha256:00c43379a70e7167e59f71d7da775489dc2f218c768cff68c1edc8e51f35c2c5",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "9.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/procps-ng-3.3.17-9.fc38.x86_64.rpm",
+        "checksum": "sha256:139c6a046ae7b9a5693783f75a28b2b99b9411b62e89df3ca634d8b950d7d005",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20230318",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/publicsuffix-list-dafsa-20230318-1.fc39.noarch.rpm",
+        "checksum": "sha256:d788820fb30eb3c1f1a89196f50775012cb36cf7c2b8794b1dfdef0e5358c4c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "23.1.2",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-pip-wheel-23.1.2-1.fc39.noarch.rpm",
+        "checksum": "sha256:83833a1fd03e6a13c14251b21fa40d6b1349d37e91f27ef76cd350d2ae0b43fb",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "67.7.2",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-setuptools-wheel-67.7.2-2.fc39.noarch.rpm",
+        "checksum": "sha256:474fdfa51df9c79234469a87e3f5491acd6c3b50c6a141f4f06aed0480a95f15",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python-unversioned-command-3.11.3-2.fc39.noarch.rpm",
+        "checksum": "sha256:be1676b477df8e053e0ff8c65f7f03bdcaab90d1a795e1ec9f3bc04eaa4116fc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python3-3.11.3-2.fc39.x86_64.rpm",
+        "checksum": "sha256:787d6dd0b7c35906ced566f5736514fc23bdf1aea2f8d53b373a1e26fb102b93",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.3",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/p/python3-libs-3.11.3-2.fc39.x86_64.rpm",
+        "checksum": "sha256:297427a147dbfaee9ccf62f5b932c61e20ac1f4c51c59fff08f2bfa7ce8e030b",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/q/qrencode-libs-4.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:b8d6d9c6f976e196f8eb0a8d04ca1f02821d0dbc904120d0c4bd7d7fc2ef8fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.2",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/readline-8.2-3.fc38.x86_64.rpm",
+        "checksum": "sha256:1a878a4a0448222e0a34864ef4f3c8b674b05ef08a05ea992d9c50b3ecbae10d",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-4.18.90-9.fc39.x86_64.rpm",
+        "checksum": "sha256:0f8d70087a096464aa39765b43896756bc2fcc240761b20a5ced18b5e8a96eba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-libs-4.18.90-9.fc39.x86_64.rpm",
+        "checksum": "sha256:d87d83fc74ac91caf86d4279b314cf61571db64eb306a966b9b13ed46b144370",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-ostree-2023.4-4.fc39.x86_64.rpm",
+        "checksum": "sha256:bf7c75ed0a42709af3f9a106e50b4c7115df6d0e31436e08538526b9bb9a5fc1",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-ostree-libs",
+        "epoch": 0,
+        "version": "2023.4",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-ostree-libs-2023.4-4.fc39.x86_64.rpm",
+        "checksum": "sha256:31954f960d6568c7099e5643df604bae2b8a5cea80964f7f2e38fba33f4282c2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.90",
+        "release": "9.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-plugin-selinux-4.18.90-9.fc39.x86_64.rpm",
+        "checksum": "sha256:71c070018b837af835d854d206763b1e2c7dbd1be174b8af9d2320671ba5f51b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sequoia",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/r/rpm-sequoia-1.4.0-3.fc39.x86_64.rpm",
+        "checksum": "sha256:9e7c2ace9e7277c41e527ccfe1b2dd7fb2d6e3a551bbe530120c373433f83450",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "12.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/sed-4.8-12.fc38.x86_64.rpm",
+        "checksum": "sha256:13767df6745449f9458b4097fd10cdc5a6f577f53a14cf4d3608052a9cb368a3",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "38.14",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/selinux-policy-38.14-1.fc39.noarch.rpm",
+        "checksum": "sha256:66f488c41b5d33fb67b76f0be0d088f66c903f872ba4a3c425c34acb8678de66",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "38.14",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/selinux-policy-targeted-38.14-1.fc39.noarch.rpm",
+        "checksum": "sha256:6f78bbde50a94674042f5be5a152024e800d45e6bbe74c4a55f64ed836b66dea",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.3",
+        "release": "3.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/setup-2.14.3-3.fc39.noarch.rpm",
+        "checksum": "sha256:e10c0ec1a70226866cd13c044cdb398d519fa28ae3f2cf5747b6ce799d3bd0c5",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.13",
+        "release": "6.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/shadow-utils-4.13-6.fc39.x86_64.rpm",
+        "checksum": "sha256:c8a2cbec7fc78f885cf077f6ee088e64634a48694b94e611ad57f9ee15314731",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-x64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/shim-x64-15.6-2.x86_64.rpm",
+        "checksum": "sha256:174bda41056c4cac41ef9bf8a7adb06affd92bcb18a258d319b9153bf0f00686",
+        "check_gpg": true
+      },
+      {
+        "name": "skopeo",
+        "epoch": 1,
+        "version": "1.12.0",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/skopeo-1.12.0-2.fc39.x86_64.rpm",
+        "checksum": "sha256:1f492b502b6fcdbfb00da1806098c72fd6c98a933de1da88e6ccb9ab94b3489c",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.41.2",
+        "release": "2.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/sqlite-libs-3.41.2-2.fc39.x86_64.rpm",
+        "checksum": "sha256:58097fdce516150bfd8672b27bd81216bd53ab8018f641ca589d1b8296bec4ec",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:c50fd2a65b6513c225497edda88cdff2a4fa28b58677547c35854e92f6eb8416",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-libs-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:1b31f3c7b4597ee1de8fd41df3eeac17f0c7ce80cf5940175b177c73c5051245",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-networkd-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:697b90a3d3df742a19ffbbf1a2b1f3d078555a599948863018358f3e49d34df3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-pam-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:fcf6c828babc018410423095e394a1aa7a5413f607baf24abb55b548e33e78cf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-resolved-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:25fbeb94c8d80e57041fe3ff25ba592f0a493f42c40d5074d3e7ebe8892b5755",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "253.4",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/s/systemd-udev-253.4-1.fc39.x86_64.rpm",
+        "checksum": "sha256:9adc6495a79fb9c91da51c4dbeeed3e4065527e1229f8c0e57fae3c6b01898cd",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tools",
+        "epoch": 0,
+        "version": "5.5",
+        "release": "3.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tpm2-tools-5.5-3.fc39.x86_64.rpm",
+        "checksum": "sha256:2b5b235fa0b846542da3d2a3839ce9ecfbb89391dec229863bf44fe452eeab00",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "4.0.1",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tpm2-tss-4.0.1-3.fc38.x86_64.rpm",
+        "checksum": "sha256:d624895c7f19e23fb77b7f2ae21a9dcf0698820a3325ae5b1343f6bb612a178e",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2023c",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/t/tzdata-2023c-1.fc39.noarch.rpm",
+        "checksum": "sha256:fcdcbdb6c0127b1695f264a33783169cb22dc9c4159a33d3cd868fff7c39f007",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/u/util-linux-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:3aede8d217c8a83c56f09f8383bc214a2a7fac22b5d74f4edf7e25d061e02d69",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.39",
+        "release": "4.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/u/util-linux-core-2.39-4.fc39.x86_64.rpm",
+        "checksum": "sha256:f500e8074a0efa8ab9eb76113e2d51fdec550534894fbf31d7623c265318b122",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "39.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/w/which-2.21-39.fc39.x86_64.rpm",
+        "checksum": "sha256:45b50ec7c49cdaf0d9116037718e11de09c6684633ee8a6123dd1dab0016723e",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.17",
+        "release": "1.fc39",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/w/whois-nls-5.5.17-1.fc39.noarch.rpm",
+        "checksum": "sha256:05607ec505c430d28c980e96d63a399495ec87366c2893031e9fb16baf4a954e",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xkeyboard-config-2.38-1.fc38.noarch.rpm",
+        "checksum": "sha256:c77fd27cb1dc592a2d9ba9238b80aafdf340749d690f15db59e8483609da884c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xz-5.4.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8a903aba425eb2316615701eba6fab7de59d7dd4f0ab54f0c256f04445d510e9",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/x/xz-libs-5.4.3-1.fc39.x86_64.rpm",
+        "checksum": "sha256:9d578fe4710399df0da61b66274fc6d66e18d9c656e6bbf2172a075075d268f4",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc39",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/z/zchunk-libs-1.3.1-1.fc39.x86_64.rpm",
+        "checksum": "sha256:8e84688bf747e9331440d196f59da8f99bebaebc5eb93cb8c061bedf6476ea41",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.13",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f39/f39-x86_64-rawhide-20230601/Packages/z/zlib-1.2.13-3.fc38.x86_64.rpm",
+        "checksum": "sha256:6fc47cd2f53b150153a3865c2fbd6b1c57fcc265fb3602b6f4f3883cf6ec64e2",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -627,6 +627,21 @@
     },
     "overrides": {}
   },
+  "iot-ami": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "iot-ami",
+      "repositories": [],
+      "filename": "image.raw",
+      "ostree": {
+        "ref": "test/fedora/iot",
+        "url": "http://fedora.example.com/repo"
+      },
+      "blueprint": {}
+    },
+    "overrides": {}
+  },
   "openstack": {
     "boot": {
       "type": "openstack"
@@ -867,7 +882,7 @@
     },
     "overrides": {}
   },
-    "edge-ami": {
+  "edge-ami": {
     "compose-request": {
       "distro": "",
       "arch": "",


### PR DESCRIPTION
Adds the 'iot-ami' image type based on 'iot-raw-image', which allows to create a raw image (x86_64, aarch64) ready to upload to AWS EC2.

This is the upstream version of RHEL's https://github.com/osbuild/osbuild-composer/pull/3429 (`edge-ami`).

This PR needs https://github.com/osbuild/osbuild-composer/pull/3282 in order to add Ignition support.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
