### PR TITLE
HMS-1442: handle RPM errors

### DIFF
--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -309,6 +309,12 @@ func (s *Server) OSBuildJobInfo(id uuid.UUID, result *OSBuildJobResult) (*JobInf
 			result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorTargetError, "at least one target failed", result.TargetErrors())
 		}
 	}
+	if result.JobError != nil && result.JobError.ID == clienterrors.ErrorBuildJob {
+		rpmError := result.RpmError()
+		if rpmError != nil {
+			result.JobError = rpmError
+		}
+	}
 	// For backwards compatibility: OSBuildJobResult didn't use to have a
 	// top-level `Success` flag. Override it here by looking into the job.
 	if !result.Success && result.OSBuildOutput != nil {


### PR DESCRIPTION
As requested by https://issues.redhat.com/browse/HMS-1442 implement a simple routine to extract the RPM errors and forward them to the user.

This only changes the way the JobError is computed, when the OSBuildJorResult is download, so it'll be compatible with any route to expose the information.

An example of API result when RPM is causing troubles:

```
{
  "href": "/api/image-builder-composer/v2/composes/bfc183dd-326d-4cf7-a812-783585a8dd2e",
  "id": "bfc183dd-326d-4cf7-a812-783585a8dd2e",
  "kind": "ComposeStatus",
  "image_status": {
    "error": {
      "details": {
        "id": 10,
        "reason": "rpm stage failed",
        "details": "/usr/lib/tmpfiles.d/abrt.conf:2: Failed to resolve user 'abrt': No such process\n/usr/lib/tmpfiles.d/abrt.conf:9: Failed to resolve user 'abrt': No such process\n/usr/lib/tmpfiles.d/colord.conf:1: Failed to resolve user 'colord': No such process\n/usr/lib/tmpfiles.d/colord.conf:2: Failed to resolve user 'colord': No such process\n/usr/lib/tmpfiles.d/colord.conf:3: Failed to resolve user 'colord': No such process\n/usr/lib/tmpfiles.d/gluster.conf:2: Failed to resolve user 'gluster': No such process\n/usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory\n/usr/lib/tmpfiles.d/openvpn.conf:1: Failed to resolve group 'openvpn'.\n/usr/lib/tmpfiles.d/openvpn.conf:2: Failed to resolve group 'openvpn'.\n/usr/lib/tmpfiles.d/rpcbind.conf:2: Failed to resolve user 'rpc': No such process\n/usr/lib/tmpfiles.d/systemd.conf:23: Failed to replace specifiers in '/run/log/journal/%m': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:25: Failed to replace specifiers in '/run/log/journal/%m': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:26: Failed to replace specifiers in '/run/log/journal/%m/*.journal*': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:29: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:30: Failed to replace specifiers in '/var/log/journal/%m/system.journal': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:32: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory\n/usr/lib/tmpfiles.d/systemd.conf:33: Failed to replace specifiers in '/var/log/journal/%m/system.journal': No such file or directory\nFailed to open file \"/sys/fs/selinux/checkreqprot\": Read-only file system\nTraceback (most recent call last):\n  File \"/run/osbuild/bin/org.osbuild.rpm\", line 400, in <module>\n    r = main(args[\"tree\"], args[\"inputs\"], args[\"options\"])\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/run/osbuild/bin/org.osbuild.rpm\", line 345, in main\n    raise Exception(\"ahahah I'm crashing here!\")\nException: ahahah I'm crashing here!\n"
      },
      "id": 10,
      "reason": "at least one rpm failed"
    },
    "status": "failure"
  },
  "status": "failure"
}
```


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
