### PR TITLE
distro/rhel8: fix Azure EAP7 RHUI image definition

### DIFF
--- a/internal/distro/rhel8/azure.go
+++ b/internal/distro/rhel8/azure.go
@@ -249,6 +249,9 @@ func azureSapPackageSet(t *imageType) rpmmd.PackageSet {
 
 func azureEapPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
+		Include: []string{
+			"rhui-azure-rhel8",
+		},
 		Exclude: []string{
 			"firewalld",
 		},

--- a/test/data/manifests/rhel_8-x86_64-azure_eap7_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-azure_eap7_rhui-boot.json
@@ -2545,6 +2545,9 @@
                     "id": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
                   },
                   {
+                    "id": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
+                  },
+                  {
                     "id": "sha256:ca3e0ec3842accbc0b801561a716708261f7fac32fcccaa6bf70bd862739aa67",
                     "options": {
                       "metadata": {
@@ -6968,6 +6971,9 @@
           },
           "sha256:331b405a0b2b4bf93534af445da72d35eb1acd9ce66bd2d84f8ae5b169097d24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-jbeap7-20230202/Packages/eap7-hibernate-search-engine-5.10.7-1.Final_redhat_00001.1.el8eap.noarch.rpm"
+          },
+          "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm"
           },
           "sha256:336ed0cd6b743583edda90cb5730ca407721f6336b8d5eeca7d25981fcb4b28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sudo-1.8.29-8.el8.x86_64.rpm"
@@ -16831,6 +16837,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm",
         "checksum": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
+      },
+      {
+        "name": "rhui-azure-rhel8",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "484",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm",
+        "checksum": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
       },
       {
         "name": "eap7-FastInfoset",

--- a/test/data/manifests/rhel_86-x86_64-azure_eap7_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_eap7_rhui-boot.json
@@ -2551,6 +2551,9 @@
                     "id": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
                   },
                   {
+                    "id": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
+                  },
+                  {
                     "id": "sha256:ca3e0ec3842accbc0b801561a716708261f7fac32fcccaa6bf70bd862739aa67",
                     "options": {
                       "metadata": {
@@ -7034,6 +7037,9 @@
           },
           "sha256:333f6871ae18253546f50fea5dcb97635da5ee74b2c109911a605ddd50c9226c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/libcap-2.26-5.el8.x86_64.rpm"
+          },
+          "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm"
           },
           "sha256:336ed0cd6b743583edda90cb5730ca407721f6336b8d5eeca7d25981fcb4b28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.6-20220201/Packages/sudo-1.8.29-8.el8.x86_64.rpm"
@@ -16861,6 +16867,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.6-20220201/Packages/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm",
         "checksum": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
+      },
+      {
+        "name": "rhui-azure-rhel8",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "484",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm",
+        "checksum": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
       },
       {
         "name": "eap7-FastInfoset",

--- a/test/data/manifests/rhel_87-x86_64-azure_eap7_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_eap7_rhui-boot.json
@@ -2545,6 +2545,9 @@
                     "id": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
                   },
                   {
+                    "id": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
+                  },
+                  {
                     "id": "sha256:ca3e0ec3842accbc0b801561a716708261f7fac32fcccaa6bf70bd862739aa67",
                     "options": {
                       "metadata": {
@@ -6968,6 +6971,9 @@
           },
           "sha256:331b405a0b2b4bf93534af445da72d35eb1acd9ce66bd2d84f8ae5b169097d24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-jbeap7-20230202/Packages/eap7-hibernate-search-engine-5.10.7-1.Final_redhat_00001.1.el8eap.noarch.rpm"
+          },
+          "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm"
           },
           "sha256:336ed0cd6b743583edda90cb5730ca407721f6336b8d5eeca7d25981fcb4b28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.7-20221015/Packages/sudo-1.8.29-8.el8.x86_64.rpm"
@@ -16831,6 +16837,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.7-20221015/Packages/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm",
         "checksum": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
+      },
+      {
+        "name": "rhui-azure-rhel8",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "484",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm",
+        "checksum": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
       },
       {
         "name": "eap7-FastInfoset",

--- a/test/data/manifests/rhel_88-x86_64-azure_eap7_rhui-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-azure_eap7_rhui-boot.json
@@ -2545,6 +2545,9 @@
                     "id": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
                   },
                   {
+                    "id": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
+                  },
+                  {
                     "id": "sha256:ca3e0ec3842accbc0b801561a716708261f7fac32fcccaa6bf70bd862739aa67",
                     "options": {
                       "metadata": {
@@ -7004,6 +7007,9 @@
           },
           "sha256:3332a81a228e74db0d5a840c7d95af3d8998ef834bbc02223f51fff7b01a5d21": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/qemu-img-6.2.0-22.module+el8.8.0+16816+1d3555ec.x86_64.rpm"
+          },
+          "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm"
           },
           "sha256:336ed0cd6b743583edda90cb5730ca407721f6336b8d5eeca7d25981fcb4b28c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.8-20221025/Packages/sudo-1.8.29-8.el8.x86_64.rpm"
@@ -16831,6 +16837,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.8-20221025/Packages/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm",
         "checksum": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
+      },
+      {
+        "name": "rhui-azure-rhel8",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "484",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm",
+        "checksum": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
       },
       {
         "name": "eap7-FastInfoset",

--- a/test/data/manifests/rhel_89-x86_64-azure_eap7_rhui-boot.json
+++ b/test/data/manifests/rhel_89-x86_64-azure_eap7_rhui-boot.json
@@ -2542,6 +2542,9 @@
                     "id": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
                   },
                   {
+                    "id": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
+                  },
+                  {
                     "id": "sha256:ca3e0ec3842accbc0b801561a716708261f7fac32fcccaa6bf70bd862739aa67",
                     "options": {
                       "metadata": {
@@ -6971,6 +6974,9 @@
           },
           "sha256:331b405a0b2b4bf93534af445da72d35eb1acd9ce66bd2d84f8ae5b169097d24": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-jbeap7-20230202/Packages/eap7-hibernate-search-engine-5.10.7-1.Final_redhat_00001.1.el8eap.noarch.rpm"
+          },
+          "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm"
           },
           "sha256:3384bccab530807195eb9d72547aa588bdea55567ca86d1719f32402bf1cd0c9": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-baseos-n8.9-20230615/Packages/libpsl-0.20.2-6.el8.x86_64.rpm"
@@ -16816,6 +16822,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-appstream-n8.9-20230615/Packages/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm",
         "checksum": "sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae"
+      },
+      {
+        "name": "rhui-azure-rhel8",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "484",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el8/el8-x86_64-rhui-azure-20230418/Packages/r/rhui-azure-rhel8-2.2-484.noarch.rpm",
+        "checksum": "sha256:334ac6137a78b2d57afb209804d1ae2374d7b877aa12ef85d02aa6487e496140"
       },
       {
         "name": "eap7-FastInfoset",


### PR DESCRIPTION
PR#3421 [1] unintentionally removed the `rhui-azure-rhel8` package from the Azure EAP7 RHUI image base package set. As a result, the image manifest can't be built successfully. The reason is that the removed package installs a RPM GPG key, which is hard-coded in the image manifest to be imported as part of the image build.

Add the package back to the image base package set and regenerate all affected test manifests.

[1] https://github.com/osbuild/osbuild-composer/pull/3421


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
