### PR TITLE
jsondb: improve performance of list operation

### DIFF
--- a/internal/jsondb/db.go
+++ b/internal/jsondb/db.go
@@ -66,14 +66,14 @@ func (db *JSONDatabase) List() ([]string, error) {
 	}
 	defer f.Close()
 
-	infos, err := f.Readdir(-1)
+	dirNames, err := f.Readdirnames(-1)
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, len(infos))
-	for i, info := range infos {
-		names[i] = strings.TrimSuffix(info.Name(), ".json")
+	names := make([]string, len(dirNames))
+	for i, name := range dirNames {
+		names[i] = strings.TrimSuffix(name, ".json")
 	}
 
 	return names, nil


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->

Since we only need to retrieve the file names, we can use `(*os.File).Readdirnames` to avoid reading the whole file info for better performance.

Sample benchmark:

```go
func Benchmark_Readdir(b *testing.B) {
	for i := 0; i < b.N; i++ {
		f, err := os.Open("/")
		if err != nil {
			b.Fatal(err)
		}

		_, err = f.Readdir(-1)
		if err != nil {
			f.Close()
			b.Fatal(err)
		}

		f.Close()
	}
}

func Benchmark_Readdirnames(b *testing.B) {
	for i := 0; i < b.N; i++ {
		f, err := os.Open("/")
		if err != nil {
			b.Fatal(err)
		}

		_, err = f.Readdirnames(-1)
		if err != nil {
			f.Close()
			b.Fatal(err)
		}

		f.Close()
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/osbuild/osbuild-composer/internal/jsondb
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
Benchmark_Readdir-16         	   31304	     33551 ns/op	    5638 B/op	      70 allocs/op
Benchmark_Readdirnames-16    	  128443	     12124 ns/op	    1228 B/op	      30 allocs/op
PASS
ok  	github.com/osbuild/osbuild-composer/internal/jsondb	3.098s
```