### PR TITLE
composer/main: debug entry point for profiling

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -18,6 +18,7 @@ type ComposerConfigFile struct {
 	LogLevel     string          `toml:"log_level"`
 	LogFormat    string          `toml:"log_format"`
 	DNFJson      string          `toml:"dnf-json"`
+	ProfilePort  int             `toml:"profile_port"`
 }
 
 type KojiAPIConfig struct {
@@ -110,9 +111,10 @@ func GetDefaultConfig() *ComposerConfigFile {
 				},
 			},
 		},
-		LogLevel:  "info",
-		LogFormat: "text",
-		DNFJson:   "/usr/libexec/osbuild-composer/dnf-json",
+		LogLevel:    "info",
+		LogFormat:   "text",
+		DNFJson:     "/usr/libexec/osbuild-composer/dnf-json",
+		ProfilePort: -1,
 	}
 }
 


### PR DESCRIPTION
This commit adds a debug mode for composer that can be toggled via a parameter in the config file. When the profile_port is set to any other value than -1, the debug entry points will be reachable for the composer main process.

http://localhot:$profile_port/debug/pprof for a global look at all the exposed entry points

- Run CPU profiling on composer for 5 seconds:

```
curl -o profile.out http://localhost:6060/debug/pprof/profile?seconds=5
go tool pprof -http=localhost:8080 profile.out
```

Then visit http://localhot:8080 to access the interactive view on the CPU performance of the application

- Tracing for 5 seconds:

```
curl -o trace.out http://localhost:6060/debug/pprof/trace?seconds=5
go tool trace trace.out
```

Then visit the page served by the trace tool.
There you can have many more different view about the application being traced:
- what CPUs are executing at a given point in time
- how long each task is taking
- What is the overall memory usage and CPU usage Checkout: https://pkg.go.dev/runtime/trace

- Get Memory profiling for composer:

go tool pprof -http=localhost:8080 http://localhost:6060/debug/pprof/heap

For more info: https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
