### PR TITLE
Remove redundant script in upgrade8to9 test

### DIFF
--- a/test/data/upgrade8to9/upgrade_prepare.sh
+++ b/test/data/upgrade8to9/upgrade_prepare.sh
@@ -14,9 +14,6 @@ dnf install -y osbuild-composer composer-cli
 curl -k -o /etc/yum.repos.d/oam-group-leapp-rhel-8.repo https://gitlab.cee.redhat.com/leapp/oamg-rhel8-vagrant/-/raw/master/roles/init/files/leapp-copr.repo
 # install the leapp upgrade tool + other dependencies
 dnf install -y leapp-upgrade-el8toel9 vdo jq rpmdevtools
-curl -kLO https://gitlab.cee.redhat.com/leapp/oamg-rhel7-vagrant/raw/master/roles/init/files/prepare_test_env.sh
-source /root/prepare_test_env.sh
-get_data_files
 
 # prepare upgrade repositories
 tee /etc/leapp/files/leapp_upgrade_repositories.repo > /dev/null << EOF

--- a/test/data/upgrade8to9/upgrade_verify.sh
+++ b/test/data/upgrade8to9/upgrade_verify.sh
@@ -46,7 +46,7 @@ rpm -qi osbuild-composer
 
 # Prepare repository override
 mkdir -p /etc/osbuild-composer/repositories
-tee /etc/osbuild-composer/repositories/rhel-92.json > /dev/null << EOF
+tee /etc/osbuild-composer/repositories/rhel-93.json > /dev/null << EOF
 {
     "x86_64": [
         {


### PR DESCRIPTION
Upstream leapp no longer uses separate channels for obtaining its data and instead packages them into the RPM. See
https://redhat-internal.slack.com/archives/C04JP91FB8X/p1687428000886329


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
