### PR TITLE
Set the tenant in the request context, reuse it for the status and request duration metrics

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+)
+
+const TenantCtxKey string = "tenant"
+
+func TenantChannelMiddleware(tenantProviderFields []string, onFail error) func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			tenant, err := GetFromClaims(ctx.Request().Context(), tenantProviderFields)
+			// Allowlisted paths won't have a token
+			if err != nil && !errors.Is(err, NoJWTError) {
+				return onFail
+			}
+
+			// prefix the tenant to prevent collisions if support for specifying channels in a request is ever added
+			if tenant != "" {
+				ctx.Set(TenantCtxKey, fmt.Sprintf("org-%s", tenant))
+			}
+
+			return next(ctx)
+		}
+	}
+}

--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -68,6 +68,7 @@ const (
 	ErrorGettingOSBuildJobStatus                  ServiceErrorCode = 1017
 	ErrorGettingAWSEC2JobStatus                   ServiceErrorCode = 1018
 	ErrorGettingJobType                           ServiceErrorCode = 1019
+	ErrorTenantNotInContext                       ServiceErrorCode = 1020
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -143,6 +144,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorGettingOSBuildJobStatus, http.StatusInternalServerError, "Unable to get osbuild job status"},
 		serviceError{ErrorGettingAWSEC2JobStatus, http.StatusInternalServerError, "Unable to get ec2 job status"},
 		serviceError{ErrorGettingJobType, http.StatusInternalServerError, "Unable to get job type of existing job"},
+		serviceError{ErrorTenantNotInContext, http.StatusInternalServerError, "Unable to retrieve tenant from request context"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -93,6 +93,7 @@ func (s *Server) Handler(path string) http.Handler {
 
 	mws := []echo.MiddlewareFunc{
 		prometheus.StatusMiddleware(prometheus.ComposerSubsystem),
+		prometheus.HTTPDurationMiddleware(prometheus.ComposerSubsystem),
 	}
 	if s.config.JWTEnabled {
 		mws = append(mws, auth.TenantChannelMiddleware(s.config.TenantProviderFields, HTTPError(ErrorTenantNotFound)))

--- a/internal/cloudapi/v2/v2_multi_tenancy_test.go
+++ b/internal/cloudapi/v2/v2_multi_tenancy_test.go
@@ -176,6 +176,7 @@ func runNextJob(t *testing.T, jobs []uuid.UUID, workerHandler http.Handler, orgI
 		Method:         http.MethodPatch,
 		Path:           job.Location,
 		RequestBody:    test.JSONRequestBody(`{"result": {"job_result":{}}}`),
+		Context:        reqContext(orgID),
 		ExpectedStatus: http.StatusOK,
 	}.Do(t)
 }

--- a/internal/prometheus/http_metrics.go
+++ b/internal/prometheus/http_metrics.go
@@ -30,5 +30,5 @@ var (
 		Subsystem: ComposerSubsystem,
 		Help:      "Duration of HTTP requests.",
 		Buckets:   []float64{.025, .05, .075, .1, .2, .5, .75, 1, 1.5, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20},
-	}, []string{"path"})
+	}, []string{"path", "tenant"})
 )

--- a/internal/prometheus/http_metrics.go
+++ b/internal/prometheus/http_metrics.go
@@ -23,12 +23,24 @@ var (
 	})
 )
 
-var (
-	httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+func HTTPDurationHisto(subsystem string) *prometheus.HistogramVec {
+	reg := prometheus.NewRegistry()
+	histo := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "http_duration_seconds",
 		Namespace: Namespace,
-		Subsystem: ComposerSubsystem,
+		Subsystem: subsystem,
 		Help:      "Duration of HTTP requests.",
 		Buckets:   []float64{.025, .05, .075, .1, .2, .5, .75, 1, 1.5, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20},
 	}, []string{"path", "tenant"})
-)
+
+	err := prometheus.Register(histo)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			panic(err)
+		}
+		// return existing counter if metrics already registered
+		return registered.ExistingCollector.(*prometheus.HistogramVec)
+	}
+	return histo
+}

--- a/internal/prometheus/status_metrics.go
+++ b/internal/prometheus/status_metrics.go
@@ -14,7 +14,7 @@ func StatusRequestsCounter(subsystem string) *prometheus.CounterVec {
 		Namespace: Namespace,
 		Subsystem: subsystem,
 		Help:      "total number of http requests",
-	}, []string{"method", "path", "code", "subsystem"})
+	}, []string{"method", "path", "code", "subsystem", "tenant"})
 
 	err := prometheus.Register(counter)
 	if err != nil {

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -102,6 +102,7 @@ func (s *Server) Handler() http.Handler {
 
 	mws := []echo.MiddlewareFunc{
 		prometheus.StatusMiddleware(prometheus.WorkerSubsystem),
+		prometheus.HTTPDurationMiddleware(prometheus.WorkerSubsystem),
 	}
 	if s.config.JWTEnabled {
 		mws = append(mws, auth.TenantChannelMiddleware(s.config.TenantProviderFields, api.HTTPError(api.ErrorTenantNotFound)))

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -413,7 +413,7 @@ function collectMetrics(){
                           --cert /etc/osbuild-composer/client-crt.pem \
                           https://localhost/metrics)
 
-    echo "$METRICS_OUTPUT" | grep "^image_builder_composer_total_compose_requests" | cut -f2 -d' '
+    echo "$METRICS_OUTPUT" | grep "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' '
 }
 
 function testNewMetricsPort(){
@@ -424,8 +424,8 @@ function testNewMetricsPort(){
                           https://localhost/metrics)
     METRICS_OUTPUT2=$(curl http://localhost:8008/metrics)
 
-    COMPOSES1=$(echo "$METRICS_OUTPUT1" | grep "^image_builder_composer_total_compose_requests" | cut -f2 -d' ')
-    COMPOSES2=$(echo "$METRICS_OUTPUT2" | grep "^image_builder_composer_total_compose_requests" | cut -f2 -d' ')
+    COMPOSES1=$(echo "$METRICS_OUTPUT1" | grep  "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' ')
+    COMPOSES2=$(echo "$METRICS_OUTPUT2" | grep  "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' ')
 
     test "$COMPOSES1" = "$COMPOSES2"
 }


### PR DESCRIPTION
Adds the tenant field to the status and request duration metrics, and uses the the latter in the worker api as well.

---

Once we update the dashboards we can move the total_requests and total_compose_requests counters.  