### PR TITLE
Sanity check if cloud-cleaner workflow is enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,3 +228,19 @@ jobs:
         directory: processed-templates
         config: templates/.kube-linter-config.yml
         version: 0.3.0
+
+  cloud-cleaner-is-enabled:
+    name: "🧹 cloud-cleaner-is-enabled"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if workflow is enabled
+      run: |
+        curl https://github.com/osbuild/cloud-cleaner/actions/workflows/run_ib.yml 2>/dev/null | grep -vz "This scheduled workflow is disabled" >/dev/null
+
+    - name: How to enable cloud-cleaner
+      if: failure()
+      run: |
+        echo "Cloud-cleaner is disabled"
+        echo "Go to https://github.com/osbuild/cloud-cleaner/actions/workflows/run_ib.yml and"
+        echo "https://github.com/osbuild/cloud-cleaner/actions/workflows/run_cloudx.yml and"
+        echo "manually enable it!"


### PR DESCRIPTION
GitHub will automatically disable scheduled actions defined on repositories which don't receive much activity. In particular such scheduled jobs will be disabled after 60 days of repo inactivity.

This CI job sanity checks the current status and reports back to every PR so we can manually re-enable cloud-cleaner if necessary.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
