### PR TITLE
Allow any hashing algorithm in osbuild stage inputs

### DIFF
--- a/internal/distro/distro_test.go
+++ b/internal/distro/distro_test.go
@@ -155,8 +155,8 @@ func TestImageTypePipelineNames(t *testing.T) {
 					// manifest creation doesn't fail.
 					allPipelines := append(imageType.BuildPipelines(), imageType.PayloadPipelines()...)
 					minimalPackageSet := []rpmmd.PackageSpec{
-						{Name: "kernel"},
-						{Name: "filesystem"},
+						{Name: "kernel", Checksum: "sha256:a0c936696eb7d5ee3192bf53b9d281cecbb40ca9db520de72cb95817ad92ac72"},
+						{Name: "filesystem", Checksum: "sha256:6b4bf18ba28ccbdd49f2716c9f33c9211155ff703fa6c195c78a07bd160da0eb"},
 					}
 
 					packageSets := make(map[string][]rpmmd.PackageSpec, len(allPipelines))

--- a/internal/manifest/os_test.go
+++ b/internal/manifest/os_test.go
@@ -28,7 +28,7 @@ func NewTestOS() *OS {
 
 	os := NewOS(&manifest, build, platform, repos)
 	packages := []rpmmd.PackageSpec{
-		rpmmd.PackageSpec{Name: "pkg1"},
+		{Name: "pkg1", Checksum: "sha1:c02524e2bd19490f2a7167958f792262754c5f46"},
 	}
 	os.serializeStart(packages, nil, nil)
 

--- a/internal/osbuild/copy_stage_test.go
+++ b/internal/osbuild/copy_stage_test.go
@@ -46,11 +46,11 @@ func TestNewCopyStage(t *testing.T) {
 }
 
 func TestNewCopyStageSimpleSourcesInputs(t *testing.T) {
-	fileSum := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	fileSum := "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
 	paths := []CopyStagePath{
 		{
-			From: fmt.Sprintf("input://inlinefile/sha256:%x", fileSum),
+			From: fmt.Sprintf("input://inlinefile/%x", fileSum),
 			To:   "tree://etc/inlinefile",
 		},
 	}

--- a/internal/osbuild/fdo_stage.go
+++ b/internal/osbuild/fdo_stage.go
@@ -15,7 +15,7 @@ func (FDOStageInputs) isStageInputs() {}
 func NewFDOStageForRootCerts(rootCertsData string) *Stage {
 	dataBytes := []byte(rootCertsData)
 	input := NewFilesInput(NewFilesInputSourcePlainRef([]string{
-		fmt.Sprintf("%x", sha256.Sum256(dataBytes)),
+		fmt.Sprintf("sha256:%x", sha256.Sum256(dataBytes)),
 	}))
 
 	return &Stage{

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -195,13 +195,11 @@ type FilesInputSourcePlainRef []string
 
 func (*FilesInputSourcePlainRef) isFilesInputRef() {}
 
-// NewFilesInputSourcePlainRef creates a FilesInputSourcePlainRef from a list of sha256sums.
-// The slice items are the SHA256 checksums of files as a hexadecimal string without any prefix (e.g. "sha256:").
-func NewFilesInputSourcePlainRef(sha256Sums []string) FilesInputRef {
-	refs := FilesInputSourcePlainRef{}
-	for _, sha256Sum := range sha256Sums {
-		refs = append(refs, fmt.Sprintf("sha256:%s", sha256Sum))
-	}
+// NewFilesInputSourcePlainRef creates a FilesInputSourcePlainRef from a list
+// of checksums. The checksums must be prefixed by the name of the corresponding
+// hashing algorithm followed by a colon (e.g. sha256:, sha1:, etc).
+func NewFilesInputSourcePlainRef(checksums []string) FilesInputRef {
+	refs := FilesInputSourcePlainRef(checksums)
 	return &refs
 }
 
@@ -235,11 +233,13 @@ type FilesInputSourceArrayRefEntry struct {
 	Options *FilesInputSourceOptions `json:"options,omitempty"`
 }
 
-// NewFilesInputSourceArrayRefEntry creates a FilesInputSourceArrayRefEntry from a sha256sum and metadata.
-// The sha256sum is the SHA256 checksum of the file as a hexadecimal string without any prefix (e.g. "sha256:").
-func NewFilesInputSourceArrayRefEntry(sha256Sum string, metadata FilesInputRefMetadata) FilesInputSourceArrayRefEntry {
+// NewFilesInputSourceArrayRefEntry creates a FilesInputSourceArrayRefEntry
+// from a checksum and metadata. The checksum must be prefixed by the name of
+// the corresponding hashing algorithm followed by a colon (e.g. sha256:,
+// sha1:, etc).
+func NewFilesInputSourceArrayRefEntry(checksum string, metadata FilesInputRefMetadata) FilesInputSourceArrayRefEntry {
 	ref := FilesInputSourceArrayRefEntry{
-		ID: fmt.Sprintf("sha256:%s", sha256Sum),
+		ID: checksum,
 	}
 	if metadata != nil {
 		ref.Options = &FilesInputSourceOptions{Metadata: metadata}
@@ -269,12 +269,15 @@ type FilesInputSourceObjectRef map[string]FilesInputSourceOptions
 
 func (*FilesInputSourceObjectRef) isFilesInputRef() {}
 
-// NewFilesInputSourceObjectRef creates a FilesInputSourceObjectRef from a map of sha256sums to metadata
-// The key is the SHA256 checksum of the file as a hexadecimal string without any prefix (e.g. "sha256:").
+// NewFilesInputSourceObjectRef creates a FilesInputSourceObjectRef from a map
+// of checksums to metadata. The checksums must be prefixed by the name of the
+// corresponding hashing algorithm followed by a colon (e.g. sha256:, sha1:,
+// etc).
 func NewFilesInputSourceObjectRef(entries map[string]FilesInputRefMetadata) FilesInputRef {
 	refs := FilesInputSourceObjectRef{}
-	for sha256Sum, metadata := range entries {
-		refs[fmt.Sprintf("sha256:%s", sha256Sum)] = FilesInputSourceOptions{Metadata: metadata}
+	for checksum, metadata := range entries {
+		refs[checksum] = FilesInputSourceOptions{Metadata: metadata}
+
 	}
 	return &refs
 }

--- a/internal/osbuild/files_input_test.go
+++ b/internal/osbuild/files_input_test.go
@@ -25,20 +25,20 @@ func TestFilesInput_UnmarshalJSON(t *testing.T) {
 		},
 		{
 			name:    "source-plain-ref",
-			ref:     NewFilesInputSourcePlainRef([]string{"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}),
+			ref:     NewFilesInputSourcePlainRef([]string{"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}),
 			rawJson: []byte(`{"type":"org.osbuild.files","origin":"org.osbuild.source","references":["sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]}`),
 		},
 		{
 			name: "source-array-ref",
 			ref: NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-				NewFilesInputSourceArrayRefEntry("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", nil),
+				NewFilesInputSourceArrayRefEntry("sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", nil),
 			}),
 			rawJson: []byte(`{"type":"org.osbuild.files","origin":"org.osbuild.source","references":[{"id":"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}]}`),
 		},
 		{
 			name: "source-object-ref",
 			ref: NewFilesInputSourceObjectRef(map[string]FilesInputRefMetadata{
-				"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef": nil,
+				"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef": nil,
 			}),
 			rawJson: []byte(`{"type":"org.osbuild.files","origin":"org.osbuild.source","references":{"sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef":{}}}`),
 		},

--- a/internal/osbuild/fsnode.go
+++ b/internal/osbuild/fsnode.go
@@ -31,7 +31,7 @@ func GenFileNodesStages(files []*fsnode.File) []*Stage {
 			RemoveDestination: true,
 		})
 		copyStageInputs[copyStageInputKey] = NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-			NewFilesInputSourceArrayRefEntry(fileDataChecksum, nil),
+			NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%s", fileDataChecksum), nil),
 		}))
 
 		if file.Mode() != nil {

--- a/internal/osbuild/fsnode_test.go
+++ b/internal/osbuild/fsnode_test.go
@@ -53,7 +53,7 @@ func TestGenFileNodesStages(t *testing.T) {
 					},
 				}, &CopyStageFilesInputs{
 					fmt.Sprintf("file-%x", sha256.Sum256(fileData1)): NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("%x", sha256.Sum256(fileData1)), nil),
+						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%x", sha256.Sum256(fileData1)), nil),
 					})),
 				}),
 			},
@@ -80,10 +80,10 @@ func TestGenFileNodesStages(t *testing.T) {
 					},
 				}, &CopyStageFilesInputs{
 					fmt.Sprintf("file-%x", sha256.Sum256(fileData1)): NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("%x", sha256.Sum256(fileData1)), nil),
+						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%x", sha256.Sum256(fileData1)), nil),
 					})),
 					fmt.Sprintf("file-%x", sha256.Sum256(fileData2)): NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("%x", sha256.Sum256(fileData2)), nil),
+						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%x", sha256.Sum256(fileData2)), nil),
 					})),
 				}),
 			},
@@ -110,10 +110,10 @@ func TestGenFileNodesStages(t *testing.T) {
 					},
 				}, &CopyStageFilesInputs{
 					fmt.Sprintf("file-%x", sha256.Sum256(fileData1)): NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("%x", sha256.Sum256(fileData1)), nil),
+						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%x", sha256.Sum256(fileData1)), nil),
 					})),
 					fmt.Sprintf("file-%x", sha256.Sum256(fileData2)): NewFilesInput(NewFilesInputSourceArrayRef([]FilesInputSourceArrayRefEntry{
-						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("%x", sha256.Sum256(fileData2)), nil),
+						NewFilesInputSourceArrayRefEntry(fmt.Sprintf("sha256:%x", sha256.Sum256(fileData2)), nil),
 					})),
 				}),
 				NewChmodStage(&ChmodStageOptions{

--- a/internal/osbuild/ignition_stage.go
+++ b/internal/osbuild/ignition_stage.go
@@ -26,7 +26,7 @@ func (IgnitionStageInputInline) isStageInputs() {}
 
 func NewIgnitionInlineInput(embeddedData string) Inputs {
 	input := NewFilesInput(NewFilesInputSourcePlainRef([]string{
-		fmt.Sprintf("%x", sha256.Sum256([]byte(embeddedData))),
+		fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(embeddedData))),
 	}))
 	return &IgnitionStageInputInline{InlineFile: input}
 }

--- a/internal/osbuild/rpm_stage.go
+++ b/internal/osbuild/rpm_stage.go
@@ -1,8 +1,6 @@
 package osbuild
 
 import (
-	"strings"
-
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
 
@@ -128,14 +126,13 @@ func NewRpmStageSourceFilesInputs(specs []rpmmd.PackageSpec) *RPMStageInputs {
 func pkgRefs(specs []rpmmd.PackageSpec) FilesInputRef {
 	refs := make([]FilesInputSourceArrayRefEntry, len(specs))
 	for idx, pkg := range specs {
-		pkgSum := strings.TrimPrefix(pkg.Checksum, "sha256:")
 		var pkgMetadata FilesInputRefMetadata
 		if pkg.CheckGPG {
 			pkgMetadata = &RPMStageReferenceMetadata{
 				CheckGPG: pkg.CheckGPG,
 			}
 		}
-		refs[idx] = NewFilesInputSourceArrayRefEntry(pkgSum, pkgMetadata)
+		refs[idx] = NewFilesInputSourceArrayRefEntry(pkg.Checksum, pkgMetadata)
 	}
 	return NewFilesInputSourceArrayRef(refs)
 }


### PR DESCRIPTION
Helper functions that create stage input objects with references always hard-coded `sha256:` as a prefix/algorithm for the checksum.  This prevents the functions from being used in cases where other algorithms are use, like sha1, which is possible with (perhaps older) RPM repositories.  The inputs in osbuild a number of hashing algorithms and we should be able to generate stages with other prefixes when necessary.

This PR removes the `sha256:` prefix in the helper functions and assumes all arguments to these functions provide the correct prefix.

Fixes rhbz#2215043 (RHELPLAN-159871).

This pull request includes:
- [x] adequate testing for the new functionality or fixed issue

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
