### PR TITLE
spec: require osbuild >= 89

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -156,28 +156,28 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -223,7 +223,7 @@
   "rhel-8.9": {
     "dependencies": {
       "osbuild": {
-        "commit": "8669d0ad4ca2941da21191cacec738b5b5ec734d"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -269,21 +269,21 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -329,7 +329,7 @@
   "rhel-9.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "8669d0ad4ca2941da21191cacec738b5b5ec734d"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -375,21 +375,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [
@@ -435,7 +435,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "1fbd9d975f15b845b9a9519097cd307253a64f1e"
+        "commit": "c90b587dccf5f82e5732b7a264866c3535c066c2"
       }
     },
     "repos": [

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -294,10 +294,10 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 Summary:    The worker for osbuild-composer
 Requires:   systemd
 Requires:   qemu-img
-Requires:   osbuild >= 85
-Requires:   osbuild-ostree >= 85
-Requires:   osbuild-lvm2 >= 85
-Requires:   osbuild-luks2 >= 85
+Requires:   osbuild >= 89
+Requires:   osbuild-ostree >= 89
+Requires:   osbuild-lvm2 >= 89
+Requires:   osbuild-luks2 >= 89
 Requires:   %{name}-dnf-json = %{version}-%{release}
 
 %description worker


### PR DESCRIPTION
The recently merged `live-installer` image type depends on osbuild >= 89, see the following commit in osbuild:

https://github.com/osbuild/osbuild/commit/c90b587dccf5f82e5732b7a264866c3535c066c2