### PR TITLE
reorder middlewares in worker and cloud apis

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -93,12 +93,13 @@ func (s *Server) Handler(path string) http.Handler {
 
 	mws := []echo.MiddlewareFunc{
 		prometheus.StatusMiddleware(prometheus.ComposerSubsystem),
-		prometheus.HTTPDurationMiddleware(prometheus.ComposerSubsystem),
 	}
 	if s.config.JWTEnabled {
 		mws = append(mws, auth.TenantChannelMiddleware(s.config.TenantProviderFields, HTTPError(ErrorTenantNotFound)))
 	}
-	mws = append(mws, prometheus.MetricsMiddleware, s.ValidateRequest)
+	mws = append(mws,
+		prometheus.HTTPDurationMiddleware(prometheus.ComposerSubsystem),
+		prometheus.MetricsMiddleware, s.ValidateRequest)
 	RegisterHandlers(e.Group(path, mws...), &handler)
 
 	return e

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -102,11 +102,11 @@ func (s *Server) Handler() http.Handler {
 
 	mws := []echo.MiddlewareFunc{
 		prometheus.StatusMiddleware(prometheus.WorkerSubsystem),
-		prometheus.HTTPDurationMiddleware(prometheus.WorkerSubsystem),
 	}
 	if s.config.JWTEnabled {
 		mws = append(mws, auth.TenantChannelMiddleware(s.config.TenantProviderFields, api.HTTPError(api.ErrorTenantNotFound)))
 	}
+	mws = append(mws, prometheus.HTTPDurationMiddleware(prometheus.WorkerSubsystem))
 	api.RegisterHandlers(e.Group(api.BasePath, mws...), &handler)
 
 	return e


### PR DESCRIPTION
The duration middleware should come after the tenant channel mw. The status mw can come before because it queries the request context right before sending the response, but the duration metric needs the tenant set in the request context as it creates the timer timing the request.