### PR TITLE
Schedule a nightly CI pipeline against each PR

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
+      GITLAB_TOKEN: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_PIPELINE_TRIGGER_TOKEN }}
     steps:
       - name: Report status
         uses: haya14busa/action-workflow_run-status@v1
@@ -36,6 +37,7 @@ jobs:
           per_page: 100
 
       - name: Checkout branch
+        id: pr_data
         run: |
           PR_DATA=$(mktemp)
           # use uuid as a file terminator to avoid conflicts with data content
@@ -45,6 +47,7 @@ jobs:
 
           PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
           if [ ! -z "$PR" ]; then
+            echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"
             git checkout -b PR-$PR
           else
             git checkout ${{ github.event.workflow_run.head_branch }}
@@ -88,3 +91,17 @@ jobs:
           else
             git push -f ci 
           fi
+
+      - name: Trigger GitLab nightly pipeline against this PR
+        if: ${{ env.GITLAB_TOKEN }} && ${{ steps.pr_date.outputs.pr_branch }}
+        run: |
+            # osbuild-composer
+            PROJECT_ID=34771166
+
+            # Simulate a nightly CI pipeline against this PR
+            curl --request POST --fail --form "token=$GITLAB_TOKEN" \
+                --form ref=${{ steps.pr_date.outputs.pr_branch }} \
+                --form "variables[CI_PIPELINE_SOURCE]=schedule" \
+                --form "variables[NIGHTLY]=true" \
+                --form "variables[RHEL_MAJOR]=9" \
+                "https://gitlab.com/api/v4/projects/$PROJECT_ID/trigger/pipeline"

--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+if [ -z "$SLACK_WEBHOOK_URL" ]; then
+    echo "INFO: Variable SLACK_WEBHOOK_URL is undefined"
+    exit 0
+fi
+
 COMPOSE_ID=$(cat COMPOSE_ID)
 COMPOSER_NVR=$(cat COMPOSER_NVR)
 MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @jabia\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""

--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-
-# Don't overwrite CI statuses on GitHub branches for nightly pipelines
-if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
-    exit 0
-fi
-
 # if a user is logged in to the runner, wait until they're done
 while (( $(who -s | wc -l)  > 0 )); do
     echo "Waiting for user(s) to log off"
@@ -33,12 +27,17 @@ else
   exit 1
 fi
 
+CONTEXT="Schutzbot on GitLab"
+if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
+    CONTEXT="$CONTEXT, RHEL-${RHEL_MAJOR:-}-nightly"
+fi
+
 curl \
     -u "${SCHUTZBOT_LOGIN}" \
     -X POST \
     -H "Accept: application/vnd.github.v3+json" \
     "https://api.github.com/repos/osbuild/osbuild-composer/statuses/${CI_COMMIT_SHA}" \
-    -d '{"state":"'"${GITHUB_NEW_STATE}"'", "description": "'"${GITHUB_NEW_DESC}"'", "context": "Schutzbot on GitLab", "target_url": "'"${CI_PIPELINE_URL}"'"}'
+    -d '{"state":"'"${GITHUB_NEW_STATE}"'", "description": "'"${GITHUB_NEW_DESC}"'", "context": "'"${CONTEXT}"'", "target_url": "'"${CI_PIPELINE_URL}"'"}'
 
 # ff release branch on github if this ran on main
 if [ "$CI_COMMIT_BRANCH" = "main" ] && [ "$GITHUB_NEW_STATE" = "success" ]; then


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
