### PR TITLE
Fix for possibly undefined variable in CI script

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -100,7 +100,7 @@ jobs:
 
             # Simulate a nightly CI pipeline against this PR
             curl --request POST --fail --form "token=$GITLAB_TOKEN" \
-                --form ref=${{ steps.pr_date.outputs.pr_branch }} \
+                --form ref=${{ steps.pr_data.outputs.pr_branch }} \
                 --form "variables[CI_PIPELINE_SOURCE]=schedule" \
                 --form "variables[NIGHTLY]=true" \
                 --form "variables[RHEL_MAJOR]=9" \

--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-if [ -z "$SLACK_WEBHOOK_URL" ]; then
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
     echo "INFO: Variable SLACK_WEBHOOK_URL is undefined"
     exit 0
 fi


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
