### PR TITLE
.github/workflows: trigger gitlab as soon as possible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,20 +195,6 @@ jobs:
       - name: Run rpmlint
         run: rpmlint rpmbuild/SRPMS/*
 
-  gitlab-ci-helper:
-    name: "Gitlab CI trigger helper"
-    runs-on: ubuntu-latest
-    env:
-      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
-    steps:
-      - name: Write PR status
-        run: echo "$SKIP_CI" > SKIP_CI.txt
-      - name: Upload status
-        uses: actions/upload-artifact@v3
-        with:
-          name: PR_STATUS
-          path: SKIP_CI.txt
-
   kube-linter:
     name: "🎀 kube-linter"
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-gitlab-helper.yml
+++ b/.github/workflows/trigger-gitlab-helper.yml
@@ -1,0 +1,26 @@
+name: Trigger GitLab
+
+# NOTE(mhayden): Restricting branches prevents jobs from being doubled since
+# a push to a pull request triggers two events.
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - main
+
+jobs:
+  gitlab-ci-helper:
+    name: "Gitlab CI trigger helper"
+    runs-on: ubuntu-latest
+    env:
+      SKIP_CI: ${{ (github.event.pull_request.draft == true || contains(github.event.pull_request.labels.*.name, 'WIP')) && !contains(github.event.pull_request.labels.*.name, 'WIP+test') }}
+    steps:
+      - name: Write PR status
+        run: echo "$SKIP_CI" > SKIP_CI.txt
+      - name: Upload status
+        uses: actions/upload-artifact@v3
+        with:
+          name: PR_STATUS
+          path: SKIP_CI.txt

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -4,7 +4,7 @@ name: Trigger GitLab CI
 
 on:
   workflow_run:
-    workflows: ["Tests"]
+    workflows: ["Trigger GitLab"]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
Previously, we gated the GitLab tests on the unit tests. However, these now take ~10 minutes, which is just annoying for engineers. This commit changes the trigger to fire immediately after the PR is updated. This should save our engineers 10 minutes on every push.

Regarding higher infra costs: Engineers are more expensive. :P