### PR TITLE
remove old prometheus listener

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -281,10 +281,6 @@ func (c *Composer) Start() error {
 		// handler functions don't.
 		mux.Handle(apiRouteV2+"/", c.api.V2(apiRouteV2))
 
-		// Metrics handler attached to api mux to avoid a
-		// separate listener/socket
-		mux.Handle("/metrics", promhttp.Handler().(http.HandlerFunc))
-
 		handler := http.Handler(mux)
 		var err error
 		if c.config.Koji.EnableJWT {
@@ -296,7 +292,6 @@ func (c *Composer) Start() error {
 				[]string{
 					"/api/image-builder-composer/v2/openapi/?$",
 					"/api/image-builder-composer/v2/errors/?$",
-					"/metrics/?$",
 				}, mux)
 			if err != nil {
 				panic(err)

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -407,27 +407,9 @@ createReqFile
 #
 
 function collectMetrics(){
-    METRICS_OUTPUT=$(curl \
-                          --cacert /etc/osbuild-composer/ca-crt.pem \
-                          --key /etc/osbuild-composer/client-key.pem \
-                          --cert /etc/osbuild-composer/client-crt.pem \
-                          https://localhost/metrics)
+    METRICS_OUTPUT=$(curl http://localhost:8008/metrics)
 
     echo "$METRICS_OUTPUT" | grep "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' '
-}
-
-function testNewMetricsPort(){
-    METRICS_OUTPUT1=$(curl \
-                          --cacert /etc/osbuild-composer/ca-crt.pem \
-                          --key /etc/osbuild-composer/client-key.pem \
-                          --cert /etc/osbuild-composer/client-crt.pem \
-                          https://localhost/metrics)
-    METRICS_OUTPUT2=$(curl http://localhost:8008/metrics)
-
-    COMPOSES1=$(echo "$METRICS_OUTPUT1" | grep  "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' ')
-    COMPOSES2=$(echo "$METRICS_OUTPUT2" | grep  "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' ')
-
-    test "$COMPOSES1" = "$COMPOSES2"
 }
 
 function sendCompose() {
@@ -583,8 +565,6 @@ fi
 sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c \
      "DELETE FROM jobs WHERE id = '$COMPOSE_ID'"
 sudo systemctl start "osbuild-remote-worker@localhost:8700.service"
-
-testNewMetricsPort
 
 # full integration case
 INIT_COMPOSES="$(collectMetrics)"


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
