### PR TITLE
tools: replace spec Provides generator

### DIFF
--- a/tools/rpm_spec_add_provides_bundle.sh
+++ b/tools/rpm_spec_add_provides_bundle.sh
@@ -5,7 +5,7 @@ SPEC_FILE=${1:-"osbuild-composer.spec"}
 # Save the list of bundled packages into a file
 WORKDIR=$(mktemp -d)
 BUNDLES_FILE=${WORKDIR}/bundles.txt
-grep "^# " vendor/modules.txt | awk '{print "Provides: bundled(golang("$2")) = "$3}' | sort --ignore-case | uniq | sed -e 's/-/_/g' > "${BUNDLES_FILE}"
+./tools/rpm_spec_vendor2provides vendor/modules.txt > "${BUNDLES_FILE}"
 
 # Remove the current bundle lines
 sed -i '/^# BUNDLE_START/,/^# BUNDLE_END/{//p;d;}' "${SPEC_FILE}"

--- a/tools/rpm_spec_vendor2provides
+++ b/tools/rpm_spec_vendor2provides
@@ -1,0 +1,56 @@
+#!/usr/bin/python3 -s
+
+# Parse modules.txt files into rpm .spec file Provides for bundled dependencies.
+# Written by Fabio "decathorpe" Valentini <decathorpe@fedoraproject.org> for
+# the fedora syncthing package: https://src.fedoraproject.org/rpms/syncthing
+# SPDX-License-Identifier: CC0-1.0 OR Unlicense
+
+# Modified by @gotmax23 to be used as a dependency generator
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022 Maxwell G <gotmax@e.email>
+#
+# Minor modifications by Achilleas Koutsou <achilleas@koutsou.net> to be used in
+# the rpm spec file generator for https://github.com/osbuild/osbuild-composer
+
+import re
+import sys
+
+
+def process(path: str):
+    with open(path, encoding="utf-8") as file:
+        contents = file.read()
+
+    lines = contents.split("\n")
+
+    # dependencies = filter lines for "# package version"
+    dependencies = list(filter(lambda line: line.startswith("# "), lines))
+
+    # parse vendored dependencies into (import path, version) pairs
+    vendored = list()
+    # Handle => style replace directives
+    replace_regex = re.compile("^.+( v[0-9-\.]+)? => ")
+    for dep in dependencies:
+        ipath, version = replace_regex.sub("", dep[2:]).split(" ")[:2]
+
+        # check for git snapshots
+        if len(version) > 27:
+            # return only 7 digits of git commit hash
+            version = version[-12:-1][0:7]
+        else:
+            # strip off leading "v"
+            version = version.lstrip("v")
+
+        vendored.append((ipath, version))
+
+    for ipath, version in vendored:
+        print(f"Provides: bundled(golang({ipath})) = {version}")
+
+
+def main() -> None:
+    files = sys.argv[1:]
+    for file in files:
+        process(file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace the generator for the spec file "Provides:" list with the one from the current go-rpm-macros [1].  The new generator can handle 'replace' commands in vendor/modules.txt, which makes it possible to build RPMs with temporarily modified dependencies.  This enables making scratch builds against forks or branches of the new osbuild/images repository for development and testing.

In the (distant) future, we can use the packaged version of the script, but this isn't yet available in all supported distros (EL8).

Made some minor modifications to the original script to prepend each dependency with "Provides:" and read input files as arguments instead of lines from stdin.

https://pagure.io/go-rpm-macros/blob/c32fbbd25bbcedee8c0b898d3653255b18a0d30e/f/rpm/go_mod_vendor.prov

@supakeen @bcl I've tested this myself but try it out as well and let me know if it's working.