### PR TITLE
lint: Enable check for replace in go.mod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,10 +3,14 @@ linters-settings:
     disable:
       - shadow # default value recommended by golangci
       - composites
-  
+
+  gomoddirectives:
+    replace-local: false
+
 linters:
   enable:
     - gosec
+    - gomoddirectives
 
 run:
   build-tags:


### PR DESCRIPTION
Use the linter to make sure go.mod doesn't include a replace directive.
