### PR TITLE
cloudapi: add `live-installer`

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -565,6 +565,8 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 				fallthrough
 			case ImageTypesIotInstaller:
 				fallthrough
+			case ImageTypesLiveInstaller:
+				fallthrough
 			case ImageTypesEdgeCommit:
 				fallthrough
 			case ImageTypesIotCommit:
@@ -783,6 +785,8 @@ func imageTypeFromApiImageType(it ImageTypes, arch distro.Arch) string {
 		return "iot-installer"
 	case ImageTypesIotRawImage:
 		return "iot-raw-image"
+	case ImageTypesLiveInstaller:
+		return "live-installer"
 	}
 	return ""
 }


### PR DESCRIPTION
This was missing to enable `live-installer` in the CloudAPI.