### PR TITLE
ci: fix the gitlab trigger

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
       - name: Trigger GitLab nightly pipeline against this PR
-        if: ${{ env.GITLAB_TOKEN }} && ${{ steps.pr_date.outputs.pr_branch }}
+        if: env.GITLAB_TOKEN && steps.pr_data.outputs.pr_branch
         run: |
             # osbuild-composer
             PROJECT_ID=34771166


### PR DESCRIPTION
There were two issues:

- ${{ }} converts the expression to a string, and strings are apparently always truthy
  https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
- There was a typo in pr_data

Therefore, the check didn't work properly.