### PR TITLE
update to go 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: 1.19
     - env:
         PGUSER: postgres
         PGPASSWORD: foobar
@@ -106,10 +106,10 @@ jobs:
     name: "⌨ Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
@@ -136,10 +136,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Set up Go 1.18
+      - name: Set up Go 1.19
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The requirements for this project are:
 
 At build-time, the following software is required:
 
- * `go >= 1.18`
+ * `go >= 1.19`
  * `python-docutils >= 0.13`
  * `krb5-devel` for fedora/rhel or `libkrb5-dev` for debian/ubuntu`
 

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -78,8 +78,8 @@ func (c *ComposerConfigFile) weldrDistrosImageTypeDenyList() map[string][]string
 
 // GetDefaultConfig returns the default configuration of osbuild-composer
 // Defaults:
-// - 'azure-rhui', 'azure-sap-rhui', 'ec2', 'ec2-ha', 'ec2-sap' image types on 'rhel-*'
-//   are not exposed via Weldr API
+//   - 'azure-rhui', 'azure-sap-rhui', 'ec2', 'ec2-ha', 'ec2-sap' image types on 'rhel-*'
+//     are not exposed via Weldr API
 func GetDefaultConfig() *ComposerConfigFile {
 	return &ComposerConfigFile{
 		Koji: KojiAPIConfig{

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
+
 	"github.com/osbuild/osbuild-composer/internal/upload/oci"
 
 	"github.com/google/uuid"
@@ -150,21 +151,21 @@ func (impl *OSBuildJobImpl) getAWSForS3Target(options *target.AWSS3TargetOptions
 // getGCP returns an *gcp.GCP object using credentials based on the following
 // predefined preference:
 //
-// 1. If the provided `credentials` parameter is not `nil`, it is used to
-//    authenticate with GCP.
+//  1. If the provided `credentials` parameter is not `nil`, it is used to
+//     authenticate with GCP.
 //
-// 2. If a path to GCP credentials file was provided in the worker's
-//    configuration, it is used to authenticate with GCP.
+//  2. If a path to GCP credentials file was provided in the worker's
+//     configuration, it is used to authenticate with GCP.
 //
-// 3. Use Application Default Credentials from the Google library, which tries
-//    to automatically find a way to authenticate using the following options:
+//  3. Use Application Default Credentials from the Google library, which tries
+//     to automatically find a way to authenticate using the following options:
 //
-//    3a. If `GOOGLE_APPLICATION_CREDENTIALS` environment variable is set, it
-//        tries to load and use credentials form the file pointed to by the
-//        variable.
+//     3a. If `GOOGLE_APPLICATION_CREDENTIALS` environment variable is set, it
+//     tries to load and use credentials form the file pointed to by the
+//     variable.
 //
-//    3b. It tries to authenticate using the service account attached to the
-//        resource which is running the code (e.g. Google Compute Engine VM).
+//     3b. It tries to authenticate using the service account attached to the
+//     resource which is running the code (e.g. Google Compute Engine VM).
 func (impl *OSBuildJobImpl) getGCP(credentials []byte) (*gcp.GCP, error) {
 	if credentials != nil {
 		logrus.Info("[GCP] 🔑 using credentials provided with the job request")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/osbuild-composer
 
-go 1.18
+go 1.19
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
 

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -250,7 +250,7 @@ func TestError(t *testing.T) {
 
 }
 
-//This tests calling all the functions on a Blueprint with no Customizations
+// This tests calling all the functions on a Blueprint with no Customizations
 func TestNoCustomizationsInBlueprint(t *testing.T) {
 
 	TestBP := Blueprint{}
@@ -271,7 +271,7 @@ func TestNoCustomizationsInBlueprint(t *testing.T) {
 	assert.Nil(t, nilNTPServers)
 }
 
-//This tests additional scenarios where GetPrimaryLocale() returns nil values
+// This tests additional scenarios where GetPrimaryLocale() returns nil values
 func TestNilGetPrimaryLocale(t *testing.T) {
 
 	//Case empty Customization
@@ -299,7 +299,7 @@ func TestNilGetPrimaryLocale(t *testing.T) {
 
 }
 
-//This tests additional scenario where GetTimezoneSEtting() returns nil values
+// This tests additional scenario where GetTimezoneSEtting() returns nil values
 func TestNilGetTimezoneSettings(t *testing.T) {
 
 	TestCustomizationsEmpty := Customizations{}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -86,7 +86,8 @@ func NewAPIResponse(body []byte) (*APIResponse, error) {
 // apiError converts an API error 400 JSON to a status response
 //
 // The response body should alway be of the form:
-//     {"status": false, "errors": [{"id": ERROR_ID, "msg": ERROR_MESSAGE}, ...]}
+//
+//	{"status": false, "errors": [{"id": ERROR_ID, "msg": ERROR_MESSAGE}, ...]}
 func apiError(resp *http.Response) (*APIResponse, error) {
 	defer resp.Body.Close()
 

--- a/internal/client/compose_test.go
+++ b/internal/client/compose_test.go
@@ -8,18 +8,19 @@
 // not from other functions.
 //
 // NOTE: The compose fail/finish tests use fake composes so the following are not
-//       fully tested here:
 //
-//       * image download
-//       * log download
-//       * logs archive download
-//       * cancel waiting compose
-//       * cancel running compose
+//	fully tested here:
 //
-//       In addition osbuild-composer has not implemented:
+//	* image download
+//	* log download
+//	* logs archive download
+//	* cancel waiting compose
+//	* cancel running compose
 //
-//       * compose/results
-//       * compose/metadata
+//	In addition osbuild-composer has not implemented:
+//
+//	* compose/results
+//	* compose/metadata
 package client
 
 import (

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -55,7 +55,7 @@ func GetProjectsInfoV0(socket *http.Client, projNames string) ([]rpmmd.PackageIn
 	return list.Projects, nil, nil
 }
 
-//DepsolveProjectsV0 returns the dependencies of the names projects
+// DepsolveProjectsV0 returns the dependencies of the names projects
 func DepsolveProjectsV0(socket *http.Client, projNames string) ([]rpmmd.PackageSpec, *APIResponse, error) {
 	body, resp, err := GetRaw(socket, "GET", "/api/v0/projects/depsolve/"+projNames)
 	if resp != nil || err != nil {

--- a/internal/cloud/gcp/storage.go
+++ b/internal/cloud/gcp/storage.go
@@ -28,7 +28,7 @@ const (
 // The ObjectAttrs is returned if the object has been created.
 //
 // Uses:
-//	- Storage API
+//   - Storage API
 func (g *GCP) StorageObjectUpload(ctx context.Context, filename, bucket, object string, metadata map[string]string) (*storage.ObjectAttrs, error) {
 	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
 	if err != nil {
@@ -82,7 +82,7 @@ func (g *GCP) StorageObjectUpload(ctx context.Context, filename, bucket, object 
 // StorageObjectDelete deletes the given object from a bucket.
 //
 // Uses:
-//	- Storage API
+//   - Storage API
 func (g *GCP) StorageObjectDelete(ctx context.Context, bucket, object string) error {
 	storageClient, err := storage.NewClient(ctx, option.WithCredentials(g.creds))
 	if err != nil {

--- a/internal/dnfjson/dnfjson.go
+++ b/internal/dnfjson/dnfjson.go
@@ -490,6 +490,7 @@ type Request struct {
 }
 
 // Hash returns a hash of the unique aspects of the Request
+//
 //nolint:errcheck
 func (r *Request) Hash() string {
 	h := sha256.New()

--- a/internal/jobqueue/fsjobqueue/fsjobqueue.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
 
 	"github.com/osbuild/osbuild-composer/internal/jsondb"
@@ -566,8 +567,8 @@ func (q *fsJobQueue) removePendingJob(id uuid.UUID) {
 // jobMatchesCriteria returns true if it matches criteria defined in parameters
 //
 // Criteria:
-//  - the job's type is one of the acceptedJobTypes
-//  - the job's channel is one of the acceptedChannels
+//   - the job's type is one of the acceptedJobTypes
+//   - the job's channel is one of the acceptedChannels
 func jobMatchesCriteria(j *job, acceptedJobTypes []string, acceptedChannels []string) bool {
 	contains := func(slice []string, str string) bool {
 		for _, item := range slice {

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -243,13 +243,17 @@ func (k *Koji) CGInitBuild(name, version, release string) (*CGInitBuildResult, e
 	return &result, nil
 }
 
-/* from `koji/__init__.py`
+/*
+	from `koji/__init__.py`
+
 BUILD_STATES = Enum((
-    'BUILDING',
-    'COMPLETE',
-    'DELETED',
-    'FAILED',
-    'CANCELED',
+
+	'BUILDING',
+	'COMPLETE',
+	'DELETED',
+	'FAILED',
+	'CANCELED',
+
 ))
 */
 const (

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.18.9
+GO_VERSION=1.19.11
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
UBI and the oldest support Fedora (37) now all have go 1.19, so we are cleared to switch.

gofmt now reformats comments in certain cases, so that explains the formatting changes in this commit.
See https://go.dev/doc/go1.19#go-doc