### PR TITLE
test: Add workaround for BZ#2213660 and #2225667

### DIFF
--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -71,6 +71,13 @@ EOFKS
     echo "============================"
 }
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -8,6 +8,13 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh none
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Start firewalld
 greenprint "Start firewalld"
 sudo systemctl enable --now firewalld

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -11,6 +11,13 @@ source /etc/os-release
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree-ignition.sh
+++ b/test/cases/ostree-ignition.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Install and start firewalld
 greenprint "🔧 Install and start firewalld"
 sudo dnf install -y firewalld

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
 
 # Install openshift client
 greenprint "🔧 Installing oenshift client(oc)"

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -10,6 +10,12 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 source /etc/os-release
 ARCH=$(uname -m)
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
 
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -27,6 +27,13 @@ done
 sudo /usr/local/bin/yq -iy '.service_info.diskencryption_clevis |= [{disk_label: "/dev/vda4", reencrypt: true, binding: {pin: "tpm2", config: "{}"}}]' /etc/fdo/aio/configs/serviceinfo_api_server.yml
 sudo systemctl restart fdo-aio
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -150,6 +150,12 @@ case "${ID}-${VERSION_ID}" in
         exit 1;;
 esac
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
 
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -34,6 +34,13 @@ function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
 
+# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
+if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
+    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
+LIBVIRTD_ARGS=
+EOF
+fi
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd


### PR DESCRIPTION
All RHEL for Edge test on RHEL 9.3 failed due to bug https://bugzilla.redhat.com/show_bug.cgi?id=2225667 which would be related with systemd bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660.
This PR is just a workaround, it'll be removed when issue fixed.