### PR TITLE
test: Make log errors easier to find

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -161,7 +161,7 @@ trap - EXIT
 
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
-    echo "Something went wrong with the compose. 😢"
+    redprint "Something went wrong with the compose. 😢"
     exit 1
 fi
 
@@ -187,19 +187,19 @@ if nvrGreaterOrEqual "osbuild-composer" "83"; then
         aarch64)
             # aarch64 image supports only uefi boot mode
             if [[ "$AMI_BOOT_MODE" != "uefi" ]]; then
-                echo "AMI boot mode is not \"uefi\", but \"$AMI_BOOT_MODE\""
+                redprint "AMI boot mode is not \"uefi\", but \"$AMI_BOOT_MODE\""
                 exit 1
             fi
             ;;
         x86_64)
             # x86_64 image supports hybrid boot mode with preference for uefi
             if [[ "$AMI_BOOT_MODE" != "uefi-preferred" ]]; then
-                echo "AMI boot mode is not \"uefi-preferred\", but \"$AMI_BOOT_MODE\""
+                redprint "AMI boot mode is not \"uefi-preferred\", but \"$AMI_BOOT_MODE\""
                 exit 1
             fi
             ;;
         *)
-            echo "Unsupported architecture: $ARCH"
+            redprint "Unsupported architecture: $ARCH"
             exit 1
             ;;
     esac
@@ -249,7 +249,7 @@ if [ "$ARCH" == "aarch64" ]; then
 fi
 
 if [ -z "$CIV_CONFIG_FILE" ]; then
-    echo "ERROR: please provide the variable CIV_CONFIG_FILE"
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
     exit 1
 fi
 
@@ -289,7 +289,7 @@ if [[ $RESULTS == 1 ]]; then
     greenprint "💚 Success"
     exit 0
 elif [[ $RESULTS != 1 ]]; then
-    greenprint "❌ Failed"
+    redprint "❌ Failed"
     exit 1
 fi
 

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -188,7 +188,7 @@ trap - EXIT
 
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then
-    echo "Something went wrong with the compose. 😢"
+    redprint "Something went wrong with the compose. 😢"
     exit 1
 fi
 
@@ -226,7 +226,7 @@ tee "${TEMPDIR}/resource-file.json" <<EOF
 EOF
 
 if [ -z "$CIV_CONFIG_FILE" ]; then
-    echo "ERROR: please provide the variable CIV_CONFIG_FILE"
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
     exit 1
 fi
 
@@ -261,7 +261,7 @@ if [[ $RESULTS == 1 ]]; then
     greenprint "💚 Success with HyperV ${HYPER_V_GEN}"
     exit 0
 elif [[ $RESULTS != 1 ]]; then
-    greenprint "❌ Failed ${HYPER_V_GEN}"
+    redprint "❌ Failed ${HYPER_V_GEN}"
     exit 1
 fi
 

--- a/test/cases/base_tests.sh
+++ b/test/cases/base_tests.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 #
 # Script that executes different high level sanity tests writen in GO. 
 #
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
 WORKING_DIRECTORY=/usr/libexec/osbuild-composer
 TESTS_PATH=/usr/libexec/osbuild-composer-test
@@ -67,15 +68,15 @@ done
 
 # Print a report of the test results.
 test_divider
-echo "😃 Passed tests:" "${PASSED_TESTS[@]}"
-echo "☹ Failed tests:" "${FAILED_TESTS[@]}"
+greenprint "😃 Passed tests:" "${PASSED_TESTS[@]}"
+redprint "☹ Failed tests:" "${FAILED_TESTS[@]}"
 test_divider
 
 # Exit with a failure if tests were executed and any of them failed.
 if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
-    echo "🎉 All tests passed."
+    greenprint "🎉 All tests passed."
     exit 0
 else
-    echo "🔥 One or more tests failed."
+    redprint "🔥 One or more tests failed."
     exit 1
 fi

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -51,7 +51,7 @@ build_image() {
     STATUS=$(get_build_info ".status" "$COMPOSE_START")
 
     if [[ $want_fail == "$STATUS" ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         sudo pkill -P ${WORKER_JOURNAL_PID}
         trap - EXIT
         exit 1
@@ -87,7 +87,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -102,9 +102,9 @@ clean_up () {
 }
 check_result () {
     if [ ${#FAILED_MOUNTPOINTS[@]} -eq 0 ]; then
-        echo "🎉 $1 scenario went as expected"
+        greenprint "🎉 $1 scenario went as expected"
     else
-        echo "🔥 $1 scenario didn't go as expected. The following mountpoints were not present:"
+        redprint "🔥 $1 scenario didn't go as expected. The following mountpoints were not present:"
         printf '%s\n' "${FAILED_MOUNTPOINTS[@]}"
         exit 1
     fi
@@ -251,5 +251,5 @@ sudo composer-cli blueprints delete rhel85-custom-filesystem-fail > /dev/null
 
 clean_up
 
-echo "🎉 All tests passed."
+greenprint "🎉 All tests passed."
 exit 0

--- a/test/cases/image_tests.sh
+++ b/test/cases/image_tests.sh
@@ -79,7 +79,7 @@ run_test_case () {
 
     echo
     test_divider
-    echo "🏃🏻 Running test: ${TEST_NAME}"
+    greenprint "🏃🏻 Running test: ${TEST_NAME}"
     test_divider
 
     TEST_CMD="env BRANCH_NAME=${BRANCH_NAME-main} BUILD_ID=$BUILD_ID DISTRO_CODE=$DISTRO_CODE $TEST_RUNNER -test.v ${IMAGE_TEST_CASES_PATH}/${TEST_CASE_FILENAME}"
@@ -114,15 +114,15 @@ done
 
 # Print a report of the test results.
 test_divider
-echo "😃 Passed tests: " "${PASSED_TESTS[@]}"
-echo "☹ Failed tests: " "${FAILED_TESTS[@]}"
+greenprint "😃 Passed tests: " "${PASSED_TESTS[@]}"
+redprint "☹ Failed tests: " "${FAILED_TESTS[@]}"
 test_divider
 
 # Exit with a failure if tests were executed and any of them failed.
 if [ ${#PASSED_TESTS[@]} -gt 0 ] && [ ${#FAILED_TESTS[@]} -eq 0 ]; then
-    echo "🎉 All tests passed."
+    greenprint "🎉 All tests passed."
     exit 0
 else
-    echo "🔥 One or more tests failed."
+    redprint "🔥 One or more tests failed."
     exit 1
 fi

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -137,7 +137,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="centos-stream9"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 TEST_UUID=$(uuidgen)
@@ -226,7 +226,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 
@@ -265,7 +265,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -109,7 +109,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="fedora-rawhide"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -184,7 +184,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -221,7 +221,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -96,7 +96,7 @@ case "${ID}-${VERSION_ID}" in
         DATASTREAM="/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml"
         ;;
     *)
-        echo "$0 should be skipped on ${ID}-${VERSION_ID} check gitlab-ci.yml"
+        redprint "$0 should be skipped on ${ID}-${VERSION_ID} check gitlab-ci.yml"
         exit 1
         ;;
 esac
@@ -198,7 +198,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ ${COMPOSE_STATUS} != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -224,7 +224,7 @@ wait_for_ssh_up () {
   done
   if [[ ${RESULTS} == 0 ]]; then
       clean_up "${1}"
-      echo "SSH failed to become ready 😢"
+      redprint "SSH failed to become ready 😢"
       exit 1
   fi
 }
@@ -473,7 +473,7 @@ echo "Hardened score: ${HARDENED_SCORE}%"
 
 # compare floating point numbers
 if python3 -c "exit(${HARDENED_SCORE} > ${BASELINE_SCORE})"; then
-  greenprint "❌ Failed"
+  redprint "❌ Failed"
   echo "Hardened image did not improve baseline score"
   exit 1
 fi
@@ -481,7 +481,7 @@ fi
 # one grub rule fails (expected)
 # check if any other rules have failed
 if [[ ${SEVERITY} -gt 1 ]]; then
-  greenprint "❌ Failed"
+  redprint "❌ Failed"
   echo "More than one oscap rule with high severity failed"
   exit 1
 fi

--- a/test/cases/ostree-ami-image.sh
+++ b/test/cases/ostree-ami-image.sh
@@ -90,7 +90,7 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -169,7 +169,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -246,7 +246,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi
@@ -573,7 +573,7 @@ while true; do
 done
 
 if [[ $IMPORT_STATUS != completed ]]; then
-  echo "Something went wrong with the snapshot. 😢"
+  redprint "Something went wrong with the snapshot. 😢"
   exit 1
 else
   greenprint "Snapshot imported successfully."

--- a/test/cases/ostree-ignition.sh
+++ b/test/cases/ostree-ignition.sh
@@ -126,7 +126,7 @@ case "${ID}-${VERSION_ID}" in
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -206,7 +206,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -248,7 +248,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -151,7 +151,7 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -293,7 +293,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -344,7 +344,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -139,7 +139,7 @@ case "${ID}-${VERSION_ID}" in
         CUSTOM_DIRS_FILES="true"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -222,7 +222,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -270,7 +270,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -154,7 +154,7 @@ case "${ID}-${VERSION_ID}" in
         FDO_USER_ONBOARDING="true"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -251,7 +251,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -301,7 +301,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -146,7 +146,7 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         ;;
     *)
-        echo "unsupported distro: ${ID}-${VERSION_ID}"
+        redprint "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;
 esac
 
@@ -308,7 +308,7 @@ build_image() {
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
-        echo "Something went wrong with the compose. 😢"
+        redprint "Something went wrong with the compose. 😢"
         exit 1
     fi
 }
@@ -350,7 +350,7 @@ check_result () {
     if [[ $RESULTS == 1 ]]; then
         greenprint "💚 Success"
     else
-        greenprint "❌ Failed"
+        redprint "❌ Failed"
         clean_up
         exit 1
     fi

--- a/test/cases/upgrade8to9.sh
+++ b/test/cases/upgrade8to9.sh
@@ -148,7 +148,7 @@ sudo scp "${SSH_OPTIONS[@]}" -q -i "${SSH_KEY}" root@"$INSTANCE_ADDRESS":logs/* 
 if [[ "$RESULT" == 0 ]]; then
   greenprint "💚 Success"
 else
-  greenprint "❌ Failed"
+  redprint "❌ Failed"
   exit 1
 fi
 


### PR DESCRIPTION
We were using greenprint for failures, which makes it hard to quickly find where the tests failed. This switches errors to use redprint, and adds it to places that were simply using echo before doing an exit 1.


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/