### PR TITLE
internal/cloud/gcp/compute: Add SEV_SNP_CAPABLE Guest OS Feature

### DIFF
--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -30,6 +30,15 @@ var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeatu
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
 }
 
+// Guest OS Features for RHEL9.0 images.
+// The SEV-SNP support was added since RHEL-9.1, so keeping this for RHEL-9.0 only.
+var GuestOsFeaturesRHEL90 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
+	{Type: common.ToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+}
+
 // GuestOsFeaturesByDistro returns the the list of Guest OS Features, which
 // should be used when importing an image of the specified distribution.
 //
@@ -42,6 +51,8 @@ func GuestOsFeaturesByDistro(distroName string) []*computepb.GuestOsFeature {
 	case strings.HasPrefix(distroName, "rhel-8"):
 		return GuestOsFeaturesRHEL8
 
+	case distroName == "rhel-90":
+		return GuestOsFeaturesRHEL90
 	case strings.HasPrefix(distroName, "centos-9"):
 		fallthrough
 	case strings.HasPrefix(distroName, "rhel-9"):

--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -27,6 +27,7 @@ var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeatu
 	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
 }
 
 // GuestOsFeaturesByDistro returns the the list of Guest OS Features, which


### PR DESCRIPTION
See: https://github.com/coreos/coreos-assembler/pull/3547
See: https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
See: https://issues.redhat.com/browse/COS-2343

---

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->