### PR TITLE
Koji: expose image metadata in build extra metadata, including boot mode

### DIFF
--- a/cmd/osbuild-koji-tests/main_test.go
+++ b/cmd/osbuild-koji-tests/main_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 )
@@ -180,7 +181,8 @@ func TestKojiImport(t *testing.T) {
 			RPMs:         []rpmmd.RPM{},
 			Extra: koji.BuildOutputExtra{
 				Image: koji.ImageExtraInfo{
-					Arch: "noarch",
+					Arch:     "noarch",
+					BootMode: distro.BOOT_LEGACY.String(),
 				},
 			},
 		},

--- a/cmd/osbuild-koji-tests/main_test.go
+++ b/cmd/osbuild-koji-tests/main_test.go
@@ -141,7 +141,7 @@ func TestKojiImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// Import the build
-	build := koji.ImageBuild{
+	build := koji.Build{
 		TaskID:    1,
 		Name:      buildName,
 		Version:   "1",
@@ -168,18 +168,18 @@ func TestKojiImport(t *testing.T) {
 			RPMs:  []rpmmd.RPM{},
 		},
 	}
-	output := []koji.Image{
+	output := []koji.BuildOutput{
 		{
 			BuildRootID:  1,
 			Filename:     filename,
 			FileSize:     uint64(filesize),
 			Arch:         "noarch",
-			ChecksumType: "md5",
-			MD5:          hash,
-			Type:         "image",
+			ChecksumType: koji.ChecksumTypeMD5,
+			Checksum:     hash,
+			Type:         koji.BuildOutputTypeImage,
 			RPMs:         []rpmmd.RPM{},
-			Extra: koji.ImageExtra{
-				Info: koji.ImageExtraInfo{
+			Extra: koji.BuildOutputExtra{
+				Image: koji.ImageExtraInfo{
 					Arch: "noarch",
 				},
 			},

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -60,7 +60,7 @@ func main() {
 		return
 	}
 
-	build := koji.ImageBuild{
+	build := koji.Build{
 		TaskID:    uint64(taskID),
 		Name:      name,
 		Version:   version,
@@ -87,18 +87,18 @@ func main() {
 			RPMs:  []rpmmd.RPM{},
 		},
 	}
-	output := []koji.Image{
+	output := []koji.BuildOutput{
 		{
 			BuildRootID:  1,
 			Filename:     path.Base(filename),
 			FileSize:     length,
 			Arch:         arch,
-			ChecksumType: "md5",
-			MD5:          hash,
-			Type:         "image",
+			ChecksumType: koji.ChecksumTypeMD5,
+			Checksum:     hash,
+			Type:         koji.BuildOutputTypeImage,
 			RPMs:         []rpmmd.RPM{},
-			Extra: koji.ImageExtra{
-				Info: koji.ImageExtraInfo{
+			Extra: koji.BuildOutputExtra{
+				Image: koji.ImageExtraInfo{
 					Arch: arch,
 				},
 			},

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/sirupsen/logrus"
@@ -99,7 +100,8 @@ func main() {
 			RPMs:         []rpmmd.RPM{},
 			Extra: koji.BuildOutputExtra{
 				Image: koji.ImageExtraInfo{
-					Arch: arch,
+					Arch:     arch,
+					BootMode: distro.BOOT_NONE.String(), // TODO: put the correct boot mode here
 				},
 			},
 		},

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -184,7 +184,8 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 		imageRPMs = rpmmd.DeduplicateRPMs(imageRPMs)
 
 		imgOutputExtraInfo := koji.ImageExtraInfo{
-			Arch: buildArgs.Arch,
+			Arch:     buildArgs.Arch,
+			BootMode: buildArgs.ImageBootMode,
 		}
 		imgOutputsExtraInfo[args.KojiFilenames[i]] = imgOutputExtraInfo
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -360,6 +360,9 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	// copy pipeline info to the result
 	osbuildJobResult.PipelineNames = jobArgs.PipelineNames
 
+	// copy the image boot mode to the result
+	osbuildJobResult.ImageBootMode = jobArgs.ImageBootMode
+
 	// get exports for all job's targets
 	exports := jobArgs.OsbuildExports()
 	if len(exports) == 0 {

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -351,6 +351,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 			},
 			Targets:            targets,
 			ManifestDynArgsIdx: common.ToPtr(1),
+			ImageBootMode:      ir.imageType.BootMode().String(),
 		}, []uuid.UUID{initID, manifestJobID}, channel)
 		if err != nil {
 			return id, HTTPErrorWithInternal(ErrorEnqueueingJob, err)

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -41,7 +41,11 @@ type Koji struct {
 // used for the build, and the values are free-form maps containing
 // type-specific information for the build.
 type TypeInfo struct {
-	Image struct{} `json:"image"`
+	// Image holds extra metadata about all images built by the build.
+	// It is a map whose keys are the filenames of the images, and
+	// the values are the extra metadata for the image.
+	// There can't be more than one image with the same filename.
+	Image map[string]ImageExtraInfo `json:"image"`
 }
 
 // BuildExtra holds extra metadata associated with the build.

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -110,8 +110,12 @@ type BuildRoot struct {
 // ImageExtraInfo holds extra metadata about the image.
 // This structure is shared for the Extra metadata of the output and the build.
 type ImageExtraInfo struct {
-	// TODO: Ideally this is where the pipeline would be passed.
-	Arch string `json:"arch"` // TODO: why?
+	// Koji docs say: "should contain IDs that allow tracking the output back to the system in which it was generated"
+	// TODO: we should probably add some ID here, probably the OSBuildJob UUID?
+
+	Arch string `json:"arch"`
+	// Boot mode of the image
+	BootMode string `json:"boot_mode,omitempty"`
 }
 
 // BuildOutputExtra holds extra metadata associated with the build output.

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2581,6 +2581,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 				Build:   imageType.BuildPipelines(),
 				Payload: imageType.PayloadPipelines(),
 			},
+			ImageBootMode: imageType.BootMode().String(),
 		}, "")
 		if err == nil {
 			err = api.store.PushCompose(composeID, mf, imageType, bp, size, targets, jobId, packages)

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -22,6 +22,10 @@ type OSBuildJob struct {
 	ManifestDynArgsIdx *int             `json:"manifest_dyn_args_idx,omitempty"`
 	Targets            []*target.Target `json:"targets,omitempty"`
 	PipelineNames      *PipelineNames   `json:"pipeline_names,omitempty"`
+	// The ImageBootMode is just copied to the result by the worker, so that
+	// the value can be accessed job which depend on it.
+	// (string representation of distro.BootMode values)
+	ImageBootMode string `json:"image_boot_mode,omitempty"`
 }
 
 // OsbuildExports returns a slice of osbuild pipeline names, which should be
@@ -54,6 +58,9 @@ type OSBuildJobResult struct {
 	HostOS string `json:"host_os"`
 	// Architecture of the worker which handled the job
 	Arch string `json:"arch"`
+	// Boot mode supported by the image
+	// (string representation of distro.BootMode values)
+	ImageBootMode string `json:"image_boot_mode,omitempty"`
 	JobResult
 }
 

--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -21,6 +21,9 @@ CLOUD_PROVIDER_AWS="aws"
 CLOUD_PROVIDER_GCP="gcp"
 CLOUD_PROVIDER_AZURE="azure"
 
+# define the default cloud provider to test for
+CLOUD_PROVIDER="none"
+
 #
 # Test types
 #
@@ -108,6 +111,60 @@ else
 fi
 
 trap cleanups EXIT
+
+# Verify that all the expected information is present in the buildinfo
+function verify_buildinfo() {
+    local buildinfo="${1}"
+    local target_cloud="${2:-none}"
+
+    local extra_build_metadata
+    # extract the extra build metadata JSON from the output
+    extra_build_metadata="$(echo "${buildinfo}" | grep -oP '(?<=Extra: ).*' | tr "'" '"')"
+
+    # sanity check the extra build metadata
+    if [ -z "${extra_build_metadata}" ]; then
+        echo "Extra build metadata is empty"
+        exit 1
+    fi
+
+    # extract the image archives paths from the output and keep only the filenames
+    local outputs_images
+    outputs_images="$(echo "${buildinfo}" |
+        sed -zE 's/.*Image archives:\n((\S+\n){1,})([\w\s]+:){0,}.*/\1/g' |
+        sed -E 's/.*\/(.*)/\1/g')"
+
+    # we build one image for cloud test case and two for non-cloud test case
+    if [ "${target_cloud}" == "none" ]; then
+        if [[ $(echo "${outputs_images}" | wc -l) -ne 2 ]]; then
+            echo "Unexpected number of images in the buildinfo"
+            exit 1
+        fi
+    else
+        if [[ $(echo "${outputs_images}" | wc -l) -ne 1 ]]; then
+            echo "Unexpected number of images in the buildinfo"
+            exit 1
+        fi
+    fi
+
+    local images_metadata
+    images_metadata="$(echo "${extra_build_metadata}" | jq -r '.typeinfo.image')"
+
+    for image in $outputs_images; do
+        local image_metadata
+        image_metadata="$(echo "${images_metadata}" | jq -r ".\"${image}\"")"
+        if [ "${image_metadata}" == "null" ]; then
+            echo "Image metadata for '${image}' is missing"
+            exit 1
+        fi
+
+        local image_arch
+        image_arch="$(echo "${image_metadata}" | jq -r '.arch')"
+        if [ "${image_arch}" != "${ARCH}" ]; then
+            echo "Unexpected arch for '${image}'. Expected '${ARCH}', but got '${image_arch}'"
+            exit 1
+        fi
+    done
+}
 
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh jwt
@@ -201,7 +258,13 @@ fi
 
 greenprint "Show Koji task"
 koji --server=http://localhost:8080/kojihub taskinfo 1
-koji --server=http://localhost:8080/kojihub buildinfo 1
+
+greenprint "Show Koji buildinfo"
+BUILDINFO_OUTPUT="$(koji --server=http://localhost:8080/kojihub buildinfo 1)"
+echo "${BUILDINFO_OUTPUT}"
+
+greenprint "Verify the buildinfo output"
+verify_buildinfo "${BUILDINFO_OUTPUT}" "${CLOUD_PROVIDER}"
 
 greenprint "Run the integration test"
 sudo /usr/libexec/osbuild-composer-test/osbuild-koji-tests

--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -163,6 +163,19 @@ function verify_buildinfo() {
             echo "Unexpected arch for '${image}'. Expected '${ARCH}', but got '${image_arch}'"
             exit 1
         fi
+
+        local image_boot_mode
+        image_boot_mode="$(echo "${image_metadata}" | jq -r '.boot_mode')"
+        # for now, check just that the boot mode is a valid value
+        case "${image_boot_mode}" in
+            "uefi"|"legacy"|"hybrid")
+                ;;
+            "none"|*)
+                # for now, we don't upload any images that have 'none' as boot mode, although it is a valid value
+                echo "Unexpected boot mode for '${image}'. Expected 'uefi', 'legacy' or 'hybrid', but got '${image_boot_mode}'"
+                exit 1
+                ;;
+        esac
     done
 }
 


### PR DESCRIPTION
The main goal of this PR is to expose the image boot mode in the Koji Build Extra metadata field.

Notable changes:

- Refactor Koji structures to be more consistent with their JSON representation and to what's used in Koji documentation. The changes make data structures more generic, which will be later helpful for the consolidation of information attached to Koji builds.
- Expose the image output extra metadata also in the build extra metadata under the image filename. The same data structure is now used for these two situations.
- Add the image boot mode to the `OSBuildJob` options and `OSBuildJobResult` options and copy the value in worker from job options to the result. Unfortunately, there is no better way (see discussion in this PR) to enable `KojiFinalize` job to access the data.
- Modify Weldr API and Cloud API to set the boot mode in the `OSBuildJob` options.
- Extend the Koji image output extra metadata to contain image boot mode.
- Extend the `koji.sh` test case to verify the Koji buildinfo content, with the focus on the build extra metadata.

This PR partially relates to https://issues.redhat.com/browse/COMPOSER-1801

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
