### PR TITLE
DEBUG: use cloud-image-val:pr-266 container

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -215,15 +215,7 @@ fi
 
 greenprint "Pulling cloud-image-val container"
 
-if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
-  # If running on CIV, get dev container
-  TAG=${CI_COMMIT_REF_SLUG}
-else
-  # If not, get prod container
-  TAG="prod"
-fi
-
-CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:pr-266"
 
 sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 


### PR DESCRIPTION
in order to exercise test for RHBZ#2221269. See:
https://github.com/osbuild/cloud-image-val/pull/266


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
