### PR TITLE
DEBUG: Execute installers.sh test in GCP

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -652,7 +652,7 @@ NIGHTLY_SUCCESS:
 
 Installer:
   stage: test
-  extends: .terraform/openstack
+  extends: .terraform/gcp
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
@@ -662,9 +662,10 @@ Installer:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/rhel-8.9-nightly-x86_64
-          - rhos-01/rhel-9.3-nightly-x86_64
-          - rhos-01/centos-stream-9-x86_64
+          - gcp/rhel-8.9-nightly-x86_64
+          - gcp/rhel-9.3-nightly-x86_64
+          - gcp/centos-stream-9-x86_64
+        INTERNAL_NETWORK: ["true"]
 
 Manifest-diff:
   stage: test

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -61,9 +61,9 @@ EOFKS
 
     echo "Writing new ISO"
     if nvrGreaterOrEqual "lorax" "34.9.18"; then
-        sudo mkksiso -c "console=ttyS0,115200" --ks "${newksfile}" "${iso}" "${newiso}"
+        sudo mkksiso -c "console=ttyS0,115200 softlockup_all_cpu_backtrace=1" --ks "${newksfile}" "${iso}" "${newiso}"
     else
-        sudo mkksiso -c "console=ttyS0,115200" "${newksfile}" "${iso}" "${newiso}"
+        sudo mkksiso -c "console=ttyS0,115200 softlockup_all_cpu_backtrace=1" "${newksfile}" "${iso}" "${newiso}"
     fi
 
     echo "==== NEW KICKSTART FILE ===="


### PR DESCRIPTION
trying to reproduce the kernel soft-lockup issue here


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
