### PR TITLE
dependabot: group go package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,9 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
+    groups:
+      go-deps:
+        patterns:
+          - "*"  # group all dependency updates into one PR
+    open-pull-requests-limit: 1
+    rebase-strategy: "auto"


### PR DESCRIPTION
Imho, this is much saner than having so many PRs for all individual dependencies. Taken from osbuild/images.