### PR TITLE
Tests: Remove deprecated --os-type cli argument

### DIFF
--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -372,7 +372,6 @@ sudo virt-install  --name="${IMAGE_KEY}"\
                    --ram 3072 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --nographics \

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -323,7 +323,6 @@ sudo virt-install --name="${VIRSH_DOMAIN}"\
                   --ram 3072 \
                   --vcpus 2 \
                   --network network=integration,mac=34:49:22:B0:83:30 \
-                  --os-type linux \
                   --os-variant "${OS_VARIANT}" \
                   --import \
                   --noautoconsole \
@@ -422,7 +421,6 @@ sudo virt-install --name="${VIRSH_DOMAIN}"\
                   --ram 3072 \
                   --vcpus 2 \
                   --network network=integration,mac=34:49:22:B0:83:30 \
-                  --os-type linux \
                   --os-variant "${OS_VARIANT}" \
                   --import \
                   --nographics \

--- a/test/cases/ostree-ignition.sh
+++ b/test/cases/ostree-ignition.sh
@@ -518,7 +518,6 @@ sudo virt-install  --name="${IMAGE_KEY}-simplified"\
                    --ram 2048 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "${BOOT_ARGS}" \
@@ -799,7 +798,6 @@ sudo virt-install  --name="${IMAGE_KEY}-simplified"\
                    --ram 2048 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "${BOOT_ARGS}" \
@@ -940,7 +938,6 @@ sudo virt-install  --name="${IMAGE_KEY}-raw"\
                    --ram 2048 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:31 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --boot "${BOOT_ARGS}" \
                    --tpm backend.type=emulator,backend.version=2.0,model=tpm-crb \

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -562,7 +562,6 @@ sudo virt-install  --name="${IMAGE_KEY}-bios" \
                    --ram 2048 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --nographics \
@@ -653,7 +652,6 @@ sudo virt-install  --name="${IMAGE_KEY}-uefi"\
                    --ram 2048 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:31 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "$BOOT_ARGS" \

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -504,14 +504,12 @@ if [[ "$ID" != "fedora" ]]; then
     sudo restorecon -Rv /var/lib/libvirt/images/
 
     greenprint "💿 Installing raw image on BIOS VM"
-    # TODO: os-type is deprecated in newer versions; remove conditionally
     sudo virt-install  --name="${IMAGE_KEY}-bios"\
                        --disk path="${LIBVIRT_IMAGE_PATH}",format=qcow2 \
                        --ram 3072 \
                        --vcpus 2 \
                        --network network=integration,mac=34:49:22:B0:83:30 \
                        --import \
-                       --os-type linux \
                        --os-variant ${OS_VARIANT} \
                        --nographics \
                        --noautoconsole \
@@ -782,7 +780,6 @@ sudo virt-install --name="${IMAGE_KEY}-uefi"\
                --ram 3072 \
                --vcpus 2 \
                --network network=integration,mac=34:49:22:B0:83:31 \
-               --os-type linux \
                --import \
                --os-variant ${OS_VARIANT} \
                --boot "$BOOT_ARGS" \

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -482,7 +482,6 @@ sudo virt-install  --name="${IMAGE_KEY}-simplified_iso_without_fdo"\
                    --ram "${MEMORY}" \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "$BOOT_ARGS" \
@@ -647,7 +646,6 @@ sudo virt-install --name="${IMAGE_KEY}-http"\
                   --ram "${MEMORY}" \
                   --vcpus 2 \
                   --network network=integration,mac=34:49:22:B0:83:30 \
-                  --os-type linux \
                   --os-variant "${OS_VARIANT}" \
                   --pxe \
                   --boot "$BOOT_ARGS" \
@@ -800,7 +798,6 @@ sudo virt-install  --name="${IMAGE_KEY}-fdosshkey"\
                    --ram "${MEMORY}" \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "$BOOT_ARGS" \
@@ -1116,7 +1113,6 @@ sudo virt-install  --name="${IMAGE_KEY}-fdorootcert"\
                    --ram "${MEMORY}" \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
                    --boot "$BOOT_ARGS" \

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -555,7 +555,6 @@ sudo virt-install  --initrd-inject="${KS_FILE}" \
                    --ram 3072 \
                    --vcpus 2 \
                    --network network=integration,mac=34:49:22:B0:83:30 \
-                   --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --location ${location_arg} \
                    --nographics \

--- a/test/cases/ubi-wsl.sh
+++ b/test/cases/ubi-wsl.sh
@@ -190,7 +190,6 @@ $AZURE_CMD vm create \
    --resource-group "$AZURE_RESOURCE_GROUP" \
    --name "wsl-vm-$TEST_ID" \
    --attach-os-disk "$AZ_DISK" \
-   --os-type "windows" \
    --security-type "TrustedLaunch" \
    --location "$AZURE_WSL_LOCATION" \
     --nic-delete-option delete \


### PR DESCRIPTION
test logs print:

[2023-08-22T10:18:14-04:00] 💿 Install image via installer(ISO) on VM WARNING  --os-type is deprecated and does nothing. Please stop using it.

