### PR TITLE
dashboards/worker: default to showing the past 6 hours

### DIFF
--- a/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
+++ b/templates/dashboards/grafana-dashboard-image-builder-worker-general.configmap.yml
@@ -2127,7 +2127,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-28d",
+        "from": "now-6h",
         "to": "now"
       },
       "timepicker": {
@@ -2158,6 +2158,6 @@ data:
       "timezone": "",
       "title": "Image Builder Worker",
       "uid": "image-builder-worker",
-      "version": 12,
+      "version": 13,
       "weekStart": ""
     }


### PR DESCRIPTION
The worker dashboard contains slow queries, running these on 28 days of data take a very long time (and they often time out).

