### PR TITLE
Consolidation & extension of information imported to Koji builds

### DIFF
--- a/cmd/osbuild-koji-tests/main_test.go
+++ b/cmd/osbuild-koji-tests/main_test.go
@@ -179,8 +179,8 @@ func TestKojiImport(t *testing.T) {
 			Checksum:     hash,
 			Type:         koji.BuildOutputTypeImage,
 			RPMs:         []rpmmd.RPM{},
-			Extra: koji.BuildOutputExtra{
-				Image: koji.ImageExtraInfo{
+			Extra: &koji.BuildOutputExtra{
+				ImageOutput: koji.ImageExtraInfo{
 					Arch:     "noarch",
 					BootMode: distro.BOOT_LEGACY.String(),
 				},

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -98,7 +98,7 @@ func main() {
 			Checksum:     hash,
 			Type:         koji.BuildOutputTypeImage,
 			RPMs:         []rpmmd.RPM{},
-			Extra: koji.BuildOutputExtra{
+			Extra: &koji.BuildOutputExtra{
 				Image: koji.ImageExtraInfo{
 					Arch:     arch,
 					BootMode: distro.BOOT_NONE.String(), // TODO: put the correct boot mode here

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -99,7 +99,7 @@ func main() {
 			Type:         koji.BuildOutputTypeImage,
 			RPMs:         []rpmmd.RPM{},
 			Extra: &koji.BuildOutputExtra{
-				Image: koji.ImageExtraInfo{
+				ImageOutput: koji.ImageExtraInfo{
 					Arch:     arch,
 					BootMode: distro.BOOT_NONE.String(), // TODO: put the correct boot mode here
 				},

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -188,6 +188,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			Arch:            buildResult.Arch,
 			BootMode:        buildResult.ImageBootMode,
 			OSBuildArtifact: kojiTargetResult.OsbuildArtifact,
+			OSBuildVersion:  buildResult.OSBuildVersion,
 		}
 
 		// The image filename is now set in the KojiTargetResultOptions.

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -198,7 +198,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			Checksum:     kojiTargetOptions.ImageMD5,
 			Type:         koji.BuildOutputTypeImage,
 			RPMs:         imageRPMs,
-			Extra: koji.BuildOutputExtra{
+			Extra: &koji.BuildOutputExtra{
 				Image: imgOutputExtraInfo,
 			},
 		})

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -164,7 +164,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			},
 			ContentGenerator: koji.ContentGenerator{
 				Name:    "osbuild",
-				Version: "0", // TODO: put the correct version here
+				Version: buildResult.OSBuildVersion,
 			},
 			Container: koji.Container{
 				Type: "none",

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -119,6 +119,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 	var outputs []koji.BuildOutput
 	// Extra info for each image output is stored using the image filename as the key
 	imgOutputsExtraInfo := map[string]koji.ImageExtraInfo{}
+	manifestOutputsExtraInfo := map[string]*koji.ManifestExtraInfo{}
 
 	var osbuildResults []worker.OSBuildJobResult
 	initArgs, osbuildResults, err = extractDynamicArgs(job)
@@ -249,6 +250,8 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 				manifestExtraInfo.Info = manifestInfo
 			}
 
+			manifestOutputsExtraInfo[kojiTargetOptions.OSBuildManifest.Filename] = &manifestExtraInfo
+
 			outputs = append(outputs, koji.BuildOutput{
 				BuildRootID:  uint64(i),
 				Filename:     kojiTargetOptions.OSBuildManifest.Filename,
@@ -291,6 +294,7 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			TypeInfo: koji.TypeInfoBuild{
 				Image: imgOutputsExtraInfo,
 			},
+			Manifest: manifestOutputsExtraInfo,
 		},
 	}
 

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -187,15 +187,24 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			Arch:     buildArgs.Arch,
 			BootMode: buildArgs.ImageBootMode,
 		}
-		imgOutputsExtraInfo[args.KojiFilenames[i]] = imgOutputExtraInfo
+
+		// The image filename is now set in the KojiTargetResultOptions.
+		// For backward compatibility, if the filename is not set in the
+		// options, use the filename from the KojiTargetOptions.
+		imageFilename := kojiTargetOptions.Image.Filename
+		if imageFilename == "" {
+			imageFilename = args.KojiFilenames[i]
+		}
+
+		imgOutputsExtraInfo[imageFilename] = imgOutputExtraInfo
 
 		outputs = append(outputs, koji.BuildOutput{
 			BuildRootID:  uint64(i),
-			Filename:     args.KojiFilenames[i],
-			FileSize:     kojiTargetOptions.ImageSize,
+			Filename:     imageFilename,
+			FileSize:     kojiTargetOptions.Image.Size,
 			Arch:         buildArgs.Arch,
-			ChecksumType: koji.ChecksumTypeMD5,
-			Checksum:     kojiTargetOptions.ImageMD5,
+			ChecksumType: koji.ChecksumType(kojiTargetOptions.Image.ChecksumType),
+			Checksum:     kojiTargetOptions.Image.Checksum,
 			Type:         koji.BuildOutputTypeImage,
 			RPMs:         imageRPMs,
 			Extra: &koji.BuildOutputExtra{

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -196,6 +196,13 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 			imageFilename = args.KojiFilenames[i]
 		}
 
+		// If there are any non-Koji target results in the build,
+		// add them to the image output extra metadata.
+		nonKojiTargetResults := buildResult.TargetResultsFilterByName([]target.TargetName{target.TargetNameKoji})
+		if len(nonKojiTargetResults) > 0 {
+			imgOutputExtraInfo.UploadTargetResults = nonKojiTargetResults
+		}
+
 		imgOutputsExtraInfo[imageFilename] = imgOutputExtraInfo
 
 		// Image output

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -184,8 +184,9 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 		imageRPMs = rpmmd.DeduplicateRPMs(imageRPMs)
 
 		imgOutputExtraInfo := koji.ImageExtraInfo{
-			Arch:     buildResult.Arch,
-			BootMode: buildResult.ImageBootMode,
+			Arch:            buildResult.Arch,
+			BootMode:        buildResult.ImageBootMode,
+			OSBuildArtifact: kojiTargetResult.OsbuildArtifact,
 		}
 
 		// The image filename is now set in the KojiTargetResultOptions.

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -872,8 +872,12 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 			logWithId.Info("[Koji] 🎉 Image successfully uploaded")
 			targetResult.Options = &target.KojiTargetResultOptions{
-				ImageMD5:  imageHash,
-				ImageSize: imageSize,
+				Image: &target.KojiOutputInfo{
+					Filename:     jobTarget.ImageName,
+					ChecksumType: target.ChecksumTypeMD5,
+					Checksum:     imageHash,
+					Size:         imageSize,
+				},
 			}
 
 		case *target.OCITargetOptions:

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -458,7 +458,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		var targetResult *target.TargetResult
 		switch targetOptions := jobTarget.Options.(type) {
 		case *target.WorkerServerTargetOptions:
-			targetResult = target.NewWorkerServerTargetResult()
+			targetResult = target.NewWorkerServerTargetResult(&jobTarget.OsbuildArtifact)
 			var f *os.File
 			imagePath := path.Join(outputDirectory, jobTarget.OsbuildArtifact.ExportName, jobTarget.OsbuildArtifact.ExportFilename)
 			f, err = os.Open(imagePath)
@@ -474,7 +474,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.VMWareTargetOptions:
-			targetResult = target.NewVMWareTargetResult()
+			targetResult = target.NewVMWareTargetResult(&jobTarget.OsbuildArtifact)
 			credentials := vmware.Credentials{
 				Username:   targetOptions.Username,
 				Password:   targetOptions.Password,
@@ -528,7 +528,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.AWSTargetOptions:
-			targetResult = target.NewAWSTargetResult(nil)
+			targetResult = target.NewAWSTargetResult(nil, &jobTarget.OsbuildArtifact)
 			a, err := impl.getAWS(targetOptions.Region, targetOptions.AccessKeyID, targetOptions.SecretAccessKey, targetOptions.SessionToken)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, err.Error(), nil)
@@ -585,7 +585,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.AWSS3TargetOptions:
-			targetResult = target.NewAWSS3TargetResult(nil)
+			targetResult = target.NewAWSS3TargetResult(nil, &jobTarget.OsbuildArtifact)
 			a, bucket, err := impl.getAWSForS3Target(targetOptions)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, err.Error(), nil)
@@ -605,7 +605,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			targetResult.Options = &target.AWSS3TargetResultOptions{URL: url}
 
 		case *target.AzureTargetOptions:
-			targetResult = target.NewAzureTargetResult()
+			targetResult = target.NewAzureTargetResult(&jobTarget.OsbuildArtifact)
 			azureStorageClient, err := azure.NewStorageClient(targetOptions.StorageAccount, targetOptions.StorageAccessKey)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, err.Error(), nil)
@@ -633,7 +633,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.GCPTargetOptions:
-			targetResult = target.NewGCPTargetResult(nil)
+			targetResult = target.NewGCPTargetResult(nil, &jobTarget.OsbuildArtifact)
 			ctx := context.Background()
 
 			g, err := impl.getGCP(targetOptions.Credentials)
@@ -698,7 +698,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.AzureImageTargetOptions:
-			targetResult = target.NewAzureImageTargetResult(nil)
+			targetResult = target.NewAzureImageTargetResult(nil, &jobTarget.OsbuildArtifact)
 			ctx := context.Background()
 
 			if impl.AzureConfig.Creds == nil {
@@ -828,7 +828,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.KojiTargetOptions:
-			targetResult = target.NewKojiTargetResult(nil)
+			targetResult = target.NewKojiTargetResult(nil, &jobTarget.OsbuildArtifact)
 			kojiServerURL, err := url.Parse(targetOptions.Server)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, fmt.Sprintf("failed to parse Koji server URL: %v", err), nil)
@@ -923,7 +923,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 
 		case *target.OCITargetOptions:
-			targetResult = target.NewOCITargetResult(nil)
+			targetResult = target.NewOCITargetResult(nil, &jobTarget.OsbuildArtifact)
 			// create an ociClient uploader with a valid storage client
 			var ociClient oci.Client
 			ociClient, err = impl.getOCI(oci.ClientParams{
@@ -984,7 +984,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			logWithId.Info("[OCI] 🎉 Image uploaded and registered!")
 			targetResult.Options = &target.OCITargetResultOptions{ImageID: imageID}
 		case *target.OCIObjectStorageTargetOptions:
-			targetResult = target.NewOCIObjectStorageTargetResult(nil)
+			targetResult = target.NewOCIObjectStorageTargetResult(nil, &jobTarget.OsbuildArtifact)
 			// create an ociClient uploader with a valid storage client
 			ociClient, err := impl.getOCI(oci.ClientParams{
 				User:        targetOptions.User,
@@ -1033,7 +1033,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			logWithId.Info("[OCI] 🎉 Image uploaded and pre-authenticated request generated!")
 			targetResult.Options = &target.OCIObjectStorageTargetResultOptions{URL: uri}
 		case *target.ContainerTargetOptions:
-			targetResult = target.NewContainerTargetResult(nil)
+			targetResult = target.NewContainerTargetResult(nil, &jobTarget.OsbuildArtifact)
 			destination := jobTarget.ImageName
 
 			logWithId.Printf("[container] 📦 Preparing upload to '%s'", destination)

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -908,7 +908,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 					Checksum:     imageHash,
 					Size:         imageSize,
 				},
-				OsbuildManifest: &target.KojiOutputInfo{
+				OSBuildManifest: &target.KojiOutputInfo{
 					Filename:     manifestFilename,
 					ChecksumType: target.ChecksumTypeMD5,
 					Checksum:     manifestHash,

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -341,6 +341,13 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		}
 	}()
 
+	osbuildVersion, err := osbuild.OSBuildVersion()
+	if err != nil {
+		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "Error getting osbuild binary version", err)
+		return err
+	}
+	osbuildJobResult.OSBuildVersion = osbuildVersion
+
 	// Read the job specification
 	var jobArgs worker.OSBuildJob
 	err = job.Args(&jobArgs)

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -414,6 +414,9 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 
 	jobResult := &worker.ManifestJobByIDResult{
 		Manifest: nil,
+		ManifestInfo: worker.ManifestInfo{
+			OSBuildComposerVersion: common.BuildVersion(),
+		},
 	}
 
 	defer func() {

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -419,6 +419,17 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 		},
 	}
 
+	// add osbuild/images dependency info to job result
+	osbuildImagesDep, err := common.GetDepModuleInfoByPath(common.OSBuildImagesModulePath)
+	if err != nil {
+		// do not fail here and just log the error, because the module info is not available in tests.
+		// Failing here would make the unit tests fail. See https://github.com/golang/go/issues/33976
+		logWithId.Errorf("Error getting %s dependency info: %v", common.OSBuildImagesModulePath, err)
+	} else {
+		osbuildImagesDepModule := worker.ComposerDepModuleFromDebugModule(osbuildImagesDep)
+		jobResult.ManifestInfo.OSBuildComposerDeps = append(jobResult.ManifestInfo.OSBuildComposerDeps, osbuildImagesDepModule)
+	}
+
 	defer func() {
 		if jobResult.JobError != nil {
 			logWithId.Errorf("Error in manifest job %v: %v", jobResult.JobError.Reason, err)

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -50,8 +50,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -87,8 +91,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -124,8 +132,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -160,8 +172,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: false,
@@ -198,8 +214,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -247,8 +267,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -288,8 +312,12 @@ func TestKojiCompose(t *testing.T) {
 				Arch:   test_distro.TestArchName,
 				HostOS: test_distro.TestDistroName,
 				TargetResults: []*target.TargetResult{target.NewKojiTargetResult(&target.KojiTargetResultOptions{
-					ImageMD5:  "browns",
-					ImageSize: 42,
+					Image: &target.KojiOutputInfo{
+						Filename:     "test.img",
+						ChecksumType: target.ChecksumTypeMD5,
+						Checksum:     "browns",
+						Size:         42,
+					},
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -56,6 +56,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -97,6 +100,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -138,6 +144,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -178,6 +187,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: false,
@@ -220,6 +232,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -273,6 +288,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,
@@ -318,6 +336,9 @@ func TestKojiCompose(t *testing.T) {
 						Checksum:     "browns",
 						Size:         42,
 					},
+				}, &target.OsbuildArtifact{
+					ExportFilename: "disk.img",
+					ExportName:     "image",
 				})},
 				OSBuildOutput: &osbuild.Result{
 					Success: true,

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -1261,6 +1261,9 @@ func TestImageFromCompose(t *testing.T) {
 	tr := target.NewAWSTargetResult(&target.AWSTargetResultOptions{
 		Ami:    "ami-abc123",
 		Region: "eu-central-1",
+	}, &target.OsbuildArtifact{
+		ExportFilename: "image.raw",
+		ExportName:     "image",
 	})
 	res, err := json.Marshal(&worker.OSBuildJobResult{
 		Success:       true,

--- a/internal/common/dependencies.go
+++ b/internal/common/dependencies.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const (
+	OSBuildImagesModulePath = "github.com/osbuild/images"
+)
+
+// GetDepModuleInfoByPath returns the debug.Module for the dependency
+// with the given path. If the dependency is not found, an error is
+// returned.
+func GetDepModuleInfoByPath(path string) (*debug.Module, error) {
+	buildinfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, fmt.Errorf("Failed to read build info")
+	}
+
+	for _, dep := range buildinfo.Deps {
+		if dep.Path == path {
+			return dep, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Could not find dependency %s", path)
+}

--- a/internal/target/aws_target.go
+++ b/internal/target/aws_target.go
@@ -37,8 +37,8 @@ type AWSTargetResultOptions struct {
 
 func (AWSTargetResultOptions) isTargetResultOptions() {}
 
-func NewAWSTargetResult(options *AWSTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameAWS, options)
+func NewAWSTargetResult(options *AWSTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameAWS, options, artifact)
 }
 
 type AWSS3TargetOptions struct {
@@ -66,6 +66,6 @@ type AWSS3TargetResultOptions struct {
 
 func (AWSS3TargetResultOptions) isTargetResultOptions() {}
 
-func NewAWSS3TargetResult(options *AWSS3TargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameAWSS3, options)
+func NewAWSS3TargetResult(options *AWSS3TargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameAWSS3, options, artifact)
 }

--- a/internal/target/azure_image_target.go
+++ b/internal/target/azure_image_target.go
@@ -39,6 +39,6 @@ type AzureImageTargetResultOptions struct {
 
 func (AzureImageTargetResultOptions) isTargetResultOptions() {}
 
-func NewAzureImageTargetResult(options *AzureImageTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameAzureImage, options)
+func NewAzureImageTargetResult(options *AzureImageTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameAzureImage, options, artifact)
 }

--- a/internal/target/azure_target.go
+++ b/internal/target/azure_target.go
@@ -24,6 +24,6 @@ func NewAzureTarget(options *AzureTargetOptions) *Target {
 	return newTarget(TargetNameAzure, options)
 }
 
-func NewAzureTargetResult() *TargetResult {
-	return newTargetResult(TargetNameAzure, nil)
+func NewAzureTargetResult(artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameAzure, nil, artifact)
 }

--- a/internal/target/container_target.go
+++ b/internal/target/container_target.go
@@ -24,6 +24,6 @@ type ContainerTargetResultOptions struct {
 
 func (ContainerTargetResultOptions) isTargetResultOptions() {}
 
-func NewContainerTargetResult(options *ContainerTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameContainer, options)
+func NewContainerTargetResult(options *ContainerTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameContainer, options, artifact)
 }

--- a/internal/target/gcp_target.go
+++ b/internal/target/gcp_target.go
@@ -28,6 +28,6 @@ type GCPTargetResultOptions struct {
 
 func (GCPTargetResultOptions) isTargetResultOptions() {}
 
-func NewGCPTargetResult(options *GCPTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameGCP, options)
+func NewGCPTargetResult(options *GCPTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameGCP, options, artifact)
 }

--- a/internal/target/koji_target.go
+++ b/internal/target/koji_target.go
@@ -1,5 +1,10 @@
 package target
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 const TargetNameKoji TargetName = "org.osbuild.koji"
 
 type KojiTargetOptions struct {
@@ -13,9 +18,101 @@ func NewKojiTarget(options *KojiTargetOptions) *Target {
 	return newTarget(TargetNameKoji, options)
 }
 
+// ChecksumType represents the type of a checksum used for a KojiOutputInfo.
+type ChecksumType string
+
+const (
+	ChecksumTypeMD5 ChecksumType = "md5"
+
+	// Only MD5 is supported for now to enable backwards compatibility.
+	// The reason is tha the old KojiTargetOptions contained only
+	// ImageMD5 and ImageSize fields, which mandates the use of MD5.
+	// TODO: uncomment the lines below when the backwards compatibility is no longer needed.
+	//ChecksumTypeAdler32 ChecksumType = "adler32"
+	//ChecksumTypeSHA256  ChecksumType = "sha256"
+)
+
+// KojiOutputInfo represents the information about any output file uploaded to Koji
+// as part of the OSBuild job. This information is then used by the KojiFinalize
+// job when importing files into Koji.
+type KojiOutputInfo struct {
+	Filename     string       `json:"filename"`
+	ChecksumType ChecksumType `json:"checksum_type"`
+	Checksum     string       `json:"checksum"`
+	Size         uint64       `json:"size"`
+}
+
 type KojiTargetResultOptions struct {
-	ImageMD5  string `json:"image_md5"`
-	ImageSize uint64 `json:"image_size"`
+	Image           *KojiOutputInfo `json:"image"`
+	Log             *KojiOutputInfo `json:"log,omitempty"`
+	OSBuildManifest *KojiOutputInfo `json:"osbuild_manifest,omitempty"`
+}
+
+func (o *KojiTargetResultOptions) UnmarshalJSON(data []byte) error {
+	type aliasType KojiTargetResultOptions
+	if err := json.Unmarshal(data, (*aliasType)(o)); err != nil {
+		return err
+	}
+
+	// compatType contains deprecated fields, which are being checked
+	// for backwards compatibility.
+	type compatType struct {
+		// Deprecated: Use Image in KojiTargetOptions instead.
+		// Kept for backwards compatibility.
+		ImageMD5  string `json:"image_md5"`
+		ImageSize uint64 `json:"image_size"`
+	}
+
+	var compat compatType
+	if err := json.Unmarshal(data, &compat); err != nil {
+		return err
+	}
+
+	// Check if the Image data in the new struct format are set.
+	// If not, then the data are coming from an old composer.
+	if o.Image == nil {
+		// o.Image.Filename is kept empty, because the filename was previously
+		// not set as there was always only the Image file. The KojiFinalize job
+		// handles this case and takes the Image filename from the KojiFinalizeJob
+		// options.
+
+		o.Image = &KojiOutputInfo{
+			ChecksumType: ChecksumTypeMD5,
+			Checksum:     compat.ImageMD5,
+			Size:         compat.ImageSize,
+		}
+	}
+
+	return nil
+}
+
+func (o KojiTargetResultOptions) MarshalJSON() ([]byte, error) {
+	type alias KojiTargetResultOptions
+	// compatType is a super-set of the current KojiTargetResultOptions and
+	// old version of it. It contains deprecated fields, which are being set
+	// for backwards compatibility.
+	type compatType struct {
+		alias
+
+		// Deprecated: Use Image in KojiTargetOptions instead.
+		// Kept for backwards compatibility.
+		ImageMD5  string `json:"image_md5"`
+		ImageSize uint64 `json:"image_size"`
+	}
+
+	// Only MD5 is supported for now to enable backwards compatibility.
+	// TODO: remove this block when the backwards compatibility is no longer needed.
+	if o.Image.ChecksumType != ChecksumTypeMD5 {
+		return nil, fmt.Errorf("unsupported checksum type: %s", o.Image.ChecksumType)
+	}
+
+	compat := compatType{
+		alias:     (alias)(o),
+		ImageMD5:  o.Image.Checksum,
+		ImageSize: o.Image.Size,
+	}
+
+	return json.Marshal(compat)
 }
 
 func (KojiTargetResultOptions) isTargetResultOptions() {}

--- a/internal/target/koji_target.go
+++ b/internal/target/koji_target.go
@@ -117,6 +117,6 @@ func (o KojiTargetResultOptions) MarshalJSON() ([]byte, error) {
 
 func (KojiTargetResultOptions) isTargetResultOptions() {}
 
-func NewKojiTargetResult(options *KojiTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameKoji, options)
+func NewKojiTargetResult(options *KojiTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameKoji, options, artifact)
 }

--- a/internal/target/koji_target.go
+++ b/internal/target/koji_target.go
@@ -42,10 +42,26 @@ type KojiOutputInfo struct {
 	Size         uint64       `json:"size"`
 }
 
+type OSBuildComposerDepModule struct {
+	Path    string                    `json:"path"`
+	Version string                    `json:"version"`
+	Replace *OSBuildComposerDepModule `json:"replace,omitempty"`
+}
+
+// ManifestInfo contains information about the environment in which
+// the manifest was produced and which could affect its content.
+type ManifestInfo struct {
+	OSBuildComposerVersion string `json:"osbuild_composer_version"`
+	// List of relevant modules used by osbuild-composer which
+	// could affect the manifest content.
+	OSBuildComposerDeps []*OSBuildComposerDepModule `json:"osbuild_composer_deps,omitempty"`
+}
+
 type KojiTargetResultOptions struct {
-	Image           *KojiOutputInfo `json:"image"`
-	Log             *KojiOutputInfo `json:"log,omitempty"`
-	OSBuildManifest *KojiOutputInfo `json:"osbuild_manifest,omitempty"`
+	Image               *KojiOutputInfo `json:"image"`
+	Log                 *KojiOutputInfo `json:"log,omitempty"`
+	OSBuildManifest     *KojiOutputInfo `json:"osbuild_manifest,omitempty"`
+	OSBuildManifestInfo *ManifestInfo   `json:"osbuild_manifest_info,omitempty"`
 }
 
 func (o *KojiTargetResultOptions) UnmarshalJSON(data []byte) error {

--- a/internal/target/koji_target_test.go
+++ b/internal/target/koji_target_test.go
@@ -1,0 +1,163 @@
+package target
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKojiTargetOptionsUnmarshalJSON tests that the resulting struct
+// has appropriate fields set when legacy JSON is used.
+func TestKojiTargetResultOptionsUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		name           string
+		JSON           []byte
+		expectedResult *KojiTargetResultOptions
+		err            bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "new format",
+			JSON: []byte(`{"image":{"checksum_type":"md5","checksum":"hash","filename":"image.raw","size":123456}}`),
+			expectedResult: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					Filename:     "image.raw",
+					ChecksumType: "md5",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+			},
+		},
+		{
+			name: "old format",
+			JSON: []byte(`{"image_md5":"hash","image_size":123456}`),
+			expectedResult: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					ChecksumType: "md5",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+			},
+		},
+		{
+			name: "full format",
+			JSON: []byte(`{"image":{"checksum_type":"md5","checksum":"hash","filename":"image.raw","size":123456},"log":{"checksum_type":"md5","checksum":"hash","filename":"log.txt","size":123456},"osbuild_manifest":{"checksum_type":"md5","checksum":"hash","filename":"manifest.json","size":123456}}`),
+			expectedResult: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					Filename:     "image.raw",
+					ChecksumType: "md5",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+				Log: &KojiOutputInfo{
+					Filename:     "log.txt",
+					ChecksumType: "md5",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+				OSBuildManifest: &KojiOutputInfo{
+					Filename:     "manifest.json",
+					ChecksumType: "md5",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+			},
+		},
+		{
+			name: "invalid JSON",
+			JSON: []byte(`{"image_md5":"hash","image_size":123456`),
+			err:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result KojiTargetResultOptions
+			err := json.Unmarshal(tc.JSON, &result)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedResult, &result)
+		})
+	}
+}
+
+// TestKojiTargetResultOptionsMarshalJSON tests that the resulting JSON
+// has the legacy fields set for backwards compatibility.
+func TestKojiTargetResultOptionsMarshalJSON(t *testing.T) {
+	type testCase struct {
+		name         string
+		results      *KojiTargetResultOptions
+		expectedJSON []byte
+		err          bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "backwards compatibility",
+			results: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					Filename:     "image.raw",
+					ChecksumType: ChecksumTypeMD5,
+					Checksum:     "hash",
+					Size:         123456,
+				},
+			},
+			expectedJSON: []byte(`{"image":{"filename":"image.raw","checksum_type":"md5","checksum":"hash","size":123456},"image_md5":"hash","image_size":123456}`),
+		},
+		{
+			name: "full format",
+			results: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					Filename:     "image.raw",
+					ChecksumType: ChecksumTypeMD5,
+					Checksum:     "hash",
+					Size:         123456,
+				},
+				Log: &KojiOutputInfo{
+					Filename:     "log.txt",
+					ChecksumType: ChecksumTypeMD5,
+					Checksum:     "hash",
+					Size:         654321,
+				},
+				OSBuildManifest: &KojiOutputInfo{
+					Filename:     "manifest.json",
+					ChecksumType: ChecksumTypeMD5,
+					Checksum:     "hash",
+					Size:         123321,
+				},
+			},
+			expectedJSON: []byte(`{"image":{"filename":"image.raw","checksum_type":"md5","checksum":"hash","size":123456},"log":{"filename":"log.txt","checksum_type":"md5","checksum":"hash","size":654321},"osbuild_manifest":{"filename":"manifest.json","checksum_type":"md5","checksum":"hash","size":123321},"image_md5":"hash","image_size":123456}`),
+		},
+		{
+			name: "invalid checksum type",
+			results: &KojiTargetResultOptions{
+				Image: &KojiOutputInfo{
+					Filename:     "image.raw",
+					ChecksumType: "sha256",
+					Checksum:     "hash",
+					Size:         123456,
+				},
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := json.Marshal(tc.results)
+			if tc.err {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectedJSON, result)
+		})
+	}
+}

--- a/internal/target/oci_target.go
+++ b/internal/target/oci_target.go
@@ -26,8 +26,8 @@ type OCITargetResultOptions struct {
 
 func (OCITargetResultOptions) isTargetResultOptions() {}
 
-func NewOCITargetResult(options *OCITargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameOCI, options)
+func NewOCITargetResult(options *OCITargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameOCI, options, artifact)
 }
 
 const TargetNameOCIObjectStorage TargetName = "org.osbuild.oci.objectstorage"
@@ -55,6 +55,6 @@ type OCIObjectStorageTargetResultOptions struct {
 
 func (OCIObjectStorageTargetResultOptions) isTargetResultOptions() {}
 
-func NewOCIObjectStorageTargetResult(options *OCIObjectStorageTargetResultOptions) *TargetResult {
-	return newTargetResult(TargetNameOCIObjectStorage, options)
+func NewOCIObjectStorageTargetResult(options *OCIObjectStorageTargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameOCIObjectStorage, options, artifact)
 }

--- a/internal/target/targetresult.go
+++ b/internal/target/targetresult.go
@@ -8,15 +8,18 @@ import (
 )
 
 type TargetResult struct {
-	Name        TargetName          `json:"name"`
-	Options     TargetResultOptions `json:"options,omitempty"`
-	TargetError *clienterrors.Error `json:"target_error,omitempty"`
+	Name    TargetName          `json:"name"`
+	Options TargetResultOptions `json:"options,omitempty"`
+	// Configuration used to produce osbuild artifact specific to this target
+	OsbuildArtifact *OsbuildArtifact    `json:"osbuild_artifact,omitempty"`
+	TargetError     *clienterrors.Error `json:"target_error,omitempty"`
 }
 
-func newTargetResult(name TargetName, options TargetResultOptions) *TargetResult {
+func newTargetResult(name TargetName, options TargetResultOptions, artifact *OsbuildArtifact) *TargetResult {
 	return &TargetResult{
-		Name:    name,
-		Options: options,
+		Name:            name,
+		Options:         options,
+		OsbuildArtifact: artifact,
 	}
 }
 
@@ -25,9 +28,10 @@ type TargetResultOptions interface {
 }
 
 type rawTargetResult struct {
-	Name        TargetName          `json:"name"`
-	Options     json.RawMessage     `json:"options,omitempty"`
-	TargetError *clienterrors.Error `json:"target_error,omitempty"`
+	Name            TargetName          `json:"name"`
+	Options         json.RawMessage     `json:"options,omitempty"`
+	OsbuildArtifact *OsbuildArtifact    `json:"osbuild_artifact,omitempty"`
+	TargetError     *clienterrors.Error `json:"target_error,omitempty"`
 }
 
 func (targetResult *TargetResult) UnmarshalJSON(data []byte) error {
@@ -48,6 +52,7 @@ func (targetResult *TargetResult) UnmarshalJSON(data []byte) error {
 
 	targetResult.Name = rawTR.Name
 	targetResult.Options = options
+	targetResult.OsbuildArtifact = rawTR.OsbuildArtifact
 	targetResult.TargetError = rawTR.TargetError
 	return nil
 }

--- a/internal/target/targetresult_test.go
+++ b/internal/target/targetresult_test.go
@@ -58,12 +58,16 @@ func TestTargetResultUnmarshal(t *testing.T) {
 			},
 		},
 		{
-			resultJSON: []byte(`{"name":"org.osbuild.koji","options":{"image_md5":"hash","image_size":123456}}`),
+			resultJSON: []byte(`{"name":"org.osbuild.koji","options":{"image":{"checksum_type":"md5","checksum":"hash","filename":"image.raw","size":123456}}}`),
 			expectedResult: &TargetResult{
 				Name: TargetNameKoji,
 				Options: &KojiTargetResultOptions{
-					ImageMD5:  "hash",
-					ImageSize: 123456,
+					Image: &KojiOutputInfo{
+						Filename:     "image.raw",
+						ChecksumType: ChecksumTypeMD5,
+						Checksum:     "hash",
+						Size:         123456,
+					},
 				},
 			},
 		},

--- a/internal/target/vmware_target.go
+++ b/internal/target/vmware_target.go
@@ -18,6 +18,6 @@ func NewVMWareTarget(options *VMWareTargetOptions) *Target {
 	return newTarget(TargetNameVMWare, options)
 }
 
-func NewVMWareTargetResult() *TargetResult {
-	return newTargetResult(TargetNameVMWare, nil)
+func NewVMWareTargetResult(artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameVMWare, nil, artifact)
 }

--- a/internal/target/worker_server_target.go
+++ b/internal/target/worker_server_target.go
@@ -10,6 +10,6 @@ func NewWorkerServerTarget() *Target {
 	return newTarget(TargetNameWorkerServer, &WorkerServerTargetOptions{})
 }
 
-func NewWorkerServerTargetResult() *TargetResult {
-	return newTargetResult(TargetNameWorkerServer, nil)
+func NewWorkerServerTargetResult(artifact *OsbuildArtifact) *TargetResult {
+	return newTargetResult(TargetNameWorkerServer, nil, artifact)
 }

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -127,6 +127,8 @@ type ImageExtraInfo struct {
 	BootMode string `json:"boot_mode,omitempty"`
 	// Configuration used to prouce this image using osbuild
 	OSBuildArtifact *target.OsbuildArtifact `json:"osbuild_artifact,omitempty"`
+	// Version of the osbuild binary used by the worker to build the image
+	OSBuildVersion string `json:"osbuild_version,omitempty"`
 	// Results from any upload targets associated with the image
 	// except for the Koji target.
 	UploadTargetResults []*target.TargetResult `json:"upload_target_results,omitempty"`

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -121,6 +121,8 @@ type ImageExtraInfo struct {
 	Arch string `json:"arch"`
 	// Boot mode of the image
 	BootMode string `json:"boot_mode,omitempty"`
+	// Configuration used to prouce this image using osbuild
+	OSBuildArtifact *target.OsbuildArtifact `json:"osbuild_artifact,omitempty"`
 	// Results from any upload targets associated with the image
 	// except for the Koji target.
 	UploadTargetResults []*target.TargetResult `json:"upload_target_results,omitempty"`

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -130,12 +130,25 @@ type ImageExtraInfo struct {
 
 func (ImageExtraInfo) isImageOutputTypeMD() {}
 
+type OSBuildComposerDepModule struct {
+	Path    string                    `json:"path"`
+	Version string                    `json:"version"`
+	Replace *OSBuildComposerDepModule `json:"replace,omitempty"`
+}
+
+// ManifestInfo holds information about the environment in which
+// the manifest was produced and which could affect its content.
+type ManifestInfo struct {
+	OSBuildComposerVersion string `json:"osbuild_composer_version"`
+	// List of relevant modules used by osbuild-composer which
+	// could affect the manifest content.
+	OSBuildComposerDeps []*OSBuildComposerDepModule `json:"osbuild_composer_deps,omitempty"`
+}
+
 // ManifestExtraInfo holds extra metadata about the osbuild manifest.
 type ManifestExtraInfo struct {
-	// TODO: include osbuild-composer version which produced the manifest?
-	// TODO: include the vendored 'images' version?
-
-	Arch string `json:"arch"`
+	Arch string        `json:"arch"`
+	Info *ManifestInfo `json:"info,omitempty"`
 }
 
 func (ManifestExtraInfo) isImageOutputTypeMD() {}

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -143,15 +143,15 @@ const (
 // The output can be a file of various types, which is imported to Koji.
 // Examples of types are "image", "log" or other.
 type BuildOutput struct {
-	BuildRootID  uint64           `json:"buildroot_id"`
-	Filename     string           `json:"filename"`
-	FileSize     uint64           `json:"filesize"`
-	Arch         string           `json:"arch"` // can be 'noarch' or a specific arch
-	ChecksumType ChecksumType     `json:"checksum_type"`
-	Checksum     string           `json:"checksum"`
-	Type         BuildOutputType  `json:"type"`
-	RPMs         []rpmmd.RPM      `json:"components"` // TODO: should be omitempty
-	Extra        BuildOutputExtra `json:"extra"`      // TODO: should be omitempty
+	BuildRootID  uint64            `json:"buildroot_id"`
+	Filename     string            `json:"filename"`
+	FileSize     uint64            `json:"filesize"`
+	Arch         string            `json:"arch"` // can be 'noarch' or a specific arch
+	ChecksumType ChecksumType      `json:"checksum_type"`
+	Checksum     string            `json:"checksum"`
+	Type         BuildOutputType   `json:"type"`
+	RPMs         []rpmmd.RPM       `json:"components,omitempty"`
+	Extra        *BuildOutputExtra `json:"extra,omitempty"`
 }
 
 // CONTENT GENERATOR METADATA

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ubccr/kerby/khttp"
 
 	"github.com/osbuild/images/pkg/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
 type Koji struct {
@@ -120,6 +121,9 @@ type ImageExtraInfo struct {
 	Arch string `json:"arch"`
 	// Boot mode of the image
 	BootMode string `json:"boot_mode,omitempty"`
+	// Results from any upload targets associated with the image
+	// except for the Koji target.
+	UploadTargetResults []*target.TargetResult `json:"upload_target_results,omitempty"`
 }
 
 func (ImageExtraInfo) isImageOutputTypeMD() {}

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -53,6 +53,10 @@ type TypeInfoBuild struct {
 // It is a free-form map, but must contain at least the 'typeinfo' key.
 type BuildExtra struct {
 	TypeInfo TypeInfoBuild `json:"typeinfo"`
+	// Manifest holds extra metadata about osbuild manifests attached to the build.
+	// It is a map whose keys are the filenames of the manifests, and
+	// the values are the extra metadata for the manifest.
+	Manifest map[string]*ManifestExtraInfo `json:"osbuild_manifest,omitempty"`
 }
 
 // Build represents a Koji build and holds metadata about it.

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+	"golang.org/x/exp/slices"
 )
 
 //
@@ -91,6 +92,19 @@ func (j *OSBuildJobResult) TargetResultsByName(name target.TargetName) []*target
 	targetResults := []*target.TargetResult{}
 	for _, targetResult := range j.TargetResults {
 		if targetResult.Name == name {
+			targetResults = append(targetResults, targetResult)
+		}
+	}
+	return targetResults
+}
+
+// TargetResultsFilterByName iterates over TargetResults attached to the Job result and
+// returns a slice of Target results excluding the provided names (types). If there were
+// no TargetResults left after filtering, the returned slice will be empty.
+func (j *OSBuildJobResult) TargetResultsFilterByName(excludeNames []target.TargetName) []*target.TargetResult {
+	targetResults := []*target.TargetResult{}
+	for _, targetResult := range j.TargetResults {
+		if !slices.Contains(excludeNames, targetResult.Name) {
 			targetResults = append(targetResults, targetResult)
 		}
 	}

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -124,10 +124,11 @@ type KojiInitJobResult struct {
 }
 
 type KojiFinalizeJob struct {
-	Server        string   `json:"server"`
-	Name          string   `json:"name"`
-	Version       string   `json:"version"`
-	Release       string   `json:"release"`
+	Server  string `json:"server"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Release string `json:"release"`
+	// TODO: eventually deprecate and remove KojiFilenames, since the image filenames are now set in the KojiTargetResultOptions.
 	KojiFilenames []string `json:"koji_filenames"`
 	KojiDirectory string   `json:"koji_directory"`
 	TaskID        uint64   `json:"task_id"` /* https://pagure.io/koji/issue/215 */

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -265,9 +265,16 @@ type DepsolveJobResult struct {
 
 type ManifestJobByID struct{}
 
+// ManifestInfo contains information about the environment in which
+// the manifest was produced and which could affect its content.
+type ManifestInfo struct {
+	OSBuildComposerVersion string `json:"osbuild_composer_version"`
+}
+
 type ManifestJobByIDResult struct {
-	Manifest manifest.OSBuildManifest `json:"data,omitempty"`
-	Error    string                   `json:"error"`
+	Manifest     manifest.OSBuildManifest `json:"data,omitempty"`
+	ManifestInfo ManifestInfo             `json:"info,omitempty"`
+	Error        string                   `json:"error"`
 	JobResult
 }
 

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -63,6 +63,8 @@ type OSBuildJobResult struct {
 	// Boot mode supported by the image
 	// (string representation of distro.BootMode values)
 	ImageBootMode string `json:"image_boot_mode,omitempty"`
+	// Version of the osbuild binary used by the worker to build the image
+	OSBuildVersion string `json:"osbuild_version,omitempty"`
 	JobResult
 }
 

--- a/internal/worker/json_test.go
+++ b/internal/worker/json_test.go
@@ -189,6 +189,150 @@ func TestOSBuildJobResultTargetResultsByName(t *testing.T) {
 	}
 }
 
+func TestOSBuildJobResultTargetResultsFilterByName(t *testing.T) {
+	testCases := []struct {
+		jobResult     OSBuildJobResult
+		targetNames   []target.TargetName
+		targetResults []*target.TargetResult
+	}{
+		{
+			jobResult: OSBuildJobResult{
+				TargetResults: []*target.TargetResult{
+					{
+						Name:        target.TargetNameAWS,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameAWSS3,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "failed to upload image to AWS S3", nil),
+					},
+				},
+			},
+			targetNames: []target.TargetName{
+				target.TargetNameVMWare,
+			},
+			targetResults: []*target.TargetResult{
+				{
+					Name:        target.TargetNameAWS,
+					TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+				},
+				{
+					Name:        target.TargetNameAWSS3,
+					TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "failed to upload image to AWS S3", nil),
+				},
+			},
+		},
+		{
+			jobResult: OSBuildJobResult{
+				TargetResults: []*target.TargetResult{
+					{
+						Name:        target.TargetNameAWS,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameAWSS3,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "failed to upload image to AWS S3", nil),
+					},
+				},
+			},
+			targetNames: []target.TargetName{
+				target.TargetNameVMWare,
+				target.TargetNameAWSS3,
+			},
+			targetResults: []*target.TargetResult{
+				{
+					Name:        target.TargetNameAWS,
+					TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+				},
+			},
+		},
+		{
+			jobResult: OSBuildJobResult{
+				TargetResults: []*target.TargetResult{
+					{
+						Name:        target.TargetNameAWS,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameAWSS3,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "failed to upload image to AWS S3", nil),
+					},
+				},
+			},
+			targetNames: []target.TargetName{
+				target.TargetNameAWS,
+				target.TargetNameAWSS3,
+			},
+			targetResults: []*target.TargetResult{
+				{
+					Name:        target.TargetNameVMWare,
+					TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+				},
+				{
+					Name:        target.TargetNameVMWare,
+					TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+				},
+			},
+		},
+		{
+			jobResult: OSBuildJobResult{
+				TargetResults: []*target.TargetResult{
+					{
+						Name:        target.TargetNameAWS,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorInvalidTargetConfig, "can't login to AWS", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameVMWare,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "can't upload image to VMWare", nil),
+					},
+					{
+						Name:        target.TargetNameAWSS3,
+						TargetError: clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, "failed to upload image to AWS S3", nil),
+					},
+				},
+			},
+			targetNames: []target.TargetName{
+				target.TargetNameAWS,
+				target.TargetNameVMWare,
+				target.TargetNameAWSS3,
+			},
+			targetResults: []*target.TargetResult{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.EqualValues(t, testCase.targetResults, testCase.jobResult.TargetResultsFilterByName(testCase.targetNames))
+	}
+}
+
 func TestOSBuildJobExports(t *testing.T) {
 	testCases := []struct {
 		job             *OSBuildJob

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -78,6 +78,11 @@ export PATH=$PWD/_bin${PATH:+:$PATH}
 export GOPATH=$GO_BUILD_PATH:%{gopath}
 export GOFLAGS+=" -mod=vendor"
 %endif
+%if 0%{?fedora}
+# Fedora disables Go modules by default, but we want to use them.
+# Undefine the macro which disables it to use the default behavior.
+%undefine gomodulesmode
+%endif
 
 # Set the commit hash so that composer can report what source version
 # was used to build it. This has to be set explicitly when calling rpmbuild,

--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -120,6 +120,9 @@ function verify_buildinfo() {
     local buildid="${1}"
     local target_cloud="${2:-none}"
 
+    local osbuild_version
+    osbuild_version="$(osbuild --version | cut -d ' ' -f 2 -)"
+
     local extra_build_metadata
     # extract the extra build metadata JSON from the output
     extra_build_metadata="$(koji -s "${KOJI_HUB_URL}" --noauth call --json getBuild "${buildid}" | jq -r '.extra')"
@@ -240,6 +243,13 @@ function verify_buildinfo() {
         image_osbuild_artifact="$(echo "${image_metadata_build}" | jq -r '.osbuild_artifact')"
         if [ "${image_osbuild_artifact}" == "null" ]; then
             echo "Image osbuild artifact information for '${image_filename}' is missing"
+            exit 1
+        fi
+
+        local image_osbuild_version
+        image_osbuild_version="$(echo "${image_metadata_build}" | jq -r '.osbuild_version')"
+        if [ "${image_osbuild_version}" != "${osbuild_version}" ]; then
+            echo "Unexpected osbuild version for '${image_filename}'. Expected '${osbuild_version}', but got '${image_osbuild_version}'"
             exit 1
         fi
 

--- a/test/cases/koji.sh
+++ b/test/cases/koji.sh
@@ -236,6 +236,13 @@ function verify_buildinfo() {
                 ;;
         esac
 
+        local image_osbuild_artifact
+        image_osbuild_artifact="$(echo "${image_metadata_build}" | jq -r '.osbuild_artifact')"
+        if [ "${image_osbuild_artifact}" == "null" ]; then
+            echo "Image osbuild artifact information for '${image_filename}' is missing"
+            exit 1
+        fi
+
         local image_metadata_archive
         image_metadata_archive="$(echo "${image}" | jq -r '.extra.image')"
         if [ "${image_metadata_build}" != "${image_metadata_archive}" ]; then


### PR DESCRIPTION
This PR is related to [COMPOSER-1801](https://issues.redhat.com/browse/COMPOSER-1801).

The main intention of this PR is to enhance osbuild-composer as a Koji Content Generator, to import all of the most important artifacts to the Koji build, with additional metadata. The goal is to ensure that these additional files and data are preserved for the lifetime of the image in a Koji build.

Previously, some files such as OSBuild logs and manifests were uploaded only to the Koji task by the `koji-osbuild` builder plugin. This resulted in an undesirable situation of them being garbage collected after some time, thus making it extremely difficult (close to impossible) to reproduce the same image build using OSBuild if needed.

With this PR, all the information needed to reproduce an image build are attached to the Koji build and preserved with the image file itself.

## Main changes from Koji PoV

1. OSBuild manifests for the images attached to the Koji build are now also attached to the Koji build as an output archive (in the Koji nomenclature).
2. OSBuild logs from image builds are now attached as logs to the Koji build. These are not JSON files, but a human readable text files with the same format as produced by Image Builder on-prem (when using Weldr API).
3. OSBuild manifest and image archives have additional extra metadata attached to them, and the same metadata are also combined and attached to the build itself.

### Extra metadata attached to OSBuild manifests

The metadata attached to OSBuild manifests are intended to make it easy to reproduce the creation of the manifest used for image build and to expose versions of all relevant tools and dependencies which can affect the resulting manifest.

Attached information:

- **Architecture** of the manifest. Manifest itself is a JSON, but the resulting image is architecture-specific.
- **osbuild-composer version** which generated the manifest. The version is determined by https://github.com/osbuild/osbuild-composer/blob/9d7159dab36efce8035f35b3cdaa0e9d9438f799/internal/common/constants.go#L30-L38
- List of selected **osbuild-composer Go dependencies versions**, which could affect the manifest content. For now, only the `osbuild/images` dependency is included, since it contains the actual image definitions.

Example extra metadata attached to a manifest archive:

```json
{
  "image": {
    "arch": "x86_64",
    "info": {
      "osbuild_composer_version": "git-rev:08a6029ea0b5add394c7ce464e63dffb899790d9",
      "osbuild_composer_deps": [
        {
          "path": "github.com/osbuild/images",
          "version": "v0.6.1-0.20230922185004-1318eb3fc554"
        }
      ]
    }
  }
}
```

### Extra metadata attached to the image

The metadata attached the image are intended to:

- Make it easy to reproduce the image build.
- Make it easy to locate the image in the target cloud environment if it was specified when the build was triggered.
- Provide additional context and information about the image (such as the boot mode).

Attached information:

- **Architecture** of the image.
- **Boot mode** of the image.
- Information about the **osbuild artifact**. Specifically, the **name of the manifest pipeline**, which was exported to produce the image and the **filename of the exported file**.
- **OSBuild version** which was used by the worker to produce the image. This is the version determined by `osbuild --version`.
- **Upload target results** , for any non-Koji upload target. It is a list of target-specific information to make it possible to locate the uploaded image in the target environment. In addition, also the target-specific **osbuild artifact** information is included. Technically, a different pipeline could have been exported from the same OSBuild manifest for each upload target. In reality, this is never happening at the moment. 

Example extra metadata attached to a GCP image uploaded to GCP:

```json
{
  "image": {
    "arch": "x86_64",
    "boot_mode": "uefi",
    "osbuild_artifact": {
      "export_filename": "image.tar.gz",
      "export_name": "archive"
    },
    "osbuild_version": "93",
    "upload_target_results": [
      {
        "name": "org.osbuild.gcp",
        "options": {
          "image_name": "composer-api-82b40e29-95e9-4b0c-8935-dd401086b65a",
          "project_id": "cockpituous"
        },
        "osbuild_artifact": {
          "export_filename": "image.tar.gz",
          "export_name": "archive"
        }
      }
    ]
  }
}
```

### Extra metadata attached to the build

The extra metadata attached to the build just combines the extra metadata attached to each specific output archive attached to the Koji build.

Example extra metadata attached to a build:

```json
{
  "typeinfo": {
    "image": {
      "name-version-release.x86_64.tar.gz": {
        "arch": "x86_64",
        "boot_mode": "uefi",
        "osbuild_artifact": {
          "export_filename": "image.tar.gz",
          "export_name": "archive"
        },
        "osbuild_version": "93",
        "upload_target_results": [
          {
            "name": "org.osbuild.gcp",
            "options": {
              "image_name": "composer-api-82b40e29-95e9-4b0c-8935-dd401086b65a",
              "project_id": "cockpituous"
            },
            "osbuild_artifact": {
              "export_filename": "image.tar.gz",
              "export_name": "archive"
            }
          }
        ]
      }
    }
  },
  "osbuild_manifest": {
    "name-version-release.x86_64.tar.gz.manifest.json": {
      "arch": "x86_64",
      "info": {
        "osbuild_composer_version": "git-rev:08a6029ea0b5add394c7ce464e63dffb899790d9",
        "osbuild_composer_deps": [
          {
            "path": "github.com/osbuild/images",
            "version": "v0.6.1-0.20230922185004-1318eb3fc554"
          }
        ]
      }
    }
  }
}
```

## Main changes from osbuild-composer PoV

Besides the changes mentioned above, which imply direct changes to Koji-related code in osbuild-composer, the following notable changes happened in the rest of the osbuild-composer code:

- `target.OsbuildArtifact` is now included also in the `target.TargetResult` and copied from the `target.Target` by the worker. This makes it possible to access the information by any job which depends on the `OSBuildJob`. Specifically, the `koji-finalize` job is taking advantage of it.
- `worker.ManifestJobByIDResult` now includes the information about the `osbuild-composer` version which produced the manifest.
- `worker.ManifestJobByIDResult` now includes the information about the `osbuild/images` version used by `osbuild-composer` which produced the manifest. If osbuild-composer is not compiled with the support for Go modules, this information can't be retrieved and it is not included in the result structure.
- `worker.OSBuildJobResult` now includes the `osbuild` version used by the worker to produce the image.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
  - `koji.sh` have been extended to cover the newly added functionality.
  - Some new unit tests have been added.
- [ ] adequate documentation informing people about the change such as
  - **TBD** 
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
