### PR TITLE
test: add workaround for bug BZ#2234390

### DIFF
--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -139,7 +139,7 @@ case "${ID}-${VERSION_ID}" in
         OSTREE_REF="centos/9/${ARCH}/edge"
         OS_VARIANT="centos-stream9"
         USER_IN_COMMIT="true"
-        BOOT_LOCATION="https://odcs.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/x86_64/os/"
+        BOOT_LOCATION="https://odcs.stream.centos.org/production/CentOS-Stream-9-20230823.0/compose/BaseOS/x86_64/os/"
         EMBEDED_CONTAINER="true"
         FIREWALL_FEATURE="false"
         DIRS_FILES_CUSTOMIZATION="true"


### PR DESCRIPTION
Test `edge-commit-cs9` failure is caused by bug https://bugzilla.redhat.com/show_bug.cgi?id=2234390. This PR adds workaround for this bug.