### PR TITLE
Handle panics in the osbuild job & fix panic when OCI authentication fails

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -280,6 +280,15 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 
 	// In all cases it is necessary to report result back to osbuild-composer worker API.
 	defer func() {
+		if r := recover(); r != nil {
+			logWithId.Errorf("Recovered from panic: %v", r)
+
+			osbuildJobResult.JobError = clienterrors.WorkerClientError(
+				clienterrors.ErrorJobPanicked,
+				fmt.Sprintf("job panicked:\n%v\n\noriginal error:\n%v", r, osbuildJobResult.JobError),
+				nil,
+			)
+		}
 		validateResult(osbuildJobResult, job.Id().String())
 
 		err := job.Update(osbuildJobResult)

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -278,8 +278,6 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	}
 	osbuildJobResult.HostOS = hostOS
 
-	var outputDirectory string
-
 	// In all cases it is necessary to report result back to osbuild-composer worker API.
 	defer func() {
 		validateResult(osbuildJobResult, job.Id().String())
@@ -288,17 +286,18 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		if err != nil {
 			logWithId.Errorf("Error reporting job result: %v", err)
 		}
+	}()
 
+	outputDirectory, err := os.MkdirTemp(impl.Output, job.Id().String()+"-*")
+	if err != nil {
+		return fmt.Errorf("error creating temporary output directory: %v", err)
+	}
+	defer func() {
 		err = os.RemoveAll(outputDirectory)
 		if err != nil {
 			logWithId.Errorf("Error removing temporary output directory (%s): %v", outputDirectory, err)
 		}
 	}()
-
-	outputDirectory, err = os.MkdirTemp(impl.Output, job.Id().String()+"-*")
-	if err != nil {
-		return fmt.Errorf("error creating temporary output directory: %v", err)
-	}
 
 	// Read the job specification
 	var jobArgs worker.OSBuildJob

--- a/internal/upload/oci/upload.go
+++ b/internal/upload/oci/upload.go
@@ -77,7 +77,9 @@ func (c Client) uploadToBucket(objectName string, bucketName string, namespace s
 	ctx := context.Background()
 	resp, err := uploadManager.UploadFile(ctx, req)
 	if err != nil {
-		if resp.IsResumable() {
+		// resp.IsResumable crashes if resp.MultipartUploadResponse == nil
+		// Thus, we need to check for both.
+		if resp.MultipartUploadResponse != nil && resp.IsResumable() {
 			resp, err = uploadManager.ResumeUploadFile(ctx, *resp.MultipartUploadResponse.UploadID)
 			if err != nil {
 				return err

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -41,6 +41,7 @@ const (
 	ErrorOSTreeParamsInvalid  ClientErrorCode = 34
 	ErrorOSTreeDependency     ClientErrorCode = 35
 	ErrorRemoteFileResolution ClientErrorCode = 36
+	ErrorJobPanicked          ClientErrorCode = 37
 )
 
 type ClientErrorCode int


### PR DESCRIPTION
Two fixes related to each other:

1. When an osbuild job panics, but `osbuild` actually succeeded and no `JobError` was set, we currently report success back to composer. That's wrong. I added a `recover()` to set an error state.
2. Passing wrong credentials when uploading to OCI causes a panic. Seems like the OCI SDK doesn't handle this well. I worked around this by doing more checking when the error is returned.