### PR TITLE
[RHEL 9.3.0] deps: update osbuild/images to v0.3.0-r9.3.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,7 @@ jobs:
         with:
           version: v1.51.0
           args: --verbose --timeout 5m0s
+          skip-cache: true
 
   prepare:
     name: "🔍 Check source preparation"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/labstack/gommon v0.4.0
 	github.com/openshift-online/ocm-sdk-go v0.1.362
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.3.0
+	github.com/osbuild/images v0.3.0-r9.3.2
 	github.com/prometheus/client_golang v1.16.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.362 h1:MoaSMCSzcr8nSK9DBqKmZ9c5e4Cp8
 github.com/openshift-online/ocm-sdk-go v0.1.362/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.3.0 h1:eedZbt/9B8UNVfI8TDfFNqX+Psi9YMOdbA1MXcBPHnk=
-github.com/osbuild/images v0.3.0/go.mod h1:lZsi8oJNfk57VRv5zhdrSLmn0z8YPcQzZBxzdHNfZls=
+github.com/osbuild/images v0.3.0-r9.3.2 h1:jSt69Ac/6vh+7hLx1M6c5ER0+aARLxB3+I/W6bTcBCE=
+github.com/osbuild/images v0.3.0-r9.3.2/go.mod h1:lZsi8oJNfk57VRv5zhdrSLmn0z8YPcQzZBxzdHNfZls=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -13,9 +13,15 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 # Start firewalld
 sudo systemctl enable --now firewalld
 sudo pip3 install yq==v3.2.1
-# Install fdo packages (This cannot be done in the setup.sh because fdo-admin-cli is not available on fedora)
-# Install fdo-client and fdo-init to workaround bug https://bugzilla.redhat.com/show_bug.cgi?id=2230537
-sudo dnf install -y fdo-admin-cli fdo-client fdo-init
+
+# workaround for bug https://issues.redhat.com/browse/RHEL-4992
+if [[ "$VERSION_ID" == "9.3" ]]; then
+    sudo dnf install -y http://download-node-02.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/RHEL-9.3.0-20230915.0/compose/AppStream/x86_64/os/Packages/fdo-{admin-cli,client,init,manufacturing-server,owner-cli,owner-onboarding-server,rendezvous-server}-0.4.12-4.el9_2.x86_64.rpm
+else
+    # Install fdo-client and fdo-init to workaround bug https://bugzilla.redhat.com/show_bug.cgi?id=2230537
+    sudo dnf install -y fdo-admin-cli fdo-client fdo-init
+fi
+
 # Start fdo-aio to have /etc/fdo/aio folder
 sudo systemctl enable --now fdo-aio
 # Wait until config file serviceinfo_api_server.yml exists

--- a/vendor/github.com/osbuild/images/pkg/disk/partition_table.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/partition_table.go
@@ -17,6 +17,7 @@ type PartitionTable struct {
 
 	SectorSize   uint64 // Sector size in bytes
 	ExtraPadding uint64 // Extra space at the end of the partition table (sectors)
+	StartOffset  uint64 // Starting offset of the first partition in the table (Mb)
 }
 
 func NewPartitionTable(basePT *PartitionTable, mountpoints []blueprint.FilesystemCustomization, imageSize uint64, lvmify bool, requiredSizes map[string]uint64, rng *rand.Rand) (*PartitionTable, error) {
@@ -77,6 +78,7 @@ func (pt *PartitionTable) Clone() Entity {
 		Partitions:   make([]Partition, len(pt.Partitions)),
 		SectorSize:   pt.SectorSize,
 		ExtraPadding: pt.ExtraPadding,
+		StartOffset:  pt.StartOffset,
 	}
 
 	for idx, partition := range pt.Partitions {
@@ -364,6 +366,7 @@ func (pt *PartitionTable) relayout(size uint64) uint64 {
 	}
 
 	start := pt.AlignUp(header)
+	start += pt.StartOffset
 	size = pt.AlignUp(size)
 
 	var rootIdx = -1

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/fdo"
+	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/ignition"
 	"github.com/osbuild/images/internal/oscap"
 	"github.com/osbuild/images/internal/users"
@@ -223,6 +224,9 @@ func osCustomizations(
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality
 	osc.WSLConfig = imageConfig.WSLConfig
+
+	osc.Files = append(osc.Files, imageConfig.Files...)
+	osc.Directories = append(osc.Directories, imageConfig.Directories...)
 
 	return osc
 }
@@ -683,4 +687,14 @@ func makeOSTreePayloadCommit(options *ostree.ImageOptions, defaultRef string) (o
 		Ref:  commitRef,
 		RHSM: options.RHSM,
 	}, nil
+}
+
+// initialSetupKickstart returns the File configuration for a kickstart file
+// that's required to enable initial-setup to run on first boot.
+func initialSetupKickstart() *fsnode.File {
+	file, err := fsnode.NewFile("/root/anaconda-ks.cfg", nil, "root", "root", []byte("# Run initial-setup on first boot\n# Created by osbuild\nfirstboot --reconfig\n"))
+	if err != nil {
+		panic(err)
+	}
+	return file
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
@@ -539,6 +539,12 @@ func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
 			"@core",
+			"initial-setup",
+			"libxkbcommon",
+			"NetworkManager-wifi",
+			"brcmfmac-firmware",
+			"realtek-firmware",
+			"iwlwifi-mvm-firmware",
 		},
 	}
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/partition_tables.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/partition_tables.go
@@ -108,6 +108,101 @@ var defaultBasePartitionTables = distro.BasePartitionTableMap{
 	},
 }
 
+var minimalrawPartitionTables = distro.BasePartitionTableMap{
+	platform.ARCH_X86_64.String(): disk.PartitionTable{
+		UUID:        "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type:        "gpt",
+		StartOffset: 8 * common.MebiByte,
+		Partitions: []disk.Partition{
+			{
+				Size: 200 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * common.MebiByte,
+				Type: disk.XBootLDRPartitionGUID,
+				UUID: disk.FilesystemDataUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: disk.FilesystemDataGUID,
+				UUID: disk.RootPartitionUUID,
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+	platform.ARCH_AARCH64.String(): disk.PartitionTable{
+		UUID:        "0xc1748067",
+		Type:        "dos",
+		StartOffset: 8 * common.MebiByte,
+		Partitions: []disk.Partition{
+			{
+				Size:     200 * common.MebiByte,
+				Type:     "06",
+				Bootable: true,
+				Payload: &disk.Filesystem{
+					Type:         "vfat",
+					UUID:         disk.EFIFilesystemUUID,
+					Mountpoint:   "/boot/efi",
+					Label:        "EFI-SYSTEM",
+					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+					FSTabFreq:    0,
+					FSTabPassNo:  2,
+				},
+			},
+			{
+				Size: 500 * common.MebiByte,
+				Type: "83",
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Mountpoint:   "/boot",
+					Label:        "boot",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+			{
+				Size: 2 * common.GibiByte,
+				Type: "83",
+				Payload: &disk.Filesystem{
+					Type:         "ext4",
+					Label:        "root",
+					Mountpoint:   "/",
+					FSTabOptions: "defaults",
+					FSTabFreq:    0,
+					FSTabPassNo:  0,
+				},
+			},
+		},
+	},
+}
+
 var iotBasePartitionTables = distro.BasePartitionTableMap{
 	platform.ARCH_X86_64.String(): disk.PartitionTable{
 		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",

--- a/vendor/github.com/osbuild/images/pkg/distro/image_config.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/image_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/shell"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/subscription"
@@ -62,6 +63,9 @@ type ImageConfig struct {
 	UdevRules           *osbuild.UdevRulesStageOptions
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
 	WSLConfig           *osbuild.WSLConfStageOptions
+
+	Files       []*fsnode.File
+	Directories []*fsnode.Directory
 }
 
 // InheritFrom inherits unset values from the provided parent configuration and

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel7/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel7/images.go
@@ -213,6 +213,9 @@ func osCustomizations(
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
 
+	osc.Files = append(osc.Files, imageConfig.Files...)
+	osc.Directories = append(osc.Directories, imageConfig.Directories...)
+
 	return osc
 }
 

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel8/edge.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel8/edge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -148,8 +149,14 @@ func minimalRawImgType(rd distribution) imageType {
 		packageSets: map[string]packageSetFunc{
 			osPkgsKey: minimalrpmPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			EnabledServices: minimalrawServices(rd),
+			// NOTE: temporary workaround for a bug in initial-setup that
+			// requires a kickstart file in the root directory.
+			Files: []*fsnode.File{initialSetupKickstart()},
+		},
 		rpmOstree:           false,
-		kernelOptions:       "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0",
+		kernelOptions:       "ro",
 		bootable:            true,
 		defaultSize:         2 * common.GibiByte,
 		image:               diskImage,
@@ -400,4 +407,11 @@ func edgeServices(rd distribution) []string {
 	}
 
 	return edgeServices
+}
+
+func minimalrawServices(rd distribution) []string {
+	// Common Services
+	var minimalrawServices = []string{"NetworkManager.service", "firewalld.service", "sshd.service", "initial-setup.service"}
+
+	return minimalrawServices
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel8/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel8/images.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/images/internal/fdo"
+	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/ignition"
 	"github.com/osbuild/images/internal/oscap"
 	"github.com/osbuild/images/internal/users"
@@ -250,6 +251,9 @@ func osCustomizations(
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
 	osc.WSLConfig = imageConfig.WSLConfig
+
+	osc.Files = append(osc.Files, imageConfig.Files...)
+	osc.Directories = append(osc.Directories, imageConfig.Directories...)
 
 	return osc
 }
@@ -598,4 +602,14 @@ func makeOSTreePayloadCommit(options *ostree.ImageOptions, defaultRef string) (o
 		Ref:  commitRef,
 		RHSM: options.RHSM,
 	}, nil
+}
+
+// initialSetupKickstart returns the File configuration for a kickstart file
+// that's required to enable initial-setup to run on first boot.
+func initialSetupKickstart() *fsnode.File {
+	file, err := fsnode.NewFile("/root/anaconda-ks.cfg", nil, "root", "root", []byte("# Run initial-setup on first boot\n# Created by osbuild\nfirstboot --reconfig\nlang en_US.UTF-8\n"))
+	if err != nil {
+		panic(err)
+	}
+	return file
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel8/package_sets.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel8/package_sets.go
@@ -78,6 +78,11 @@ func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
 			"@core",
+			"initial-setup",
+			"libxkbcommon",
+			"NetworkManager-wifi",
+			"iwl7260-firmware",
+			"iwl3160-firmware",
 		},
 	}
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel9/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel9/images.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/fdo"
+	"github.com/osbuild/images/internal/fsnode"
 	"github.com/osbuild/images/internal/ignition"
 	"github.com/osbuild/images/internal/oscap"
 	"github.com/osbuild/images/internal/users"
@@ -247,6 +248,9 @@ func osCustomizations(
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
 	osc.WSLConfig = imageConfig.WSLConfig
+
+	osc.Files = append(osc.Files, imageConfig.Files...)
+	osc.Directories = append(osc.Directories, imageConfig.Directories...)
 
 	return osc
 }
@@ -646,4 +650,14 @@ func makeOSTreePayloadCommit(options *ostree.ImageOptions, defaultRef string) (o
 		Ref:  commitRef,
 		RHSM: options.RHSM,
 	}, nil
+}
+
+// initialSetupKickstart returns the File configuration for a kickstart file
+// that's required to enable initial-setup to run on first boot.
+func initialSetupKickstart() *fsnode.File {
+	file, err := fsnode.NewFile("/root/anaconda-ks.cfg", nil, "root", "root", []byte("# Run initial-setup on first boot\n# Created by osbuild\nfirstboot --reconfig\nlang en_US.UTF-8\n"))
+	if err != nil {
+		panic(err)
+	}
+	return file
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel9/package_sets.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel9/package_sets.go
@@ -250,6 +250,11 @@ func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
 	return rpmmd.PackageSet{
 		Include: []string{
 			"@core",
+			"initial-setup",
+			"libxkbcommon",
+			"NetworkManager-wifi",
+			"iwl7260-firmware",
+			"iwl3160-firmware",
 		},
 	}
 }

--- a/vendor/github.com/osbuild/images/pkg/platform/aarch64.go
+++ b/vendor/github.com/osbuild/images/pkg/platform/aarch64.go
@@ -28,21 +28,21 @@ func (p *Aarch64) GetPackages() []string {
 	return packages
 }
 
-type Aarch64_IoT struct {
+type Aarch64_Fedora struct {
 	BasePlatform
 	UEFIVendor string
 	BootFiles  [][2]string
 }
 
-func (p *Aarch64_IoT) GetArch() Arch {
+func (p *Aarch64_Fedora) GetArch() Arch {
 	return ARCH_AARCH64
 }
 
-func (p *Aarch64_IoT) GetUEFIVendor() string {
+func (p *Aarch64_Fedora) GetUEFIVendor() string {
 	return p.UEFIVendor
 }
 
-func (p *Aarch64_IoT) GetPackages() []string {
+func (p *Aarch64_Fedora) GetPackages() []string {
 	packages := p.BasePlatform.FirmwarePackages
 
 	if p.UEFIVendor != "" {
@@ -57,6 +57,6 @@ func (p *Aarch64_IoT) GetPackages() []string {
 	return packages
 }
 
-func (p *Aarch64_IoT) GetBootFiles() [][2]string {
+func (p *Aarch64_Fedora) GetBootFiles() [][2]string {
 	return p.BootFiles
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,7 +645,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.3.0
+# github.com/osbuild/images v0.3.0-r9.3.2
 ## explicit; go 1.19
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/dnfjson


### PR DESCRIPTION
Update images dependency to pull in change to minimal raw images [1] for release into RHEL 9.3.0.
Includes fix for Azure image kernel options [2].

[1] https://github.com/osbuild/images/pull/163
[2] https://github.com/osbuild/images/pull/166