### PR TITLE
test/cases/ubi-wsl: set --os-type when creating vm

### DIFF
--- a/test/cases/ubi-wsl.sh
+++ b/test/cases/ubi-wsl.sh
@@ -195,6 +195,7 @@ $AZURE_CMD vm create \
    --location "$AZURE_WSL_LOCATION" \
     --nic-delete-option delete \
     --os-disk-delete-option delete \
+    --os-type windows \
     --size "Standard_D2as_v5"
 
 $AZURE_CMD vm open-port --resource-group "$AZURE_RESOURCE_GROUP" --name "wsl-vm-$TEST_ID" --port 22


### PR DESCRIPTION
Solves `invalid usage for storage profile: attach existing managed OS disk`.
