### PR TITLE
lint: Fix implicit memory aliasing in for loops

### DIFF
--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -157,7 +157,7 @@ func main() {
 		if repo.GPGKey != "" {
 			keys = []string{repo.GPGKey}
 		}
-
+		checkGPG := repo.CheckGPG
 		repos[i] = rpmmd.RepoConfig{
 			Id:           repoId,
 			Name:         repoName,
@@ -165,7 +165,7 @@ func main() {
 			Metalink:     repo.Metalink,
 			MirrorList:   repo.MirrorList,
 			GPGKeys:      keys,
-			CheckGPG:     &repo.CheckGPG,
+			CheckGPG:     &checkGPG,
 			CheckRepoGPG: common.ToPtr(false),
 			IgnoreSSL:    common.ToPtr(false),
 			PackageSets:  repo.PackageSets,

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -211,10 +211,11 @@ func (c *Customizations) GetUsers() []UserCustomization {
 
 	// prepend sshkey for backwards compat (overridden by users)
 	if len(c.SSHKey) > 0 {
-		for _, c := range c.SSHKey {
+		for _, k := range c.SSHKey {
+			key := k.Key
 			users = append(users, UserCustomization{
-				Name: c.User,
-				Key:  &c.Key,
+				Name: k.User,
+				Key:  &key,
 			})
 		}
 	}

--- a/internal/cloudapi/v2/v2_internal_test.go
+++ b/internal/cloudapi/v2/v2_internal_test.go
@@ -186,9 +186,10 @@ func TestRepoConfigConversion(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
+		repoConfig := tc.repoConfig
 		rc, err := genRepoConfig(tc.repo)
 		assert.NoError(err)
-		assert.Equal(&tc.repoConfig, rc, "mismatch in test case %d", idx)
+		assert.Equal(&repoConfig, rc, "mismatch in test case %d", idx)
 	}
 
 	errorTestCases := []struct {


### PR DESCRIPTION
Fix all instances of gosec G601: Implicit memory aliasing in for loop.


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
