### PR TITLE
test: remove package version check

### DIFF
--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -12,10 +12,7 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
-	"os/exec"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -1107,22 +1104,6 @@ func TestBlueprintFreezeV0(t *testing.T) {
 func TestBlueprintFreezeGlobsV0(t *testing.T) {
 	// Test needs real packages, skip it for unit testing
 	if testState.unitTest {
-		t.Skip()
-	}
-
-	// works with osbuild-composer v83 and later
-	rpm_q := exec.Command("rpm", "-q", "--qf", "%{version}", "osbuild-composer")
-	out, err := rpm_q.CombinedOutput()
-	if err != nil {
-		assert.Fail(t, fmt.Sprintf("Error during rpm -q: %s", err))
-	}
-
-	rpm_version, err := strconv.Atoi(string(out))
-	if err != nil {
-		assert.Fail(t, "Error during str-int conversion", err)
-	}
-
-	if rpm_version < 83 {
 		t.Skip()
 	}
 


### PR DESCRIPTION
Package version parsing fails on minor releases (88.1).

I plan to add this as a downstream patch on top of v88.1 to get through RHEL CI.