### PR TITLE
templates/compose: add startingDeadlineSeconds to maintenance job

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -307,6 +307,8 @@ objects:
     # run maintenance job at midnight
     schedule: 0 0 * * *
     concurrencyPolicy: Forbid
+    # don't run if the job doesn't get scheduled within 30 minutes
+    startingDeadlineSeconds: 1800
     jobTemplate:
       spec:
         template:

--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -127,10 +127,10 @@ objects:
           name: fluentd-sidecar
           resources:
             requests:
-              cpu: "${CPU_REQUEST}"
+              cpu: "${FLUENTD_CPU_REQUEST}"
               memory: "${MEMORY_REQUEST}"
             limits:
-              cpu: "${CPU_REQUEST}"
+              cpu: "${FLUENTD_CPU_LIMIT}"
               memory: "${MEMORY_LIMIT}"
           env:
             - name: SPLUNK_HEC_TOKEN
@@ -166,10 +166,10 @@ objects:
           command: [ "/opt/migrate/tern", "migrate", "-m", "/opt/migrate/schemas" ]
           resources:
             requests:
-              cpu: "${FLUENTD_CPU_REQUEST}"
+              cpu: "${CPU_REQUEST}"
               memory: "${MEMORY_REQUEST}"
             limits:
-              cpu: "${FLUENTD_CPU_LIMIT}"
+              cpu: "${CPU_LIMIT}"
               memory: "${MEMORY_LIMIT}"
           env:
           - name: PGHOST
@@ -481,7 +481,7 @@ parameters:
     value: "50m"
   - name: FLUENTD_CPU_LIMIT
     description: CPU limit per container
-    value: "50m"
+    value: "100m"
   - name: MAINTENANCE_CPU_REQUEST
     description: CPU request per container
     value: "50m"


### PR DESCRIPTION
The job won't run if it doesn't get scheduled within 30 minutes. This prevents the job running multiple times in a row if it didn't get scheduled, for instance due to resource limits.

