### PR TITLE
tools/provision.sh: fix unbound variable bug if no OCI secrets are set

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -137,17 +137,18 @@ EOF
     fi
 
     # if OCI credentials are defined in the ENV, add them to the worker's configuration
+    OCI_SECRETS="${OCI_SECRETS:-}"
+    OCI_PRIVATE_KEY="${OCI_PRIVATE_KEY:-}"
+    if [[ -n "$OCI_SECRETS" && -n "$OCI_PRIVATE_KEY" ]]; then
+        OCI_USER=$(jq -r '.user' "$OCI_SECRETS")
+        OCI_TENANCY=$(jq -r '.tenancy' "$OCI_SECRETS")
+        OCI_REGION=$(jq -r '.region' "$OCI_SECRETS")
+        OCI_FINGERPRINT=$(jq -r '.fingerprint' "$OCI_SECRETS")
+        OCI_BUCKET_NAME=$(jq -r '.bucket' "$OCI_SECRETS")
+        OCI_NAMESPACE=$(jq -r '.namespace' "$OCI_SECRETS")
+        OCI_COMPARTMENT=$(jq -r '.compartment' "$OCI_SECRETS")
+        OCI_PRIV_KEY=$(cat "$OCI_PRIVATE_KEY")
 
-    OCI_USER=$(jq -r '.user' "$OCI_SECRETS")
-    OCI_TENANCY=$(jq -r '.tenancy' "$OCI_SECRETS")
-    OCI_REGION=$(jq -r '.region' "$OCI_SECRETS")
-    OCI_FINGERPRINT=$(jq -r '.fingerprint' "$OCI_SECRETS")
-    OCI_BUCKET_NAME=$(jq -r '.bucket' "$OCI_SECRETS")
-    OCI_NAMESPACE=$(jq -r '.namespace' "$OCI_SECRETS")
-    OCI_COMPARTMENT=$(jq -r '.compartment' "$OCI_SECRETS")
-    OCI_PRIV_KEY=$(cat "$OCI_PRIVATE_KEY")
-
-    if [[ -n "$OCI_TENANCY" ]]; then
         set +x
         sudo tee /etc/osbuild-worker/oci-credentials.toml > /dev/null << EOF
 user = "$OCI_USER"


### PR DESCRIPTION
This was hit in c9s CI:
https://gitlab.com/redhat/centos-stream/rpms/osbuild-composer/-/merge_requests/88 https://artifacts.dev.testing-farm.io/658332f8-8705-4727-84d3-f27b57775037/

```
/usr/libexec/osbuild-composer-test/provision.sh: line 141: OCI_SECRETS: unbound variable
```


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
