### PR TITLE
tools/appsre-ansible/rpmbuild: retry all tasks

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/subscribe.yml
+++ b/templates/packer/ansible/roles/common/tasks/subscribe.yml
@@ -7,6 +7,9 @@
   community.general.redhat_subscription:
     activationkey: "{{ RH_ACTIVATION_KEY }}"
     org_id: "{{ RH_ORG_ID }}"
+  register: result
+  retries: 5
+  until: result is success
 
 - name: Enable repo mgmt through subman
   become: yes

--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -51,26 +51,46 @@
     - /home/ec2-user/rpmbuild/RPMS
 
   - name: Download osbuild-composer archive
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     get_url:
       url: "https://github.com/osbuild/osbuild-composer/archive/{{ COMPOSER_COMMIT }}.tar.gz"
       dest: "/home/ec2-user/rpmbuild/SOURCES/osbuild-composer-{{ COMPOSER_COMMIT }}.tar.gz"
 
   - name: Download osbuild-composer spec
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     get_url:
       url: "https://raw.githubusercontent.com/osbuild/osbuild-composer/{{ COMPOSER_COMMIT }}/osbuild-composer.spec"
       dest: /home/ec2-user/osbuild-composer.spec
 
   - name: Download osbuild archive
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     get_url:
       url: "https://github.com/osbuild/osbuild/archive/{{ OSBUILD_COMMIT }}.tar.gz"
       dest: "/home/ec2-user/rpmbuild/SOURCES/osbuild-{{ OSBUILD_COMMIT }}.tar.gz"
 
   - name: Download osbuild spec
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     get_url:
       url: "https://raw.githubusercontent.com/osbuild/osbuild/{{ OSBUILD_COMMIT }}/osbuild.spec"
       dest: /home/ec2-user/osbuild.spec
 
   - name: Install build tools
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     package:
       name:
         - rpm-build
@@ -79,6 +99,10 @@
       state: present
 
   - name: Make osbuild srpm
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     command: >-
       rpmbuild -bs
       --define "commit {{ OSBUILD_COMMIT }}"
@@ -87,6 +111,10 @@
       /home/ec2-user/osbuild.spec
 
   - name: Mockbuild osbuild
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     shell: >-
         mock
         -r "rhel-9-{{ ansible_architecture }}"
@@ -97,6 +125,10 @@
         /home/ec2-user/rpmbuild/SRPMS/osbuild-*.src.rpm
 
   - name: Make osbuild-composer srpm
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     command: >-
       rpmbuild -bs
       --define "commit {{ COMPOSER_COMMIT }}"
@@ -106,6 +138,10 @@
 
 
   - name: Mockbuild osbuild-composer
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     shell: >-
         mock
         -r "rhel-9-{{ ansible_architecture }}"
@@ -116,9 +152,17 @@
         /home/ec2-user/rpmbuild/SRPMS/osbuild-composer-*.src.rpm
 
   - name: Create a repository from the artifacts
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     command: createrepo_c /home/ec2-user/rpmbuild/RPMS
 
   - name: Fetch rpms
+    retries: 5
+    delay: 20
+    register: result
+    until: result is success
     ansible.posix.synchronize:
       mode: pull
       src: /home/ec2-user/rpmbuild/RPMS


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
