### PR TITLE
Container: set the composer git revision during the build

### DIFF
--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -9,8 +9,15 @@ USER 1001
 # Otherwise, VCS stamping will fail because git >= 2.35.2 refuses to work in
 # a repository owned by a different user.
 COPY --chown=1001 . .
+ARG COMMIT
+ENV LDFLAGS="${COMMIT:+-X \'github.com/osbuild/osbuild-composer/internal/common.GitRev=${COMMIT}\'}"
+ENV LDFLAGS="${LDFLAGS:+-ldflags=\"${LDFLAGS}\"}"
 ENV GOFLAGS=-mod=vendor
-RUN go install ./cmd/osbuild-composer/
+# if run without "sh -c", podman for some reason executes the command in a way,
+# which results in the following error:
+# [1/3] STEP 12/12: RUN go install ${LDFLAGS} ./cmd/osbuild-composer/
+# invalid value "\"-X" for flag -ldflags: missing =<value> in <pattern>=<value>
+RUN /usr/bin/sh -c "go install ${LDFLAGS} ./cmd/osbuild-composer/"
 
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder2
 RUN go install github.com/jackc/tern@latest

--- a/schutzbot/containerbuild.sh
+++ b/schutzbot/containerbuild.sh
@@ -14,6 +14,7 @@ podman \
 	build \
 	--file="distribution/Dockerfile-ubi" \
 	--tag="${IMAGE_NAME}:${IMAGE_TAG}" \
+	--build-arg="COMMIT=${IMAGE_TAG}" \
 	--label="quay.expires-after=1w" \
 	.
 

--- a/tools/appsre-build-deploy.sh
+++ b/tools/appsre-build-deploy.sh
@@ -4,6 +4,7 @@ set -exv
 
 IMAGE_NAME="quay.io/app-sre/composer"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+COMMIT=$(git rev-parse HEAD)
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -13,7 +14,7 @@ fi
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" build -f distribution/Dockerfile-ubi -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" build -f distribution/Dockerfile-ubi --build-arg="COMMIT=${COMMIT}" -t "${IMAGE_NAME}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE_NAME}:${IMAGE_TAG}"
 
 # Maintenance image


### PR DESCRIPTION
When the container with osbuild-composer gets built in our CI or by AppSRE, we do not set the composer version to any value (as we do when we built RPMs). As a result, the version reported by composer is always "devel". This is not useful for debugging and determining the used version of composer. In addition, this information now gets exposed in Koji builds, therefore it makes sense to make it useful.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
