### PR TITLE
Small fixes for Koji data consolidation PR#3599

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -883,10 +884,16 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			}
 			logWithId.Info("[Koji] 🎉 Image successfully uploaded")
 
-			manifest := bytes.NewReader(jobArgs.Manifest)
+			var manifest bytes.Buffer
+			err = json.Indent(&manifest, jobArgs.Manifest, "", "  ")
+			if err != nil {
+				logWithId.Warnf("[Koji] Indenting osbuild manifest failed: %v", err)
+				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorKojiBuild, err.Error(), nil)
+				break
+			}
 			logWithId.Info("[Koji] ⬆ Uploading the osbuild manifest")
 			manifestFilename := jobTarget.ImageName + ".manifest.json"
-			manifestHash, manifestSize, err := kojiAPI.Upload(manifest, targetOptions.UploadDirectory, manifestFilename)
+			manifestHash, manifestSize, err := kojiAPI.Upload(&manifest, targetOptions.UploadDirectory, manifestFilename)
 			if err != nil {
 				logWithId.Warnf("[Koji] ⬆ upload failed: %v", err)
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, err.Error(), nil)

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -904,7 +904,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			var osbuildLog bytes.Buffer
 			err = osbuildJobResult.OSBuildOutput.Write(&osbuildLog)
 			if err != nil {
-				logWithId.Warnf("[Koji] Converting osbuild log to texrt failed: %v", err)
+				logWithId.Warnf("[Koji] Converting osbuild log to text failed: %v", err)
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorKojiBuild, err.Error(), nil)
 				break
 			}


### PR DESCRIPTION
Two small fixes as a follow-up for PR #3599:

- indent the uploaded manifest to make it nicer to read
- fix typo in error message

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
