### PR TITLE
Internal: delete unused `common.VersionLessThan()`

### DIFF
--- a/internal/common/distro.go
+++ b/internal/common/distro.go
@@ -51,33 +51,3 @@ func readOSRelease(r io.Reader) (map[string]string, error) {
 
 	return osrelease, nil
 }
-
-// Returns true if the version represented by the first argument is
-// semantically older than the second.
-// Meant to be used for comparing distro versions for differences between minor
-// releases.
-// Evaluates to false if a and b are equal.
-// Assumes any missing components are 0, so 8 < 8.1.
-func VersionLessThan(a, b string) bool {
-	aParts := strings.Split(a, ".")
-	bParts := strings.Split(b, ".")
-
-	// pad shortest argument with zeroes
-	for len(aParts) < len(bParts) {
-		aParts = append(aParts, "0")
-	}
-	for len(bParts) < len(aParts) {
-		bParts = append(bParts, "0")
-	}
-
-	for idx := 0; idx < len(aParts); idx++ {
-		if aParts[idx] < bParts[idx] {
-			return true
-		} else if aParts[idx] > bParts[idx] {
-			return false
-		}
-	}
-
-	// equal
-	return false
-}


### PR DESCRIPTION
The function is a leftover from the image definitions split and it is not used. Moreover, the `images` copy of it is being reimplemented by [1]. It is better to remove this copy to prevent any unintended use of it or confusion.

[1] https://github.com/osbuild/images/pull/195


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
