### PR TITLE
internal/weldr: specify architecture of compose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/aws/aws-sdk-go v1.48.13
 	github.com/coreos/go-semver v0.3.1
-	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/deepmap/oapi-codegen v1.8.2
 	github.com/getkin/kin-openapi v0.93.0
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,9 @@ github.com/containers/storage v1.51.0/go.mod h1:ybl8a3j1PPtpyaEi/5A6TOFs+5TrEyOb
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -22,6 +22,7 @@ type Blueprint struct {
 	Containers     []Container     `json:"containers,omitempty" toml:"containers,omitempty"`
 	Customizations *Customizations `json:"customizations,omitempty" toml:"customizations"`
 	Distro         string          `json:"distro" toml:"distro"`
+	Arch           string          `json:"architecture,omitempty" toml:"architecture,omitempty"`
 }
 
 type Change struct {

--- a/internal/client/unit_test.go
+++ b/internal/client/unit_test.go
@@ -71,6 +71,10 @@ func executeTests(m *testing.M) int {
 		panic(err)
 	}
 	distro2 := test_distro.NewTestDistro("test-distro-2", "platform:test-2", "2")
+	_, err = fixture.Workers.RegisterWorker(arch.Name())
+	if err != nil {
+		panic(err)
+	}
 
 	rr := reporegistry.NewFromDistrosRepoConfigs(rpmmd.DistrosRepoConfigs{
 		test_distro.TestDistroName: {

--- a/internal/jobqueue/fsjobqueue/fsjobqueue.go
+++ b/internal/jobqueue/fsjobqueue/fsjobqueue.go
@@ -493,18 +493,21 @@ func (q *fsJobQueue) UpdateWorkerStatus(wID uuid.UUID) error {
 	return nil
 }
 
-func (q *fsJobQueue) Workers(olderThan time.Duration) ([]uuid.UUID, error) {
+func (q *fsJobQueue) Workers(olderThan time.Duration) ([]jobqueue.Worker, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	now := time.Now()
-	wIDs := []uuid.UUID{}
-	for wID, worker := range q.workers {
-		if now.Sub(worker.Heartbeat) > olderThan {
-			wIDs = append(wIDs, wID)
+	workers := []jobqueue.Worker{}
+	for wID, w := range q.workers {
+		if now.Sub(w.Heartbeat) > olderThan {
+			workers = append(workers, jobqueue.Worker{
+				ID:   wID,
+				Arch: w.Arch,
+			})
 		}
 	}
-	return wIDs, nil
+	return workers, nil
 }
 
 func (q *fsJobQueue) DeleteWorker(wID uuid.UUID) error {

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -79,6 +79,7 @@ func FixtureBase() *Store {
 		}}
 
 	s.blueprints[bName] = b
+
 	s.composes = map[uuid.UUID]Compose{
 		uuid.MustParse("30000000-0000-0000-0000-000000000000"): {
 			Blueprint: &b,
@@ -308,6 +309,18 @@ func FixtureEmpty() *Store {
 	b3.Name = "test-fedora-1"
 	b3.Distro = "fedora-1"
 	s.blueprints[b3.Name] = b3
+
+	// Bad arch blueprint
+	b4 := b
+	b4.Name = "test-badarch"
+	b4.Arch = "badarch"
+	s.blueprints[b4.Name] = b4
+
+	// Cross arch blueprint
+	b5 := b
+	b5.Name = "test-crossarch"
+	b5.Arch = test_distro.TestArch2Name
+	s.blueprints[b5.Name] = b5
 
 	return s
 }

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -42,6 +42,8 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 		t.Fatalf("error serializing osbuild manifest: %v", err)
 	}
 
+	_, err = api.workers.RegisterWorker(arch.Name())
+	require.NoError(t, err)
 	jobId, err := api.workers.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: mf}, "")
 	require.NoError(t, err)
 
@@ -95,6 +97,8 @@ func TestComposeStatusFromJobError(t *testing.T) {
 		t.Fatalf("error serializing osbuild manifest: %v", err)
 	}
 
+	_, err = api.workers.RegisterWorker(arch.Name())
+	require.NoError(t, err)
 	jobId, err := api.workers.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: mf}, "")
 	require.NoError(t, err)
 

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -823,6 +823,15 @@ func (s *Server) RequeueOrFinishJob(token uuid.UUID, maxRetries uint64, result j
 	return nil
 }
 
+func (s *Server) RegisterWorker(a string) (uuid.UUID, error) {
+	workerID, err := s.jobs.InsertWorker(a)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	logrus.Infof("Worker (%v) registered", a)
+	return workerID, nil
+}
+
 // apiHandlers implements api.ServerInterface - the http api route handlers
 // generated from api/openapi.yml. This is a separate object, because these
 // handlers should not be exposed on the `Server` object.
@@ -1037,11 +1046,10 @@ func (h *apiHandlers) PostWorkers(ctx echo.Context) error {
 		return err
 	}
 
-	workerID, err := h.server.jobs.InsertWorker(body.Arch)
+	workerID, err := h.server.RegisterWorker(body.Arch)
 	if err != nil {
 		return api.HTTPErrorWithInternal(api.ErrorInsertingWorker, err)
 	}
-	logrus.Infof("Worker (%v) registered", body.Arch)
 
 	return ctx.JSON(http.StatusCreated, api.PostWorkersResponse{
 		ObjectReference: api.ObjectReference{

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -832,6 +832,19 @@ func (s *Server) RegisterWorker(a string) (uuid.UUID, error) {
 	return workerID, nil
 }
 
+func (s *Server) WorkerAvailableForArch(a string) (bool, error) {
+	workers, err := s.jobs.Workers(0)
+	if err != nil {
+		return false, err
+	}
+	for _, w := range workers {
+		if a == w.Arch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // apiHandlers implements api.ServerInterface - the http api route handlers
 // generated from api/openapi.yml. This is a separate object, because these
 // handlers should not be exposed on the `Server` object.

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -163,9 +163,9 @@ func (s *Server) WatchWorkers() {
 			logrus.Warningf("Unable to query workers: %v", err)
 			continue
 		}
-		for _, wID := range workers {
-			logrus.Infof("Removing inactive worker: %s", wID)
-			err = s.jobs.DeleteWorker(wID)
+		for _, w := range workers {
+			logrus.Infof("Removing inactive worker: %s", w.ID)
+			err = s.jobs.DeleteWorker(w.ID)
 			if err != nil {
 				logrus.Warningf("Unable to remove worker: %v", err)
 			}

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -88,7 +88,7 @@ type JobQueue interface {
 	UpdateWorkerStatus(workerID uuid.UUID) error
 
 	// Get a list of workers which haven't been updated in the specified time frame
-	Workers(olderThan time.Duration) ([]uuid.UUID, error)
+	Workers(olderThan time.Duration) ([]Worker, error)
 
 	// Deletes the worker
 	DeleteWorker(workerID uuid.UUID) error
@@ -115,3 +115,8 @@ var (
 	ErrActiveJobs     = errors.New("worker has active jobs associated with it")
 	ErrWorkerNotExist = errors.New("worker does not exist")
 )
+
+type Worker struct {
+	ID   uuid.UUID
+	Arch string
+}

--- a/test/cases/cross-distro.sh
+++ b/test/cases/cross-distro.sh
@@ -146,7 +146,7 @@ EOF
 
     # there is a different reponse if legacy composer-cli is used
     if rpm -q --quiet weldr-client; then
-        EXPECTED_RESPONSE="ERROR: BlueprintsError: '$REMAINING_DISTRO' is not a valid distribution"
+        EXPECTED_RESPONSE="ERROR: BlueprintsError: '$REMAINING_DISTRO' is not a valid distribution (architecture '$(uname -m)')"
     else
         EXPECTED_RESPONSE="'$REMAINING_DISTRO' is not a valid distribution"
         RESPONSE=${RESPONSE#*: }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -289,7 +289,7 @@ github.com/containers/storage/pkg/unshare
 # github.com/coreos/go-semver v0.3.1
 ## explicit; go 1.8
 github.com/coreos/go-semver/semver
-# github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+# github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 ## explicit
 github.com/coreos/go-systemd/activation
 # github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46


### PR DESCRIPTION
This is useful in environments with multi-arch remote workers. Defaults to the host architecture.

---

Wondering if we should test the cross arch in weldr api, since it queries the state of the remote worker socket now :/ 

---

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
