### PR TITLE
deps: update osbuild/images to v0.3.0-r9.3.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/labstack/gommon v0.4.0
 	github.com/openshift-online/ocm-sdk-go v0.1.362
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.3.0-r9.3.2
+	github.com/osbuild/images v0.3.0-r9.3.3
 	github.com/prometheus/client_golang v1.16.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.362 h1:MoaSMCSzcr8nSK9DBqKmZ9c5e4Cp8
 github.com/openshift-online/ocm-sdk-go v0.1.362/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.3.0-r9.3.2 h1:jSt69Ac/6vh+7hLx1M6c5ER0+aARLxB3+I/W6bTcBCE=
-github.com/osbuild/images v0.3.0-r9.3.2/go.mod h1:lZsi8oJNfk57VRv5zhdrSLmn0z8YPcQzZBxzdHNfZls=
+github.com/osbuild/images v0.3.0-r9.3.3 h1:SODY0LH3cnPAulOV4GwKB6/rhV5mTtm7XT3nS6ZQPmw=
+github.com/osbuild/images v0.3.0-r9.3.3/go.mod h1:lZsi8oJNfk57VRv5zhdrSLmn0z8YPcQzZBxzdHNfZls=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel9/partition_tables.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel9/partition_tables.go
@@ -3,167 +3,182 @@ package rhel9
 import (
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/disk"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/platform"
 )
 
-var defaultBasePartitionTables = distro.BasePartitionTableMap{
-	platform.ARCH_X86_64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
-		Partitions: []disk.Partition{
-			{
-				Size:     1 * common.MebiByte,
-				Bootable: true,
-				Type:     disk.BIOSBootPartitionGUID,
-				UUID:     disk.BIOSBootPartitionUUID,
-			},
-			{
-				Size: 200 * common.MebiByte,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+func defaultBasePartitionTables(t *imageType) (disk.PartitionTable, bool) {
+	// RHEL >= 9.3 needs to have a bigger /boot, see RHEL-7999
+	bootSize := uint64(600) * common.MebiByte
+	if common.VersionLessThan(t.arch.distro.osVersion, "9.3") && t.arch.distro.isRHEL() {
+		bootSize = 500 * common.MebiByte
+	}
+
+	switch t.platform.GetArch() {
+	case platform.ARCH_X86_64:
+		return disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: "gpt",
+			Partitions: []disk.Partition{
+				{
+					Size:     1 * common.MebiByte,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Size: 200 * common.MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: bootSize,
+					Type: disk.XBootLDRPartitionGUID,
+					UUID: disk.FilesystemDataUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size: 2 * common.GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-			{
-				Size: 500 * common.MebiByte,
-				Type: disk.XBootLDRPartitionGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+		}, true
+	case platform.ARCH_AARCH64:
+		return disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: "gpt",
+			Partitions: []disk.Partition{
+				{
+					Size: 200 * common.MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						Label:        "EFI-SYSTEM",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				{
+					Size: bootSize,
+					Type: disk.XBootLDRPartitionGUID,
+					UUID: disk.FilesystemDataUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size: 2 * common.GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Label:        "root",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-			{
-				Size: 2 * common.GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
+		}, true
+	case platform.ARCH_PPC64LE:
+		return disk.PartitionTable{
+			UUID: "0x14fc63d2",
+			Type: "dos",
+			Partitions: []disk.Partition{
+				{
+					Size:     4 * common.MebiByte,
+					Type:     "41",
+					Bootable: true,
+				},
+				{
+					Size: bootSize,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size: 2 * common.GibiByte,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-		},
-	},
-	platform.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
-		Type: "gpt",
-		Partitions: []disk.Partition{
-			{
-				Size: 200 * common.MebiByte,
-				Type: disk.EFISystemPartitionGUID,
-				UUID: disk.EFISystemPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "vfat",
-					UUID:         disk.EFIFilesystemUUID,
-					Mountpoint:   "/boot/efi",
-					Label:        "EFI-SYSTEM",
-					FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-					FSTabFreq:    0,
-					FSTabPassNo:  2,
+		}, true
+
+	case platform.ARCH_S390X:
+		return disk.PartitionTable{
+			UUID: "0x14fc63d2",
+			Type: "dos",
+			Partitions: []disk.Partition{
+				{
+					Size: bootSize,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						Label:        "boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size:     2 * common.GibiByte,
+					Bootable: true,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
 				},
 			},
-			{
-				Size: 500 * common.MebiByte,
-				Type: disk.XBootLDRPartitionGUID,
-				UUID: disk.FilesystemDataUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-			{
-				Size: 2 * common.GibiByte,
-				Type: disk.FilesystemDataGUID,
-				UUID: disk.RootPartitionUUID,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Label:        "root",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-		},
-	},
-	platform.ARCH_PPC64LE.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
-		Type: "dos",
-		Partitions: []disk.Partition{
-			{
-				Size:     4 * common.MebiByte,
-				Type:     "41",
-				Bootable: true,
-			},
-			{
-				Size: 500 * common.MebiByte,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-			{
-				Size: 2 * common.GibiByte,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-		},
-	},
-	platform.ARCH_S390X.String(): disk.PartitionTable{
-		UUID: "0x14fc63d2",
-		Type: "dos",
-		Partitions: []disk.Partition{
-			{
-				Size: 500 * common.MebiByte,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/boot",
-					Label:        "boot",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-			{
-				Size:     2 * common.GibiByte,
-				Bootable: true,
-				Payload: &disk.Filesystem{
-					Type:         "xfs",
-					Mountpoint:   "/",
-					FSTabOptions: "defaults",
-					FSTabFreq:    0,
-					FSTabPassNo:  0,
-				},
-			},
-		},
-	},
+		}, true
+
+	default:
+		return disk.PartitionTable{}, false
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,7 +645,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.3.0-r9.3.2
+# github.com/osbuild/images v0.3.0-r9.3.3
 ## explicit; go 1.19
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/dnfjson


### PR DESCRIPTION
Update images dependency to pull in change to partition tables for RHEL 9.3 images.

https://github.com/osbuild/images/pull/221


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
