### PR TITLE
test/README: run go tests when updating images

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -75,8 +75,20 @@ go mod edit -replace github.com/osbuild/images=github.com/<username>/images@<com
 ./tools/prepare-source.sh
 ```
 
-This will allow you to open a test PR and run the osbuild-composer integration
-tests against your updated code.
+Using the URL of the remote fork and branch will allow you to open a test PR
+and run the osbuild-composer integration tests against your updated code.
+
+Make sure you modify any code in osbuild-composer to adapt to the changes in
+the images repository. The images API is not considered stable and changes can
+occur frequently. A good quick check that everything compiles and _mostly_ runs
+correctly is by running the unit tests:
+```
+go test ./...
+```
+and some static checks:
+```
+go vet ./...
+```
 
 The changes to the `go.mod`, `go.sum`, and `vendor/` directory should be added
 in a separate commit from any other changes. The PR should not be merged with


### PR DESCRIPTION
Add a small paragraph with the instruction to run the go tests when pulling in a new version of images as a guide for making sure that osbuild-composer builds and runs successfully, before moving on to integration tests.

As a side note: This part of the document might be more appropriate in the HACKING document than the testing README but I'm not sure.  Or maybe somewhere else?  I'm not sure.

----

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
