### PR TITLE
store: Fix RepoConfig

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -624,9 +624,9 @@ func (s *SourceConfig) RepoConfig(name string) rpmmd.RepoConfig {
 
 	repo.Name = name
 	repo.IgnoreSSL = common.ToPtr(!s.CheckSSL)
-	repo.CheckGPG = &s.CheckGPG
+	repo.CheckGPG = common.ToPtr(s.CheckGPG)
 	repo.RHSM = s.RHSM
-	repo.CheckRepoGPG = &s.CheckRepoGPG
+	repo.CheckRepoGPG = common.ToPtr(s.CheckRepoGPG)
 	repo.GPGKeys = s.GPGKeys
 
 	var urls []string


### PR DESCRIPTION
The SourceConfig pointer may be a loop variable that gets reused. This results in unexpected behavior when the value pointed to is overwritten by the loop calling this function.

So, DO NOT point to unsafe variables. Make a new pointer using common.ToPtr where it is passed by value and returns a pointer to that new value.

NOTE: This is NOT caught by golangci-lint, there are likely other places this is happening.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
