### PR TITLE
Worker status heartbeat

### DIFF
--- a/cmd/osbuild-service-maintenance/db_test.go
+++ b/cmd/osbuild-service-maintenance/db_test.go
@@ -44,7 +44,7 @@ func testDeleteJob(t *testing.T, d db, q *dbjobqueue.DBJobQueue) {
 	id, err := q.Enqueue("octopus", nil, nil, "")
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, id)
-	_, _, _, _, _, err = q.Dequeue(context.Background(), []string{"octopus"}, []string{""})
+	_, _, _, _, _, err = q.Dequeue(context.Background(), uuid.Nil, []string{"octopus"}, []string{""})
 	require.NoError(t, err)
 
 	type Result struct {

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -418,7 +418,7 @@ func TestKojiCompose(t *testing.T) {
 			require.NoError(t, err)
 
 			// handle koji-init
-			_, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeKojiInit}, []string{""})
+			_, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeKojiInit}, []string{""}, uuid.Nil)
 			require.NoError(t, err)
 			require.Equal(t, worker.JobTypeKojiInit, jobType)
 
@@ -445,7 +445,7 @@ func TestKojiCompose(t *testing.T) {
 
 			// handle build jobs
 			for i := 0; i < len(buildJobIDs); i++ {
-				jobID, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+				jobID, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 				require.NoError(t, err)
 				require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -485,7 +485,7 @@ func TestKojiCompose(t *testing.T) {
 			}
 
 			// handle koji-finalize
-			finalizeID, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeKojiFinalize}, []string{""})
+			finalizeID, token, jobType, rawJob, _, err := workerServer.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeKojiFinalize}, []string{""}, uuid.Nil)
 			require.NoError(t, err)
 			require.Equal(t, worker.JobTypeKojiFinalize, jobType)
 

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
@@ -49,7 +50,7 @@ func newV2Server(t *testing.T, dir string, depsolveChannels []string, enableJWT 
 	go func() {
 		defer wg.Done()
 		for {
-			_, token, _, _, _, err := workerServer.RequestJob(depsolveContext, test_distro.TestDistroName, []string{worker.JobTypeDepsolve}, depsolveChannels)
+			_, token, _, _, _, err := workerServer.RequestJob(depsolveContext, test_distro.TestDistroName, []string{worker.JobTypeDepsolve}, depsolveChannels, uuid.Nil)
 			select {
 			case <-depsolveContext.Done():
 				return
@@ -86,7 +87,7 @@ func newV2Server(t *testing.T, dir string, depsolveChannels []string, enableJWT 
 	go func() {
 		defer wg.Done()
 		for {
-			_, token, _, _, _, err := workerServer.RequestJob(ostreeResolveContext, test_distro.TestDistroName, []string{worker.JobTypeOSTreeResolve}, depsolveChannels)
+			_, token, _, _, _, err := workerServer.RequestJob(ostreeResolveContext, test_distro.TestDistroName, []string{worker.JobTypeOSTreeResolve}, depsolveChannels, uuid.Nil)
 			select {
 			case <-ostreeResolveContext.Done():
 				return
@@ -597,7 +598,7 @@ func TestComposeStatusSuccess(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, args, dynArgs, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, args, dynArgs, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -708,7 +709,7 @@ func TestComposeStatusFailure(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -779,7 +780,7 @@ func TestComposeJobError(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -844,7 +845,7 @@ func TestComposeDependencyError(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -917,7 +918,7 @@ func TestComposeTargetErrors(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -1337,7 +1338,7 @@ func TestImageFromCompose(t *testing.T) {
 		"kind": "ComposeId"
 	}`, "id")
 
-	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""})
+	jobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeOSBuild, jobType)
 
@@ -1406,7 +1407,7 @@ func TestImageFromCompose(t *testing.T) {
 		"kind": "CloneComposeId"
 	}`, jobId), "id")
 
-	_, token, jobType, _, _, err = wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeAWSEC2Copy}, []string{""})
+	_, token, jobType, _, _, err = wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeAWSEC2Copy}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeAWSEC2Copy, jobType)
 
@@ -1418,7 +1419,7 @@ func TestImageFromCompose(t *testing.T) {
 	err = wrksrv.FinishJob(token, res)
 	require.NoError(t, err)
 
-	imgJobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeAWSEC2Share}, []string{""})
+	imgJobId, token, jobType, _, _, err := wrksrv.RequestJob(context.Background(), test_distro.TestArch3Name, []string{worker.JobTypeAWSEC2Share}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, worker.JobTypeAWSEC2Share, jobType)
 

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -114,6 +114,7 @@ func TestRouteWithReply(t *testing.T, api http.Handler, external bool, method, p
 
 	if expectedJSON == "" {
 		require.Lenf(t, replyJSON, 0, "%s: expected no response body, but got:\n%s", path, replyJSON)
+		return
 	}
 
 	if expectedJSON == "?" {

--- a/internal/weldr/compose_test.go
+++ b/internal/weldr/compose_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/images/pkg/distro"
@@ -44,7 +45,7 @@ func TestComposeStatusFromLegacyError(t *testing.T) {
 	jobId, err := api.workers.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: mf}, "")
 	require.NoError(t, err)
 
-	j, token, _, _, _, err := api.workers.RequestJob(context.Background(), arch.Name(), []string{worker.JobTypeOSBuild}, []string{""})
+	j, token, _, _, _, err := api.workers.RequestJob(context.Background(), arch.Name(), []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 
@@ -97,7 +98,7 @@ func TestComposeStatusFromJobError(t *testing.T) {
 	jobId, err := api.workers.EnqueueOSBuild(arch.Name(), &worker.OSBuildJob{Manifest: mf}, "")
 	require.NoError(t, err)
 
-	j, token, _, _, _, err := api.workers.RequestJob(context.Background(), arch.Name(), []string{worker.JobTypeOSBuild}, []string{""})
+	j, token, _, _, _, err := api.workers.RequestJob(context.Background(), arch.Name(), []string{worker.JobTypeOSBuild}, []string{""}, uuid.Nil)
 	require.NoError(t, err)
 	require.Equal(t, jobId, j)
 

--- a/internal/worker/api/errors.go
+++ b/internal/worker/api/errors.go
@@ -23,7 +23,8 @@ const (
 	ErrorErrorNotFound        ServiceErrorCode = 14
 	ErrorInvalidJobType       ServiceErrorCode = 15
 	ErrorTenantNotFound       ServiceErrorCode = 16
-	// ErrorTokenNotFound ServiceErrorCode = 6
+	ErrorMalformedWorkerId    ServiceErrorCode = 17
+	ErrorWorkerIdNotFound     ServiceErrorCode = 18
 
 	// internal errors
 	ErrorDiscardingArtifact       ServiceErrorCode = 1000
@@ -34,6 +35,8 @@ const (
 	ErrorRetrievingJobStatus      ServiceErrorCode = 1005
 	ErrorRequestingJob            ServiceErrorCode = 1006
 	ErrorFailedLoadingOpenAPISpec ServiceErrorCode = 1007
+	ErrorInsertingWorker          ServiceErrorCode = 1008
+	ErrorUpdatingWorkerStatus     ServiceErrorCode = 1009
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -56,11 +59,20 @@ func getServiceErrors() serviceErrors {
 	return serviceErrors{
 		serviceError{ErrorUnsupportedMediaType, http.StatusUnsupportedMediaType, "Only 'application/json' content is supported"},
 		serviceError{ErrorBodyDecodingError, http.StatusBadRequest, "Malformed json, unable to decode body"},
-
 		serviceError{ErrorJobNotFound, http.StatusNotFound, "Token not found"},
 		serviceError{ErrorJobNotRunning, http.StatusBadRequest, "Job is not running"},
 		serviceError{ErrorMalformedJobId, http.StatusBadRequest, "Given job id is not a uuidv4"},
 		serviceError{ErrorMalformedJobToken, http.StatusBadRequest, "Given job id is not a uuidv4"},
+		serviceError{ErrorInvalidErrorId, http.StatusBadRequest, "Invalid format for error id, it should be an integer as a string"},
+		serviceError{ErrorResourceNotFound, http.StatusNotFound, "Requested resource doesn't exist"},
+		serviceError{ErrorMethodNotAllowed, http.StatusMethodNotAllowed, "Requested method isn't supported for resource"},
+		serviceError{ErrorNotAcceptable, http.StatusNotAcceptable, "Only 'application/json' content is supported"},
+		serviceError{ErrorErrorNotFound, http.StatusNotFound, "Error with given id not found"},
+		serviceError{ErrorInvalidJobType, http.StatusBadRequest, "Requested job type cannot be dequeued"},
+		serviceError{ErrorTenantNotFound, http.StatusBadRequest, "Tenant not found in JWT claims"},
+		serviceError{ErrorMalformedWorkerId, http.StatusBadRequest, "Given worker id is not a uuidv4"},
+		serviceError{ErrorWorkerIdNotFound, http.StatusBadRequest, "Given worker id doesn't exist"},
+
 		serviceError{ErrorDiscardingArtifact, http.StatusInternalServerError, "Error discarding artifact"},
 		serviceError{ErrorCreatingArtifact, http.StatusInternalServerError, "Error creating artifact"},
 		serviceError{ErrorWritingArtifact, http.StatusInternalServerError, "Error writing artifact"},
@@ -68,14 +80,9 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorFinishingJob, http.StatusInternalServerError, "Error finishing job"},
 		serviceError{ErrorRetrievingJobStatus, http.StatusInternalServerError, "Error requesting job"},
 		serviceError{ErrorRequestingJob, http.StatusInternalServerError, "Error requesting job"},
-		serviceError{ErrorInvalidErrorId, http.StatusBadRequest, "Invalid format for error id, it should be an integer as a string"},
 		serviceError{ErrorFailedLoadingOpenAPISpec, http.StatusInternalServerError, "Unable to load openapi spec"},
-		serviceError{ErrorResourceNotFound, http.StatusNotFound, "Requested resource doesn't exist"},
-		serviceError{ErrorMethodNotAllowed, http.StatusMethodNotAllowed, "Requested method isn't supported for resource"},
-		serviceError{ErrorNotAcceptable, http.StatusNotAcceptable, "Only 'application/json' content is supported"},
-		serviceError{ErrorErrorNotFound, http.StatusNotFound, "Error with given id not found"},
-		serviceError{ErrorInvalidJobType, http.StatusBadRequest, "Requested job type cannot be dequeued"},
-		serviceError{ErrorTenantNotFound, http.StatusBadRequest, "Tenant not found in JWT claims"},
+		serviceError{ErrorInsertingWorker, http.StatusInternalServerError, "Unable to register the worker"},
+		serviceError{ErrorUpdatingWorkerStatus, http.StatusInternalServerError, "Unable update worker status"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -1,3 +1,4 @@
+
 openapi: 3.0.0
 info:
   title: OSBuild Composer - Worker
@@ -203,6 +204,43 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /workers:
+    post:
+      operationId: postWorkers
+      summary: Create a new worker
+      description: |
+        Creates a new worker and returns a uuid which should be used in all subsequent calls.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostWorkersRequest'
+      responses:
+        '201':
+          description: Created a new worker
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostWorkersResponse'
+  /workers/{worker_id}/status:
+    parameters:
+      - schema:
+          type: string
+          format: uuid
+        name: worker_id
+        in: path
+        required: true
+    post:
+      operationId: postWorkerStatus
+      summary: Refresh worker status
+      description: |
+        Refreshes the heartbeat of the worker, and posts stats that can be used to determine overall
+        worker health. Workers that do not respond will not be kept track of after a timeout. If
+        dropped workers were running a job, this job will be restarted.
+      responses:
+        '200':
+          description: succesfully updated worker's status
+
 components:
   schemas:
     ObjectReference:
@@ -261,6 +299,8 @@ components:
             type: string
         arch:
           type: string
+        worker_id:
+          type: string
     RequestJobResponse:
       allOf:
       - $ref: '#/components/schemas/ObjectReference'
@@ -301,3 +341,21 @@ components:
           x-go-type: json.RawMessage
     UpdateJobResponse:
       $ref: '#/components/schemas/ObjectReference'
+
+    PostWorkersRequest:
+      type: object
+      required:
+        - arch
+      properties:
+        arch:
+          type: string
+    PostWorkersResponse:
+      allOf:
+      - $ref: '#/components/schemas/ObjectReference'
+      - type: object
+        required:
+          - worker_id
+        properties:
+          worker_id:
+            type: string
+            format: uuid

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -128,11 +128,12 @@ func TestProxy(t *testing.T) {
 	require.False(t, c)
 	require.NoError(t, err)
 
-	// we expect 5 calls to go through the proxy:
+	// we expect 6 calls to go through the proxy:
+	// - register worker
 	// - request job (fails, no oauth token)
 	// - oauth call
 	// - request job (succeeds)
 	// - upload artifact
 	// - cancel
-	require.Equal(t, 5, proxy.calls)
+	require.Equal(t, 6, proxy.calls)
 }

--- a/pkg/jobqueue/dbjobqueue/schemas/007_create_table_workers.sql
+++ b/pkg/jobqueue/dbjobqueue/schemas/007_create_table_workers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE workers(
+       worker_id uuid PRIMARY KEY,
+       arch varchar NOT NULL,
+       heartbeat timestamp NOT NULL
+);
+
+ALTER TABLE heartbeats
+ADD COLUMN worker_id uuid REFERENCES workers(worker_id) ON DELETE CASCADE;


### PR DESCRIPTION
    Unresponsive workers (>=1 hour of no status update) are cleaned up.
    
    Several things are enabled by keeping track of workers, in future the
    worker server could:
    - keep track of how many workers are active
    - see if a worker for a specific architecture is available

