### PR TITLE
:package: Packit configuration enhancements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,24 @@ jobs:
           version: v1.54.2
           args: --verbose --timeout 5m0s
 
+  packit-config-lint:
+    name: "📦 Packit config lint"
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    steps:
+      - name: Install Packit
+        run: dnf -y install packit
+
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate Packit config
+        run: |
+          packit validate-config .packit.yaml
+
   prepare:
     name: "🔍 Check source preparation"
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,8 +102,8 @@ jobs:
         run: |
           python3 -m pylint dnf-json tools/koji-compose.py
 
-  lint:
-    name: "⌨ Lint"
+  golang-lint:
+    name: "⌨ Golang Lint"
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.19

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,6 +15,9 @@ actions:
   get-current-version: bash -c "git describe --tags --abbrev=0 | sed 's|v||'"
   post-upstream-clone: "./tools/rpm_spec_add_provides_bundle.sh"
 
+# Handle only releases without a "dot" (e.g. v88.2), since "dot" releases should never be released to Fedora
+upstream_tag_include: 'v\d+'
+
 jobs:
 - job: bodhi_update
   trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,7 +2,7 @@
 
 specfile_path: osbuild-composer.spec
 
-synced_files:
+files_to_sync:
     - osbuild-composer.spec
     - .packit.yaml
 


### PR DESCRIPTION
- Configure Packit to handle only release tags without a "dot".
- Fix deprecated option in the Packit config.
- Validate Packit config as part of CI.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
