### PR TITLE
Added hyper_v_generation metadata to the instance used by CIV.

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -219,7 +219,8 @@ tee "${TEMPDIR}/resource-file.json" <<EOF
     {
       "vhd_uri": "${BLOB_URL}",
       "location": "${AZURE_LOCATION}",
-      "name": "${IMAGE_KEY}"
+      "name": "${IMAGE_KEY}",
+      "hyper_v_generation": "${HYPER_V_GEN}"
     }
   ]
 }


### PR DESCRIPTION
This will allow us to define which HyperV generation to use when creating the image on the fly.

Related PRs:
* https://github.com/osbuild/cloud-image-val/pull/282
* https://github.com/osbuild/osbuild-composer/pull/3679

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
