### PR TITLE
templates/packer: configure pulp creds on startup

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_pulp_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_pulp_creds.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eo pipefail
+source /tmp/cloud_init_vars
+
+echo "Deploy Pulp credentials."
+
+if [[ -z "$PULP_PASSWORD_ARN" ]]; then
+  echo "PULP_PASSWORD_ARN not defined, skipping."
+  exit 0
+fi
+
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${PULP_PASSWORD_ARN}" | jq -r ".SecretString" > /tmp/pulp_credentials.json
+
+PULP_PASSWORD=$(jq -r ".password" /tmp/pulp_credentials.json)
+rm /tmp/pulp_credentials.json
+
+PULP_USERNAME=${PULP_USERNAME:-admin}
+PULP_SERVER=${PULP_SERVER:-}
+
+sudo tee /etc/osbuild-worker/pulp_credentials.json > /dev/null << EOF
+{
+  "username": "$PULP_USERNAME",
+  "password": "$PULP_PASSWORD"
+}
+EOF
+
+sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
+[pulp]
+server_address = "$PULP_SERVER"
+credentials = "/etc/osbuild-worker/pulp_credentials.json"
+EOF

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -17,6 +17,7 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/get_azure_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_gcp_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_koji_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_oci_creds.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/get_pulp_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
 
 [Install]


### PR DESCRIPTION
Configure pulp credentials on worker startup.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
