### PR TITLE
:lock: Update `filesystem.sh` test case to reflect update mountpoint policy

### DIFF
--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -120,7 +120,7 @@ greenprint "🚀 Checking custom filesystems (success case)"
 
 # Write a basic blueprint for our image.
 tee "$BLUEPRINT_FILE" > /dev/null << EOF
-name = "rhel85-custom-filesystem"
+name = "custom-filesystem"
 description = "A base system with custom mountpoints"
 version = "0.0.1"
 
@@ -173,7 +173,7 @@ mountpoint = "/data"
 size = 131072000
 EOF
 
-build_image "$BLUEPRINT_FILE" rhel85-custom-filesystem qcow2 false
+build_image "$BLUEPRINT_FILE" custom-filesystem qcow2 false
 
 # Download the image.
 greenprint "📥 Downloading the image"
@@ -199,7 +199,7 @@ check_result "Passing"
 # Clean compose and blueprints.
 greenprint "🧼 Clean up osbuild-composer again"
 sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
-sudo composer-cli blueprints delete rhel85-custom-filesystem > /dev/null
+sudo composer-cli blueprints delete custom-filesystem > /dev/null
 
 ##################################################
 ##
@@ -211,7 +211,7 @@ greenprint "🚀 Checking custom filesystems (fail case)"
 
 # Write a basic blueprint for our image.
 tee "$BLUEPRINT_FILE" > /dev/null << EOF
-name = "rhel85-custom-filesystem-fail"
+name = "custom-filesystem-fail"
 description = "A base system with custom mountpoints"
 version = "0.0.1"
 
@@ -229,8 +229,8 @@ size = 131072000
 
 EOF
 
-# build_image "$BLUEPRINT_FILE" rhel85-custom-filesystem-fail qcow2 true
-build_image "$BLUEPRINT_FILE" rhel85-custom-filesystem-fail qcow2 true
+# build_image "$BLUEPRINT_FILE" custom-filesystem-fail qcow2 true
+build_image "$BLUEPRINT_FILE" custom-filesystem-fail qcow2 true
 
 # Clear the test variable
 FAILED_MOUNTPOINTS=()
@@ -247,7 +247,7 @@ check_result "Failing"
 
 # Clean compose and blueprints.
 greenprint "🧼 Clean up osbuild-composer again"
-sudo composer-cli blueprints delete rhel85-custom-filesystem-fail > /dev/null
+sudo composer-cli blueprints delete custom-filesystem-fail > /dev/null
 
 clean_up
 

--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -157,6 +157,10 @@ mountpoint = "/home"
 size = 131072000
 
 [[customizations.filesystem]]
+mountpoint = "/home/shadownman"
+size = 131072000
+
+[[customizations.filesystem]]
 mountpoint = "/opt"
 size = 131072000
 
@@ -171,7 +175,25 @@ size = 131072000
 [[customizations.filesystem]]
 mountpoint = "/data"
 size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/boot"
+size = 131072000
 EOF
+
+# Workaround for RHEL-9.3 nightly pipeline
+if [[ "$VERSION_ID" != "9.3" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+
+[[customizations.filesystem]]
+mountpoint = "/boot/firmware"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/foobar"
+size = 131072000
+EOF
+fi
 
 build_image "$BLUEPRINT_FILE" custom-filesystem qcow2 false
 
@@ -224,10 +246,67 @@ mountpoint = "/etc"
 size = 131072000
 
 [[customizations.filesystem]]
+mountpoint = "/sys"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/proc"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/dev"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/run"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/bin"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/sbin"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/lib"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/lib64"
+size = 131072000
+
+[[customizations.filesystem]]
 mountpoint = "/lost+found"
 size = 131072000
 
+[[customizations.filesystem]]
+mountpoint = "/boot/efi"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/sysroot"
+size = 131072000
 EOF
+
+# Workaround for RHEL-9.3 nightly pipeline
+if [[ "$VERSION_ID" != "9.3" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+
+[[customizations.filesystem]]
+mountpoint = "/usr/bin"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/var/run"
+size = 131072000
+
+[[customizations.filesystem]]
+mountpoint = "/var/lock"
+size = 131072000
+EOF
+fi
 
 # build_image "$BLUEPRINT_FILE" custom-filesystem-fail qcow2 true
 build_image "$BLUEPRINT_FILE" custom-filesystem-fail qcow2 true
@@ -236,11 +315,20 @@ build_image "$BLUEPRINT_FILE" custom-filesystem-fail qcow2 true
 FAILED_MOUNTPOINTS=()
 
 greenprint "💬 Checking expected failures"
-for MOUNTPOINT in '/etc' '/lost+found' ; do
+for MOUNTPOINT in '/etc' '/sys' '/proc' '/dev' '/run' '/bin' '/sbin' '/lib' '/lib64' '/lost+found' '/boot/efi' '/sysroot'; do
   if ! [[ $ERROR_MSG == *"$MOUNTPOINT"* ]]; then
     FAILED_MOUNTPOINTS+=("$MOUNTPOINT")
   fi
 done
+
+# Workaround for RHEL-9.3 nightly pipeline
+if [[ "$VERSION_ID" != "9.3" ]]; then
+  for MOUNTPOINT in '/usr/bin' '/var/run' '/var/lock'; do
+    if ! [[ $ERROR_MSG == *"$MOUNTPOINT"* ]]; then
+      FAILED_MOUNTPOINTS+=("$MOUNTPOINT")
+    fi
+  done
+fi
 
 # Check the result and pass scenario type
 check_result "Failing"


### PR DESCRIPTION
SSIA

Related to https://issues.redhat.com/browse/COMPOSER-2030

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] https://github.com/osbuild/guides/pull/153

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
