### PR TITLE
Fix rhel9 oscap test

### DIFF
--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -362,6 +362,8 @@ clean_up
 ###############################
 
 # Write a blueprint for hardened image.
+# TODO: Remove firewalld rules from tailoring once https://github.com/ComplianceAsCode/content/issues/11275 is fixed
+# COMPOSER-2076 is tracking this workaround
 tee "${BLUEPRINT_FILE}" > /dev/null << EOF
 name = "hardened"
 description = "A hardened OpenSCAP image"
@@ -373,7 +375,7 @@ groups = []
 profile_id = "${PROFILE}"
 datastream = "${DATASTREAM}"
 [customizations.openscap.tailoring]
-unselected = ["grub2_password"]
+unselected = ["grub2_password", "firewalld_loopback_traffic_restricted", "firewalld_loopback_traffic_trusted"]
 
 [[customizations.user]]
 name = "${SSH_USER}"


### PR DESCRIPTION
The `oscap` remediation is failing due to an issue with remediating the
firewall loopback traffic. The remediation fails and bails out early
resulting in a lower score and causing a regression in the test. This
will need to be fixed on the OpenSCAP side, so as a workaround, we can
remove this rule from the remediation.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
