### PR TITLE
Revert "containers/osbuild-composer: wait for fluentd in entrypoint"

### DIFF
--- a/containers/osbuild-composer/entrypoint.py
+++ b/containers/osbuild-composer/entrypoint.py
@@ -20,9 +20,6 @@ import time
 class Cli(contextlib.AbstractContextManager):
     """Command Line Interface"""
 
-    SYSLOG_RETRIES=5
-    SYSLOG_WAIT=2.0
-
     def __init__(self, argv):
         self.args = None
         self._argv = argv
@@ -287,25 +284,6 @@ class Cli(contextlib.AbstractContextManager):
         )
 
     @staticmethod
-    def _wait_for_syslog(addr):
-        print("Waiting for fluentd syslog server", file=sys.stderr)
-        for _ in range(Cli.SYSLOG_RETRIES):
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                sock.connect(addr)
-            except ConnectionRefusedError:
-                time.sleep(Cli.SYSLOG_WAIT)
-                continue
-            except (NameError, ConnectionError) as ex:
-                print("Unexpected error:", ex , file=sys.stderr)
-                break
-            finally:
-                sock.close()
-
-            print("fluentd syslog server is up", file=sys.stderr)
-            break
-
-    @staticmethod
     def _spawn_composer(sockets):
         cmd = [
             "/usr/libexec/osbuild-composer/osbuild-composer",
@@ -359,9 +337,6 @@ class Cli(contextlib.AbstractContextManager):
                 proc_worker = self._spawn_worker()
 
             if any([self.args.weldr_api, self.args.composer_api, self.args.local_worker_api, self.args.remote_worker_api]):
-                if "SYSLOG_SERVER" in os.environ:
-                    addr, port = os.environ["SYSLOG_SERVER"].split(":")
-                    self._wait_for_syslog((addr, int(port)))
                 proc_composer = self._spawn_composer(sockets)
 
             if proc_composer:


### PR DESCRIPTION
This reverts commit b4cf032239e4d8ebe17934439d14a492f158e158. No longer needed after removing sidecar COMPOSER-2051


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
