### PR TITLE
dnf-json: Allow passing module_hotfixes

### DIFF
--- a/dnf-json
+++ b/dnf-json
@@ -119,6 +119,11 @@ class Solver():
         # we set the expiration to a short time period, rather than 0.
         repo.metadata_expire = desc.get("metadata_expire", "20s")
 
+        # This option if True disables modularization filtering. Effectively
+        # disabling modularity for given repository.
+        if "module_hotfixes" in desc:
+            repo.module_hotfixes = desc["module_hotfixes"]
+
         return repo
 
     @staticmethod


### PR DESCRIPTION
Allow passing [module_hotfixes](https://dnf.readthedocs.io/en/latest/modularity.html#hotfix-repositories) as repo option,
it will allow disabling of modularity filtering per repository.

WHY
This would obviously be only the first step for enabling this.
I'm happy to continue pursuing this, but first I'd like to hear if we even want to do this.
I'd believe so, as modularity might go away, ppl might just want to force packages in without enabling modularity.