### PR TITLE
Readme: Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ instance, includes a
 
 #### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/developer-guide.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our workflow, code style and more.
 
 ### About
 


### PR DESCRIPTION
After documentation refactoring "developer guide" link was pointing to non existing page. This commit updates the link to point to the latest upstream developer guide page.


