### PR TITLE
test: remove persistent log checking on minimal raw test

### DIFF
--- a/test/data/ansible/check-minimal.yaml
+++ b/test/data/ansible/check-minimal.yaml
@@ -58,18 +58,6 @@
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
 
-    - name: enable persistent logging for the systemd journal
-      file:
-        path: /var/log/journal
-        state: directory
-      become: yes
-      when: ansible_facts['distribution'] == 'RedHat' or ansible_facts['distribution'] == 'CentOS'
-
-    - name: enable persistent logging on RHEL 9 and CS9 only
-      command: journalctl --flush
-      become: yes
-      when: ansible_facts['distribution_version'] == "9.4" or ansible_facts['distribution_version'] == "9"
-
     - name: add RHEL 9.4 BaseOS repository
       yum_repository:
         name: baseos
@@ -198,26 +186,6 @@
           until: result_rollback is success
           retries: 6
           delay: 10
-      always:
-        - set_fact:
-            total_counter: "{{ total_counter | int + 1 }}"
-      rescue:
-        - name: failed count + 1
-          set_fact:
-            failed_counter: "{{ failed_counter | int + 1 }}"
-
-    # case: check persistent log in Edge system
-    - name: check journald has persistent logging
-      block:
-        - name: list boots
-          shell: journalctl --list-boots -q
-          register: result_list_boots
-
-        - assert:
-            that:
-              - result_list_boots.stdout_lines | length > 1
-            fail_msg: "journald hasn't persistent logging"
-            success_msg: "journald has persistent logging"
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"


### PR DESCRIPTION
Persistent log is not related with minimal raw image itself and it is not stable. After discuss with team, remove this test.
