### PR TITLE
test: fix ansible playbook conditional statements error

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -356,9 +356,9 @@
       block:
         - assert:
             that:
-              - result_var_mount_point.stdout == "{{ device_name }}[/ostree/deploy/{{ image_type }}/var]"
-            fail_msg: "/var does not mount on {{ device_name }}[/ostree/deploy/{{ image_type }}/var]"
-            success_msg: "/var mounts on {{ device_name }}[/ostree/deploy/{{ image_type }}/var]"
+              - result_var_mount_point.stdout == var_mount_path
+            fail_msg: "/var does not mount on {{ var_mount_path }}"
+            success_msg: "/var mounts on {{ var_mount_path }}"
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"
@@ -366,6 +366,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      vars:
+        var_mount_path: "{{ device_name  }}[/ostree/deploy/{{ image_type  }}/var]"
 
     # case: check /var mount status
     - name: check /var mount status
@@ -396,9 +398,9 @@
       block:
         - assert:
             that:
-              - result_usr_mount_point.stdout == "{{ device_name }}[/ostree/deploy/{{ image_type }}/deploy/{{ deploy_commit }}.0/usr]"
-            fail_msg: "/usr does not mount on {{ device_name }}[/ostree/deploy/{{ image_type }}/deploy/{{ deploy_commit }}.0/usr]"
-            success_msg: "/usr mounts on {{ device_name }}[/ostree/deploy/{{ image_type }}/deploy/{{ deploy_commit }}.0/usr]"
+              - result_usr_mount_point.stdout == usr_mount_path
+            fail_msg: "/usr does not mount on {{ usr_mount_path }}"
+            success_msg: "/usr mounts on {{ usr_mount_path }}"
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"
@@ -406,6 +408,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      vars:
+        usr_mount_path: "{{ device_name  }}[/ostree/deploy/{{ image_type  }}/deploy/{{ deploy_commit  }}.0/usr]"
 
     # case: check /usr mount status
     - name: check /usr mount status


### PR DESCRIPTION
Today, Edge tests in RHEL 8 and RHEL 9 are running into an ansible error `conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}` https://github.com/osbuild/rhel-edge-ci/actions/runs/7166929082/job/19511985610#step:6:4065.
This error should be imported by ansible-core upgrade from 2.14.9 to 2.14.12.
This PR addresses this error to not include templating delimiters such as {{ }} or {% %}` in conditional statements.
