### PR TITLE
test: add custom partition mount points to raw image test case

### DIFF
--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -103,6 +103,7 @@ KERNEL_RT_PKG="kernel-rt"
 # Set up variables.
 SYSROOT_RO="false"
 CUSTOM_DIRS_FILES="false"
+CUSTOM_FS_LVS="false"
 
 # Set FIPS variable default
 FIPS="${FIPS:-false}"
@@ -121,6 +122,7 @@ case "${ID}-${VERSION_ID}" in
         PARENT_REF="rhel/9/${ARCH}/edge"
         OS_VARIANT="rhel9-unknown"
         SYSROOT_RO="true"
+        CUSTOM_FS_LVS="true"
         ;;
     "centos-8")
         OSTREE_REF="centos/8/${ARCH}/edge"
@@ -134,6 +136,7 @@ case "${ID}-${VERSION_ID}" in
         OS_VARIANT="centos-stream9"
         BOOT_ARGS="uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no"
         SYSROOT_RO="true"
+        CUSTOM_FS_LVS="true"
         ;;
     "fedora-"*)
         CONTAINER_TYPE=iot-container
@@ -475,6 +478,22 @@ enabled = ["custom.service"]
 EOF
 fi
 
+if [[ "${CUSTOM_FS_LVS}" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.filesystem]]
+mountpoint = "/foo/bar"
+size=2147483648
+
+[[customizations.filesystem]]
+mountpoint = "/foo"
+size=8589934592
+
+[[customizations.filesystem]]
+mountpoint = "/var/myfiles"
+size= "1 GiB"
+EOF
+fi
+
 greenprint "📄 raw image blueprint"
 cat "$BLUEPRINT_FILE"
 
@@ -587,6 +606,7 @@ EOF
         -e sysroot_ro="$SYSROOT_RO" \
         -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
         -e fips="${FIPS}" \
+        -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
         /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
     check_result
 
@@ -755,6 +775,7 @@ EOF
         -e sysroot_ro="$SYSROOT_RO" \
         -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
         -e fips="${FIPS}" \
+        -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
         /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 
     check_result
@@ -861,6 +882,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -1053,6 +1075,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e test_custom_dirs_files="$CUSTOM_DIRS_FILES" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -115,6 +115,7 @@ INSTALLER_FILENAME=simplified-installer.iso
 MEMORY=2048
 BOOT_ARGS="uefi"
 # REF_PREFIX="rhel-edge"
+CUSTOM_FS_LVS="false"
 
 # Set up temporary files.
 TEMPDIR=$(mktemp -d)
@@ -155,6 +156,7 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         ANSIBLE_USER=fdouser
         FDO_USER_ONBOARDING="true"
+        CUSTOM_FS_LVS="true"
         # workaround selinux bug https://bugzilla.redhat.com/show_bug.cgi?id=2026795
         sudo setenforce 0
         getenforce
@@ -173,6 +175,7 @@ case "${ID}-${VERSION_ID}" in
         SYSROOT_RO="true"
         ANSIBLE_USER=fdouser
         FDO_USER_ONBOARDING="true"
+        CUSTOM_FS_LVS="true"
         # workaround selinux bug https://bugzilla.redhat.com/show_bug.cgi?id=2026795
         sudo setenforce 0
         getenforce
@@ -469,6 +472,20 @@ fips = ${FIPS}
 EOF
 fi
 
+if [[ "${CUSTOM_FS_LVS}" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.filesystem]]
+mountpoint = "/foo/bar"
+size=2147483648
+[[customizations.filesystem]]
+mountpoint = "/foo"
+size=8589934592
+[[customizations.filesystem]]
+mountpoint = "/var/myfiles"
+size= "1 GiB"
+EOF
+fi
+
 greenprint "📄 simplified_iso_without_fdo blueprint"
 cat "$BLUEPRINT_FILE"
 
@@ -575,6 +592,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e fdo_credential="false" \
     -e sysroot_ro="$SYSROOT_RO" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -636,6 +654,19 @@ append = "enforcing=0"
 EOF
 fi
 
+if [[ "${CUSTOM_FS_LVS}" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.filesystem]]
+mountpoint = "/foo/bar"
+size=2147483648
+[[customizations.filesystem]]
+mountpoint = "/foo"
+size=8589934592
+[[customizations.filesystem]]
+mountpoint = "/var/myfiles"
+size= "1 GiB"
+EOF
+fi
 
 greenprint "📄 installer blueprint"
 cat "$BLUEPRINT_FILE"
@@ -764,6 +795,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e mfg_guest_int_name="${MFG_GUEST_INT_NAME}" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -818,6 +850,20 @@ if [[ "$VERSION_ID" == "9.3" || "$VERSION_ID" == "9" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [customizations.kernel]
 append = "enforcing=0"
+EOF
+fi
+
+if [[ "${CUSTOM_FS_LVS}" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.filesystem]]
+mountpoint = "/foo/bar"
+size=2147483648
+[[customizations.filesystem]]
+mountpoint = "/foo"
+size=8589934592
+[[customizations.filesystem]]
+mountpoint = "/var/myfiles"
+size= "1 GiB"
 EOF
 fi
 
@@ -950,6 +996,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e mfg_guest_int_name="${MFG_GUEST_INT_NAME}" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -1003,6 +1050,20 @@ if [[ "$VERSION_ID" == "9.3" || "$VERSION_ID" == "9" ]]; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 [customizations.kernel]
 append = "enforcing=0"
+EOF
+fi
+
+if [[ "${CUSTOM_FS_LVS}" == "true" ]]; then
+    tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
+[[customizations.filesystem]]
+mountpoint = "/foo/bar"
+size=2147483648
+[[customizations.filesystem]]
+mountpoint = "/foo"
+size=8589934592
+[[customizations.filesystem]]
+mountpoint = "/var/myfiles"
+size= "1 GiB"
 EOF
 fi
 
@@ -1116,6 +1177,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e mfg_guest_int_name="${MFG_GUEST_INT_NAME}" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 check_result
 
@@ -1259,6 +1321,7 @@ sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
     -e sysroot_ro="$SYSROOT_RO" \
     -e mfg_guest_int_name="${MFG_GUEST_INT_NAME}" \
     -e fips="${FIPS}" \
+    -e custom_fs_lvs="${CUSTOM_FS_LVS}" \
     /usr/share/tests/osbuild-composer/ansible/check_ostree.yaml || RESULTS=0
 
 check_result

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -14,6 +14,7 @@
     test_custom_dirs_files: "false"
     sysroot_ro: "false"
     fips: "false"
+    custom_fs_lvs: "false"
 
   tasks:
     # current target host's IP address
@@ -261,7 +262,7 @@
 
     # case: check pv size
     - name: check pv size
-      shell: pvs --reportformat json | jq .report[0].pv[0].pv_size -r
+      shell: pvs --reportformat json --units g | jq .report[0].pv[0].pv_size -r | sed "s/\.[0-9]\+g//g"
       become: yes
       register: result_pv_size
       when: "'/dev/mapper/rootvg-rootlv' in result_sysroot_source.stdout"
@@ -303,6 +304,37 @@
       when:
         - "'/dev/mapper/rootvg-rootlv' in result_sysroot_source.stdout"
         - fdo_credential == "false"
+        - custom_fs_lvs == "false"
+
+    # check logical volumes
+    - name: check logical volumes
+      shell: lvdisplay -a
+      become: yes
+      register: result_custom_lvs
+      when:
+        - "'/dev/mapper/rootvg-rootlv' in result_sysroot_source.stdout"
+        - custom_fs_lvs == "true"
+
+    - name: "check that custom partitions are present"
+      block:
+        - assert:
+            that:
+              - "'var_myfileslv' in result_custom_lvs.stdout"
+              - "'foolv' in result_custom_lvs.stdout"
+              - "'foo_barlv' in result_custom_lvs.stdout"
+            fail_msg: "There are custom partitions missing"
+            success_msg: "Custom partitions present in filesystem"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - "'/dev/mapper/rootvg-rootlv' in result_sysroot_source.stdout"
+        - custom_fs_lvs == "true"
+
 
     # case: check /sysroot lv size
     - name: check sysroot lv size


### PR DESCRIPTION
This pull request includes:

This PR adds custom partitions to blueprint of edge-raw-image, making use of the example comments at [RHEL 9: Filesystem customizations for edge-raw-image](https://github.com/osbuild/images/pull/255)

A playbook task has been included to check the custom partitions using `lvdisplay` 

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
