### PR TITLE
aws: allow the user to customize their AMI name

### DIFF
--- a/cmd/osbuild-upload-aws/main.go
+++ b/cmd/osbuild-upload-aws/main.go
@@ -58,7 +58,7 @@ func main() {
 		bootModePtr = &bootMode
 	}
 
-	ami, err := a.Register(imageName, bucketName, keyName, share, arch, bootModePtr)
+	ami, err := a.Register(imageName, bucketName, keyName, imageName, share, arch, bootModePtr)
 	if err != nil {
 		println(err.Error())
 		return

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -636,7 +636,12 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				break
 			}
 
-			ami, err := a.Register(jobTarget.ImageName, bucket, targetOptions.Key, targetOptions.ShareWithAccounts, arch.Current().String(), targetOptions.BootMode)
+			// giving a Name tag value is optional, default to ImageName if missing.
+			tagName := jobTarget.ImageName
+			if targetOptions.TagName != "" {
+				tagName = targetOptions.TagName
+			}
+			ami, err := a.Register(jobTarget.ImageName, bucket, targetOptions.Key, tagName, targetOptions.ShareWithAccounts, arch.Current().String(), targetOptions.BootMode)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorImportingImage, err.Error(), nil)
 				break

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -99,7 +99,7 @@ func UploadImageToAWS(c *awsCredentials, imagePath string, imageName string) err
 	if err != nil {
 		return fmt.Errorf("cannot upload the image: %v", err)
 	}
-	_, err = uploader.Register(imageName, c.Bucket, imageName, nil, arch.Current().String(), nil)
+	_, err = uploader.Register(imageName, c.Bucket, imageName, imageName, nil, arch.Current().String(), nil)
 	if err != nil {
 		return fmt.Errorf("cannot register the image: %v", err)
 	}

--- a/internal/target/aws_target.go
+++ b/internal/target/aws_target.go
@@ -14,6 +14,9 @@ type AWSTargetOptions struct {
 	Key               string   `json:"key"`
 	ShareWithAccounts []string `json:"shareWithAccounts"`
 
+	// Optional tag value if not provided will default to the ImageName's value.
+	TagName string `json:"tag_name,omitempty"`
+
 	// Boot mode of the AMI (optional)
 	// Supported values:
 	//  - ec2.BootModeValuesLegacyBios

--- a/test/cases/api/aws.sh
+++ b/test/cases/api/aws.sh
@@ -103,7 +103,7 @@ function checkUploadStatusOptions() {
 function verify() {
   $AWS_CMD ec2 describe-images \
     --owners self \
-    --filters Name=name,Values="$AWS_SNAPSHOT_NAME" \
+    --filters Name=name,Values="$AWS_SNAPSHOT_NAME-*" \
     > "$WORKDIR/ami.json"
 
   AMI_IMAGE_ID=$(jq -r '.Images[].ImageId' "$WORKDIR/ami.json")


### PR DESCRIPTION
In the frontend a new field is allowing user to setup customized names
for their images (see
https://github.com/RedHatInsights/image-builder-frontend/pull/1136).

To allow the customization to effectively take place, this commit is
slightly changing how EC2 images are activated.

The Name tag and the AMI Name are not always sharing the same value
exactly anymore. If the user provides a SnaphsotName, the raw value is
set in the `Name` tag and the AMI name is set to `$SnaphsotName-$UUID`
(to make it unique).

This means that the `Name` tag can't be used anymore for the maintenance
tooling. The tooling will have to use the new Build-By tag to identify
the images built by osbuild-composer.

**Example**
The request:
![image](https://github.com/osbuild/osbuild-composer/assets/86971992/f7e63bc4-2195-4ffe-8d75-1f4a085d4c38)

Ended up producing this AMI:
![image](https://github.com/osbuild/osbuild-composer/assets/86971992/9b53929c-9c9f-4e0c-b9b9-4ff45b7115eb)


This pull request includes:
- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

https://issues.redhat.com/browse/HMS-2959

