### PR TITLE
Invert wrong boolean condition in filesystem test

### DIFF
--- a/test/cases/filesystem.sh
+++ b/test/cases/filesystem.sh
@@ -181,7 +181,7 @@ mountpoint = "/boot"
 size = 131072000
 EOF
 
-if ! nvrGreaterOrEqual "osbuild-composer" "94"; then
+if nvrGreaterOrEqual "osbuild-composer" "94"; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 
 [[customizations.filesystem]]
@@ -293,7 +293,7 @@ mountpoint = "/sysroot"
 size = 131072000
 EOF
 
-if ! nvrGreaterOrEqual "osbuild-composer" "94"; then
+if nvrGreaterOrEqual "osbuild-composer" "94"; then
     tee -a "$BLUEPRINT_FILE" > /dev/null << EOF
 
 [[customizations.filesystem]]
@@ -323,7 +323,7 @@ for MOUNTPOINT in '/etc' '/sys' '/proc' '/dev' '/run' '/bin' '/sbin' '/lib' '/li
   fi
 done
 
-if ! nvrGreaterOrEqual "osbuild-composer" "94"; then
+if nvrGreaterOrEqual "osbuild-composer" "94"; then
   for MOUNTPOINT in '/usr/bin' '/var/run' '/var/lock'; do
     if ! [[ $ERROR_MSG == *"$MOUNTPOINT"* ]]; then
       FAILED_MOUNTPOINTS+=("$MOUNTPOINT")


### PR DESCRIPTION
the conditionals have been introduced in
https://github.com/osbuild/osbuild-composer/commit/8960a51d2f10a9b50e7e8d296c6b9598ad181ca8 which states (emphasys mine):

> The new partition rules are **in** osbuild-composer v94 and higher.

but the condition was "not v94 or higher" and as a result it fails on 8.10 nightly with osbuild-composer v92 with:

failed to initialize osbuild manifest: The following custom mountpoints are not supported [\"/boot/firmware\" \"/foobar\"]

see https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/5905865402


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
