### PR TITLE
tests/CI: Add RHEL 9.3 and 8.9 GA to pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,10 +104,10 @@ RPM:
           - aws/fedora-40-aarch64
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-8.8-ga-aarch64
-          - aws/rhel-9.2-ga-x86_64
-          - aws/rhel-9.2-ga-aarch64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-8.9-ga-aarch64
+          - aws/rhel-9.3-ga-x86_64
+          - aws/rhel-9.3-ga-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
           - aws/centos-stream-9-x86_64
@@ -139,7 +139,7 @@ Container:
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.8-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
 
 Packer:
   stage: test
@@ -149,7 +149,7 @@ Packer:
   script:
     - tools/ci-build-worker-packer.sh
   variables:
-    RUNNER: aws/rhel-9.2-ga-x86_64
+    RUNNER: aws/rhel-9.3-ga-x86_64
 
 Prepare-rhel-internal:
   stage: prepare-rhel-internal
@@ -190,10 +190,10 @@ Base:
           - aws/fedora-39-aarch64
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-8.8-ga-aarch64
-          - aws/rhel-9.2-ga-x86_64
-          - aws/rhel-9.2-ga-aarch64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-8.9-ga-aarch64
+          - aws/rhel-9.3-ga-x86_64
+          - aws/rhel-9.3-ga-aarch64
           - aws/centos-stream-8-x86_64
           - aws/centos-stream-8-aarch64
       - RUNNER:
@@ -226,10 +226,10 @@ Base:
       - RUNNER:
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-8.8-ga-aarch64
-          - aws/rhel-9.2-ga-x86_64
-          - aws/rhel-9.2-ga-aarch64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-8.9-ga-aarch64
+          - aws/rhel-9.3-ga-x86_64
+          - aws/rhel-9.3-ga-aarch64
           - aws/rhel-8.10-nightly-x86_64
           - aws/rhel-8.10-nightly-aarch64
           - aws/rhel-9.4-nightly-x86_64
@@ -287,8 +287,8 @@ regression-old-worker-new-composer:
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-9.2-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
         INTERNAL_NETWORK: ["true"]
   extends: .regression
   variables:
@@ -356,8 +356,8 @@ Trigger-rhel-edge-ci:
     RUNNER:
       - aws/centos-stream-8-x86_64
       - aws/rhel-8.4-ga-x86_64
-      - aws/rhel-8.8-ga-x86_64
-      - aws/rhel-9.2-ga-x86_64
+      - aws/rhel-8.9-ga-x86_64
+      - aws/rhel-9.3-ga-x86_64
       - aws/rhel-8.10-nightly-x86_64
       - aws/rhel-8.10-nightly-aarch64
       - aws/rhel-9.4-nightly-x86_64
@@ -401,19 +401,19 @@ koji.sh (cloud upload):
     matrix:
       - RUNNER:
           # Brew workers use RHEL-8.7
-          - aws/rhel-8.8-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: aws
         IMAGE_TYPE: aws-rhui
       - RUNNER:
           # Brew workers use RHEL-8.6
-          - aws/rhel-8.8-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: azure
         IMAGE_TYPE: azure-rhui
       - RUNNER:
           # Brew workers use RHEL-8.6
-          - aws/rhel-8.8-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: gcp
         IMAGE_TYPE: gcp-rhui
@@ -527,8 +527,8 @@ API:
     matrix:
       - <<: *API_TESTS
         RUNNER:
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-9.2-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
           - aws/rhel-8.10-nightly-x86_64
           - aws/rhel-9.4-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -538,8 +538,8 @@ API:
           - aws/fedora-39-x86_64
       - IMAGE_TYPE: ["aws"]
         RUNNER:
-          - aws/rhel-8.8-ga-aarch64
-          - aws/rhel-9.2-ga-aarch64
+          - aws/rhel-8.9-ga-aarch64
+          - aws/rhel-9.3-ga-aarch64
         INTERNAL_NETWORK: ["true"]
 
 API-module-hotfixes:
@@ -557,14 +557,14 @@ API-module-hotfixes:
       - IMAGE_TYPE:
           - aws
         RUNNER:
-          - aws/rhel-8.8-ga-x86_64
-          - aws/rhel-8.8-ga-aarch64
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-8.9-ga-aarch64
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
       - IMAGE_TYPE:
           - vsphere
         RUNNER:
-          - aws/rhel-8.8-ga-x86_64
+          - aws/rhel-8.9-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
 
@@ -624,8 +624,8 @@ API-distro-alias:
           # - rhos-01/fedora-39-x86_64
       - RUNNER:
           - gcp/centos-stream-8-x86_64
-          - gcp/rhel-8.8-ga-x86_64
-          - gcp/rhel-9.2-ga-x86_64
+          - gcp/rhel-8.9-ga-x86_64
+          - gcp/rhel-9.3-ga-x86_64
           - gcp/rhel-8.10-nightly-x86_64
           - gcp/rhel-9.4-nightly-x86_64
           - gcp/centos-stream-9-x86_64
@@ -646,7 +646,7 @@ ubi-wsl.sh:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ubi-wsl.sh
   variables:
-      RUNNER: aws/rhel-8.8-ga-x86_64
+      RUNNER: aws/rhel-8.9-ga-x86_64
       INTERNAL_NETWORK: "true"
 
 weldr-distro-dot-notation+aliases:
@@ -701,7 +701,7 @@ RHEL 9 on 8:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/koji.sh
   variables:
-    RUNNER: aws/rhel-8.8-ga-x86_64
+    RUNNER: aws/rhel-8.9-ga-x86_64
     INTERNAL_NETWORK: "true"
     DISTRO_CODE: rhel-91
 
@@ -715,7 +715,7 @@ Multi-tenancy:
     - /usr/libexec/tests/osbuild-composer/multi-tenancy.sh
   variables:
     # only 8.7 GA b/c the Image Builder service runs on RHEL 8
-    RUNNER: aws/rhel-8.8-ga-x86_64
+    RUNNER: aws/rhel-8.9-ga-x86_64
     INTERNAL_NETWORK: "true"
 
 OpenSCAP:

--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -122,7 +122,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -148,14 +148,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
+      }
+    }
+  },
+  "rhel-8.9": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     }
   },
@@ -169,7 +176,7 @@
   "rhel-8.10": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -215,7 +222,14 @@
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
+      }
+    }
+  },
+  "rhel-9.3": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     }
   },
@@ -229,7 +243,7 @@
   "rhel-9.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -275,21 +289,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [
@@ -335,7 +349,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "5fc3b565a257b0e0636d9e7f0015fc7f6cae0e55"
+        "commit": "106681f41e8359e7b2bd1f0e091e48ec32f3b61d"
       }
     },
     "repos": [

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -13,9 +13,9 @@ ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-# Only run this on x86 and rhel8 GA
+# Only run this on x86
 if [ "$ARCH" != "x86_64" ] || [ "$ID" != rhel ] || ! sudo subscription-manager status; then
-    echo "Test only supported on GA RHEL."
+    echo "Test only supported on RHEL x86_64."
     exit 1
 fi
 


### PR DESCRIPTION
Move testing to RHEL 8.9 and 9.3 runners.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue

- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
