### PR TITLE
tools/build-rpms: fix getting the osbuild commit from Schutzfile

### DIFF
--- a/tools/build-rpms.py
+++ b/tools/build-rpms.py
@@ -144,7 +144,7 @@ def run_ansible(args, key_material):
 
     with open(args.base_dir / "Schutzfile") as f:
         osbuild_commit = json.load(
-            f)["rhel-8.6"]["dependencies"]["osbuild"]["commit"]
+            f)["centos-stream-9"]["dependencies"]["osbuild"]["commit"]
 
     return run_command(["ansible-playbook",
                         "--ssh-extra-args", "-o ControlPersist=no -o StrictHostKeyChecking=no -o ServerAliveInterval=5",


### PR DESCRIPTION
osbuild/osbuild-composer#3614 removed the rhel-8.6, the centos-stream-9 entry should be there for a while at least.
