### PR TITLE
Remove oscap.sh firewalld rules workaround

### DIFF
--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -362,8 +362,6 @@ clean_up
 ###############################
 
 # Write a blueprint for hardened image.
-# TODO: Remove firewalld rules from tailoring once https://github.com/ComplianceAsCode/content/issues/11275 is fixed
-# COMPOSER-2076 is tracking this workaround
 tee "${BLUEPRINT_FILE}" > /dev/null << EOF
 name = "hardened"
 description = "A hardened OpenSCAP image"
@@ -375,7 +373,7 @@ groups = []
 profile_id = "${PROFILE}"
 datastream = "${DATASTREAM}"
 [customizations.openscap.tailoring]
-unselected = ["grub2_password", "firewalld_loopback_traffic_restricted", "firewalld_loopback_traffic_trusted"]
+unselected = ["grub2_password"]
 
 [[customizations.user]]
 name = "${SSH_USER}"


### PR DESCRIPTION
b/c https://github.com/ComplianceAsCode/content/issues/11275 has been fixed. This reverts commit c77b73a8881a5d82ec50642e2747ab7ede061c94.

