### PR TITLE
templates/packer: deal with unbound variables

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/client_credentials.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/client_credentials.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Writing client credentials."
 
+CLIENT_CREDENTIALS_ARN=${CLIENT_CREDENTIALS_ARN:-}
 if [[ -z "$CLIENT_CREDENTIALS_ARN" ]]; then
   echo "CLIENT_CREDENTIALS_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_aws_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_aws_creds.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy AWS credentials."
@@ -14,6 +14,7 @@ sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 bucket = "${WORKER_CONFIG_AWS_BUCKET:-}"
 EOF
 
+AWS_ACCOUNT_IMAGE_BUILDER_ARN=${AWS_ACCOUNT_IMAGE_BUILDER_ARN:-}
 if [[ -z "$AWS_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
   echo "AWS_ACCOUNT_IMAGE_BUILDER_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_azure_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_azure_creds.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy Azure credentials."
 
+AZURE_ACCOUNT_IMAGE_BUILDER_ARN=${AZURE_ACCOUNT_IMAGE_BUILDER_ARN:-}
 if [[ -z "$AZURE_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
   echo "AZURE_ACCOUNT_IMAGE_BUILDER_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_gcp_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_gcp_creds.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy GCP credentials."
@@ -13,6 +13,7 @@ sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 bucket = "${WORKER_CONFIG_GCP_BUCKET:-}"
 EOF
 
+GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN=${GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN:-}
 if [[ -z "$GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
   echo "GCP_SERVICE_ACCOUNT_IMAGE_BUILDER_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_koji_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_koji_creds.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy Koji credentials."
 
+KOJI_ACCOUNT_IMAGE_BUILDER_ARN=${KOJI_ACCOUNT_IMAGE_BUILDER_ARN:-}
 if [[ -z "$KOJI_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
   echo "KOJI_ACCOUNT_IMAGE_BUILDER_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_oci_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_oci_creds.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy OCI credentials."
 
+OCI_ACCOUNT_IMAGE_BUILDER_ARN=${OCI_ACCOUNT_IMAGE_BUILDER_ARN:-}
 if [[ -z "$OCI_ACCOUNT_IMAGE_BUILDER_ARN" ]]; then
   echo "OCI_ACCOUNT_IMAGE_BUILDER_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_pulp_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_pulp_creds.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source /tmp/cloud_init_vars
 
 echo "Deploy Pulp credentials."
 
+PULP_PASSWORD_ARN=${PULP_PASSWORD_ARN:-}
 if [[ -z "$PULP_PASSWORD_ARN" ]]; then
   echo "PULP_PASSWORD_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/offline_token.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/offline_token.sh
@@ -4,6 +4,7 @@ source /tmp/cloud_init_vars
 
 echo "Writing offline token."
 
+OFFLINE_TOKEN_ARN=${OFFLINE_TOKEN_ARN:-}
 if [[ -z "$OFFLINE_TOKEN_ARN" ]]; then
   echo "OFFLINE_TOKEN_ARN not defined, skipping."
   exit 0

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/subscription_manager.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/subscription_manager.sh
@@ -4,6 +4,7 @@ source /tmp/cloud_init_vars
 
 echo "Subscribing instance to RHN."
 
+SUBSCRIPTION_MANAGER_COMMAND_ARN=${SUBSCRIPTION_MANAGER_COMMAND_ARN:-}
 if [[ -z "$SUBSCRIPTION_MANAGER_COMMAND_ARN" ]]; then
   echo "SUBSCRIPTION_MANAGER_COMMAND_ARN not defined, skipping."
   exit 0


### PR DESCRIPTION
Don't allow unbound variables, but for the variables that are used to determine whether or not that part of the setup should continue, default to false.

