### PR TITLE
Support configuring distro aliases via ENV and set aliases in the composer template.

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -124,6 +124,8 @@ objects:
                 key: dsn
                 name: "${GLITCHTIP_DSN_NAME}"
                 optional: true
+          - name: DISTRO_ALIASES
+            value: ${DISTRO_ALIASES}
           ports:
           - name: composer-api
             protocol: TCP
@@ -495,3 +497,6 @@ parameters:
   - name: GLITCHTIP_DSN_NAME
     value: "composer-stage-dsn"
     description: Name of the secret for connecting to sentry/glitchtip
+  - description: Distro name aliases
+    name: DISTRO_ALIASES
+    value: "rhel-7=rhel-7.9,rhel-8=rhel-8.9,rhel-9=rhel-9.3,rhel-10.0=rhel-9.4"


### PR DESCRIPTION
SSIA, check commit messages for more details.

Also added unit tests for the functionality.

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
