### PR TITLE
DEPLOYING/HACKING.md: Consistently use inline refs

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -10,12 +10,8 @@ take the form:
 ```
 
 `<config>` depends on the target (see below). `<userdata>` is either a
-cloud-init [cloud-config file][cloud-config], or a directory containing
-this configuration, as documented by [./tools/gen-user-data][gen-user-data].
-
-[gen-user-data]: ./tools/gen-user-data
-[cloud-config]: https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data
-
+cloud-init [cloud-config file](https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data), or a directory containing
+this configuration, as documented by [./tools/gen-user-data](./tools/gen-user-data).
 
 ## Target: QEMU
 
@@ -23,20 +19,17 @@ this configuration, as documented by [./tools/gen-user-data][gen-user-data].
 ephemeral virtual machine using qemu. The qcow2 file is not changed and all
 changes to the virtual machine are lost after stopping qemu.
 
-Two ports are forwarded to the host via qemu's [user networking][qemu-network]:
+Two ports are forwarded to the host via qemu's [user networking](https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29):
 22 → 2222 and 443 → 4430.
 
 See [HACKING.md](./HACKING.md) for how to use this target for running
 integration tests locally.
 
-[qemu-network]: https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29
-
-
 ## Target: OpenStack
 
 `tools/deploy-openstack` uses the `openstack` tool (from `python3-openstack`)
 to deploy a machine in an OpenStack cluster. It expects that an [OpenStack RC
-file][openstackrc] was sourced into the running shell:
+file](https://docs.openstack.org/newton/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html) was sourced into the running shell:
 
 ```
 . openstackrc.sh
@@ -53,5 +46,3 @@ machine to create. For example:
   "network": "my-network-id"
 }
 ```
-
-[openstackrc]: https://docs.openstack.org/newton/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html

--- a/HACKING.md
+++ b/HACKING.md
@@ -39,7 +39,7 @@ mimic what is run on *osbuild-composer*'s continuous integration
 infrastructure, i.e., installing `osbuild-composer-tests` and starting the
 service.
 
-The virtual machine uses qemu's [user networking][1], forwarding port 22 to
+The virtual machine uses qemu's [user networking](https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29), forwarding port 22 to
 the host's 2222 and 443 to 4430. You can log into the running machine with
 
 ```
@@ -50,8 +50,6 @@ The password is `foobar`. Stopping the machine loses all data.
 
 For a quick compile and debug cycle, we recommend iterating code using thorough
 unit tests before going through the full workflow described above.
-
-[1]: https://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29
 
 ## Containers
 


### PR DESCRIPTION
The footnote or endnote style links sometimes don't work well with DocuSaurus, i.e. they're not resolved correctly and lead to build errors.
https://github.com/osbuild/osbuild.github.io/actions/runs/7776075785/job/21202788034?pr=36

For reference, this is the PR this is blocking: https://github.com/osbuild/osbuild.github.io/pull/36