### PR TITLE
jobsite: `manager` and `builder`

### DIFF
--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -242,6 +242,7 @@ func (builder *Builder) HandleBuild(w http.ResponseWriter, r *http.Request) erro
 		"--store", path.Join(argBuildPath, "store"),
 		"--cache-max-size", "0",
 		"--output-directory", path.Join(argBuildPath, "export"),
+		"--json",
 	}
 
 	for _, pipeline := range buildRequest.Pipelines {

--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -123,7 +123,7 @@ func (builder *Builder) GetState() State {
 
 func (builder *Builder) GuardState(stateWanted State) {
 	if stateCurrent := builder.GetState(); stateWanted != stateCurrent {
-		logrus.Fatalf("Builder.GuardState: Requested guard for %d but we're in %d. Exit.", stateWanted, stateCurrent)
+		logrus.Fatalf("Builder.GuardState: Requested guard for %d but we're in %d. Exit", stateWanted, stateCurrent)
 	}
 }
 
@@ -146,7 +146,7 @@ func (builder *Builder) HandleClaim(w http.ResponseWriter, r *http.Request) erro
 
 	fmt.Fprintf(w, "%s", "done")
 
-	logrus.Info("Builder.HandleClaim: Done.")
+	logrus.Info("Builder.HandleClaim: Done")
 
 	builder.SetState(StateProvision)
 
@@ -157,10 +157,10 @@ func (builder *Builder) HandleProvision(w http.ResponseWriter, r *http.Request) 
 	builder.GuardState(StateProvision)
 
 	if r.Method != "PUT" {
-		return fmt.Errorf("Builder.HandleProvision: Unexpected request method.")
+		return fmt.Errorf("Builder.HandleProvision: Unexpected request method")
 	}
 
-	logrus.WithFields(logrus.Fields{"argBuildPath": argBuildPath}).Debug("Builder.HandleProvision: Opening manifest.json.")
+	logrus.WithFields(logrus.Fields{"argBuildPath": argBuildPath}).Debug("Builder.HandleProvision: Opening manifest.json")
 
 	dst, err := os.OpenFile(
 		path.Join(argBuildPath, "manifest.json"),
@@ -175,24 +175,24 @@ func (builder *Builder) HandleProvision(w http.ResponseWriter, r *http.Request) 
 	}()
 
 	if err != nil {
-		return fmt.Errorf("Builder.HandleProvision: Failed to open manifest.json.")
+		return fmt.Errorf("Builder.HandleProvision: Failed to open manifest.json")
 	}
 
-	logrus.Debug("Builder.HandleProvision: Writing manifest.json.")
+	logrus.Debug("Builder.HandleProvision: Writing manifest.json")
 
 	_, err = io.Copy(dst, r.Body)
 
 	if err != nil {
-		return fmt.Errorf("Builder.HandleProvision: Failed to write manifest.json.")
+		return fmt.Errorf("Builder.HandleProvision: Failed to write manifest.json")
 	}
 
 	w.WriteHeader(http.StatusCreated)
 
 	if _, err := w.Write([]byte(`done`)); err != nil {
-		return fmt.Errorf("Builder.HandleProvision: Failed to write response.")
+		return fmt.Errorf("Builder.HandleProvision: Failed to write response")
 	}
 
-	logrus.Info("Builder.HandleProvision: Done.")
+	logrus.Info("Builder.HandleProvision: Done")
 
 	builder.SetState(StatePopulate)
 
@@ -209,10 +209,10 @@ func (builder *Builder) HandlePopulate(w http.ResponseWriter, r *http.Request) e
 	w.WriteHeader(http.StatusOK)
 
 	if _, err := w.Write([]byte(`done`)); err != nil {
-		return fmt.Errorf("Builder.HandlePopulate: Failed to write response.")
+		return fmt.Errorf("Builder.HandlePopulate: Failed to write response")
 	}
 
-	logrus.Info("Builder.HandlePopulate: Done.")
+	logrus.Info("Builder.HandlePopulate: Done")
 
 	builder.SetState(StateBuild)
 
@@ -223,7 +223,7 @@ func (builder *Builder) HandleBuild(w http.ResponseWriter, r *http.Request) erro
 	builder.GuardState(StateBuild)
 
 	if r.Method != "POST" {
-		return fmt.Errorf("Builder.HandleBuild: Unexpected request method.")
+		return fmt.Errorf("Builder.HandleBuild: Unexpected request method")
 	}
 
 	var buildRequest BuildRequest
@@ -231,11 +231,11 @@ func (builder *Builder) HandleBuild(w http.ResponseWriter, r *http.Request) erro
 	var err error
 
 	if err = json.NewDecoder(r.Body).Decode(&buildRequest); err != nil {
-		return fmt.Errorf("HandleBuild: Failed to decode body.")
+		return fmt.Errorf("HandleBuild: Failed to decode body")
 	}
 
 	if Build != nil {
-		logrus.Fatal("HandleBuild: Build started but Build was non-nil.")
+		logrus.Fatal("HandleBuild: Build started but Build was non-nil")
 	}
 
 	args := []string{
@@ -277,14 +277,14 @@ func (builder *Builder) HandleBuild(w http.ResponseWriter, r *http.Request) erro
 	}
 
 	if err := Build.Process.Start(); err != nil {
-		return fmt.Errorf("BackgroundProcess: Failed to start process.")
+		return fmt.Errorf("BackgroundProcess: Failed to start process")
 	}
 
 	go func() {
 		Build.Error = Build.Process.Wait()
 		Build.Done = true
 
-		logrus.Info("BackgroundProcess: Exited.")
+		logrus.Info("BackgroundProcess: Exited")
 	}()
 
 	go func() {
@@ -314,11 +314,11 @@ func (builder *Builder) HandleProgress(w http.ResponseWriter, r *http.Request) e
 	builder.GuardState(StateProgress)
 
 	if r.Method != "GET" {
-		return fmt.Errorf("Builder.HandleProgress: Unexpected request method.")
+		return fmt.Errorf("Builder.HandleProgress: Unexpected request method")
 	}
 
 	if Build == nil {
-		return fmt.Errorf("HandleProgress: Progress requested but Build was nil.")
+		return fmt.Errorf("HandleProgress: Progress requested but Build was nil")
 	}
 
 	if Build.Done {
@@ -334,10 +334,10 @@ func (builder *Builder) HandleProgress(w http.ResponseWriter, r *http.Request) e
 	}
 
 	if _, err := w.Write([]byte(`done`)); err != nil {
-		return fmt.Errorf("Builder.HandleBuild: Failed to write response.")
+		return fmt.Errorf("Builder.HandleBuild: Failed to write response")
 	}
 
-	logrus.Info("Builder.HandleBuild: Done.")
+	logrus.Info("Builder.HandleBuild: Done")
 
 	return nil
 }
@@ -352,7 +352,7 @@ func (builder *Builder) HandleExport(w http.ResponseWriter, r *http.Request) err
 	exportPath := r.URL.Query().Get("path")
 
 	if exportPath == "" {
-		return fmt.Errorf("Builder.HandleExport: Missing export.")
+		return fmt.Errorf("Builder.HandleExport: Missing export")
 	}
 
 	// XXX check subdir
@@ -363,16 +363,16 @@ func (builder *Builder) HandleExport(w http.ResponseWriter, r *http.Request) err
 	)
 
 	if err != nil {
-		return fmt.Errorf("Builder.HandleExport: Failed to open source: %s.", err)
+		return fmt.Errorf("Builder.HandleExport: Failed to open source: %s", err)
 	}
 
 	_, err = io.Copy(w, src)
 
 	if err != nil {
-		return fmt.Errorf("Builder.HandleExport: Failed to write response: %s.", err)
+		return fmt.Errorf("Builder.HandleExport: Failed to write response: %s", err)
 	}
 
-	logrus.Info("Builder.HandleExport: Done.")
+	logrus.Info("Builder.HandleExport: Done")
 
 	builder.SetState(StateDone)
 
@@ -413,7 +413,7 @@ func main() {
 			"argTimeoutProvision": argTimeoutProvision,
 			"argTimeoutBuild":     argTimeoutBuild,
 			"argTimeoutExport":    argTimeoutExport,
-		}).Info("main: Starting up.")
+		}).Info("main: Starting up")
 
 	builder := Builder{
 		State:        StateClaim,
@@ -434,7 +434,7 @@ func main() {
 		select {
 		case state := <-builder.StateChannel:
 			if state == StateDone {
-				logrus.Info("main: Shutting down successfully.")
+				logrus.Info("main: Shutting down successfully")
 				os.Exit(ExitOk)
 			}
 		case err := <-errs:

--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	ExitOk int = iota
+)
+
+type State int
+
+const (
+	StateClaim State = iota
+	StateProvision
+	StatePopulate
+	StateBuild
+	StateProgress
+	StateExport
+	StateDone
+
+	StateError
+	StateSignal
+	StateTimeout
+)
+
+var (
+	argJSON bool
+
+	argBuilderHost string
+	argBuilderPort int
+
+	argTimeoutClaim     int
+	argTimeoutProvision int
+	argTimeoutPopulate  int
+	argTimeoutBuild     int
+	argTimeoutExport    int
+
+	argBuildPath string
+)
+
+type BuildRequest struct {
+	Pipelines    []string `json:"pipelines"`
+	Environments []string `json:"environments"`
+}
+
+func init() {
+	flag.BoolVar(&argJSON, "json", false, "Enable JSON output")
+
+	flag.StringVar(&argBuilderHost, "builder-host", "localhost", "Hostname or IP where this program will listen on.")
+	flag.IntVar(&argBuilderPort, "builder-port", 3333, "Port this program will listen on.")
+
+	flag.IntVar(&argTimeoutClaim, "timeout-claim", 600, "Timeout before the claim phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutProvision, "timeout-provision", 30, "Timeout before the provision phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutPopulate, "timeout-populate", 30, "Timeout before the populate phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutBuild, "timeout-build", 3600, "Timeout before the build phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutExport, "timeout-export", 1800, "Timeout before the export phase needs to be completed in seconds.")
+
+	flag.StringVar(&argBuildPath, "build-path", "/run/osbuild", "Path to use as a build directory.")
+
+	flag.Parse()
+
+	logrus.SetLevel(logrus.InfoLevel)
+
+	if argJSON {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	}
+}
+
+type Agent struct {
+	Host         string
+	Port         int
+	State        State
+	StateLock    sync.Mutex
+	StateChannel chan State
+}
+
+type BackgroundProcess struct {
+	Process *exec.Cmd
+	Stdout  io.ReadCloser
+	Stderr  io.ReadCloser
+	Done    bool
+	Error   error
+}
+
+var (
+	Build *BackgroundProcess
+)
+
+func (agent *Agent) SetState(state State) {
+	agent.StateLock.Lock()
+	defer agent.StateLock.Unlock()
+
+	if state <= agent.State {
+		agent.State = StateError
+	} else {
+		agent.State = state
+	}
+
+	agent.StateChannel <- agent.State
+}
+
+func (agent *Agent) GetState() State {
+	agent.StateLock.Lock()
+	defer agent.StateLock.Unlock()
+
+	return agent.State
+}
+
+func (agent *Agent) GuardState(stateWanted State) {
+	if stateCurrent := agent.GetState(); stateWanted != stateCurrent {
+		logrus.Fatalf("Agent.GuardState: Requested guard for %d but we're in %d. Exit.", stateWanted, stateCurrent)
+	}
+}
+
+func (agent *Agent) HandleClaim(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StateClaim)
+
+	if r.Method != "POST" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandleClaim: unexpected request method")
+	}
+
+	fmt.Fprintf(w, "%s", "done")
+
+	logrus.Info("Agent.HandleClaim: Done.")
+
+	agent.SetState(StateProvision)
+}
+
+func (agent *Agent) HandleProvision(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StateProvision)
+
+	if r.Method != "PUT" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandleProvision: Unexpected request method.")
+	}
+
+	logrus.WithFields(logrus.Fields{"argBuildPath": argBuildPath}).Debug("Agent.HandleProvision: Opening manifest.json.")
+
+	dst, err := os.OpenFile(
+		path.Join(argBuildPath, "manifest.json"),
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		0400,
+	)
+	defer dst.Close()
+
+	if err != nil {
+		logrus.Fatal("Agent.HandleProvision: Failed to open manifest.json.")
+	}
+
+	logrus.Debug("Agent.HandleProvision: Writing manifest.json.")
+
+	_, err = io.Copy(dst, r.Body)
+
+	if err != nil {
+		logrus.Fatal("Agent.HandleProvision: Failed to write manifest.json.")
+	}
+
+	w.WriteHeader(http.StatusCreated)
+
+	if _, err := w.Write([]byte(`done`)); err != nil {
+		logrus.Fatal("Agent.HandleProvision: Failed to write response.")
+	}
+
+	logrus.Info("Agent.HandleProvision: Done.")
+
+	agent.SetState(StatePopulate)
+}
+
+func (agent *Agent) HandlePopulate(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StatePopulate)
+
+	if r.Method != "POST" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandlePopulate: unexpected request method")
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write([]byte(`done`)); err != nil {
+		logrus.Fatal("Agent.HandlePopulate: Failed to write response.")
+	}
+
+	logrus.Info("Agent.HandlePopulate: Done.")
+
+	agent.SetState(StateBuild)
+}
+
+func (agent *Agent) HandleBuild(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StateBuild)
+
+	if r.Method != "POST" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandleBuild: Unexpected request method.")
+	}
+
+	var buildRequest BuildRequest
+
+	var err error
+
+	if err = json.NewDecoder(r.Body).Decode(&buildRequest); err != nil {
+		logrus.Fatal("HandleBuild: Failed to decode body.")
+	}
+
+	if Build != nil {
+		logrus.Fatal("HandleBuild: Build started but Build was non-nil.")
+	}
+
+	args := []string{
+		"--store", path.Join(argBuildPath, "store"),
+		"--cache-max-size", "unlimited",
+		"--checkpoint", "*",
+		"--output-directory", path.Join(argBuildPath, "export"),
+	}
+
+	for _, pipeline := range buildRequest.Pipelines {
+		args = append(args, "--export")
+		args = append(args, pipeline)
+	}
+
+	args = append(args, path.Join(argBuildPath, "manifest.json"))
+
+	envs := os.Environ()
+	envs = append(envs, buildRequest.Environments...)
+
+	Build = &BackgroundProcess{}
+	Build.Process = exec.Command(
+		"/usr/bin/osbuild",
+		args...,
+	)
+	Build.Process.Env = envs
+
+	logrus.Infof("BackgroundProcess: Starting %s with %s", Build.Process, envs)
+
+	Build.Stdout, err = Build.Process.StdoutPipe()
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	Build.Stderr, err = Build.Process.StderrPipe()
+
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	if err := Build.Process.Start(); err != nil {
+		logrus.Fatal("BackgroundProcess: Failed to start process.")
+	}
+
+	go func() {
+		Build.Error = Build.Process.Wait()
+		Build.Done = true
+
+		logrus.Info("BackgroundProcess: Exited.")
+	}()
+
+	go func() {
+		scanner := bufio.NewScanner(Build.Stdout)
+		for scanner.Scan() {
+			m := scanner.Text()
+			logrus.Infof("BackgroundProcess: Stdout: %s", m)
+		}
+	}()
+
+	go func() {
+		scanner := bufio.NewScanner(Build.Stderr)
+		for scanner.Scan() {
+			m := scanner.Text()
+			logrus.Infof("BackgroundProcess: Stderr: %s", m)
+		}
+	}()
+
+	w.WriteHeader(http.StatusCreated)
+
+	agent.SetState(StateProgress)
+}
+
+func (agent *Agent) HandleProgress(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StateProgress)
+
+	if r.Method != "GET" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandleProgress: Unexpected request method.")
+	}
+
+	if Build == nil {
+		logrus.Fatal("HandleProgress: Progress requested but Build was nil.")
+	}
+
+	if Build.Done {
+		w.WriteHeader(http.StatusOK)
+
+		if Build.Error != nil {
+			logrus.Fatalf("Agent.HandleBuild: Buildprocess exited with error: %s", Build.Error)
+		}
+
+		agent.SetState(StateExport)
+	} else {
+		w.WriteHeader(http.StatusAccepted)
+	}
+
+	if _, err := w.Write([]byte(`done`)); err != nil {
+		logrus.Fatal("Agent.HandleBuild: Failed to write response.")
+	}
+
+	logrus.Info("Agent.HandleBuild: Done.")
+}
+
+func (agent *Agent) HandleExport(w http.ResponseWriter, r *http.Request) {
+	agent.GuardState(StateExport)
+
+	if r.Method != "GET" {
+		logrus.WithFields(
+			logrus.Fields{"method": r.Method},
+		).Fatal("Agent.HandleExport: unexpected request method")
+	}
+
+	exportPath := r.URL.Query().Get("path")
+
+	if exportPath == "" {
+		logrus.Fatal("Agent.HandleExport: Missing export.")
+	}
+
+	// XXX check subdir
+	srcPath := path.Join(argBuildPath, "export", exportPath)
+
+	src, err := os.Open(
+		srcPath,
+	)
+
+	if err != nil {
+		logrus.Fatalf("Agent.HandleExport: Failed to open source: %s.", err)
+	}
+
+	_, err = io.Copy(w, src)
+
+	if err != nil {
+		logrus.Fatalf("Agent.HandleExport: Failed to write response: %s.", err)
+	}
+
+	logrus.Info("Agent.HandleExport: Done.")
+
+	agent.SetState(StateDone)
+}
+
+func (agent *Agent) Serve() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/claim", agent.HandleClaim)
+
+	mux.HandleFunc("/provision", agent.HandleProvision)
+	mux.HandleFunc("/populate", agent.HandlePopulate)
+
+	mux.HandleFunc("/build", agent.HandleBuild)
+	mux.HandleFunc("/progress", agent.HandleProgress)
+
+	mux.HandleFunc("/export", agent.HandleExport)
+
+	net := &http.Server{
+		ReadTimeout:       1 * time.Second,
+		WriteTimeout:      1800 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 1 * time.Second,
+		Addr:              fmt.Sprintf("%s:%d", agent.Host, agent.Port),
+		Handler:           mux,
+	}
+
+	return net.ListenAndServe()
+}
+
+func main() {
+	logrus.WithFields(
+		logrus.Fields{
+			"argJSON":             argJSON,
+			"argBuilderHost":      argBuilderHost,
+			"argBuilderPort":      argBuilderPort,
+			"argTimeoutClaim":     argTimeoutClaim,
+			"argTimeoutProvision": argTimeoutProvision,
+			"argTimeoutBuild":     argTimeoutBuild,
+			"argTimeoutExport":    argTimeoutExport,
+		}).Info("main: startup")
+
+	agent := Agent{
+		State:        StateClaim,
+		StateChannel: make(chan State, 16),
+		Host:         argBuilderHost,
+		Port:         argBuilderPort,
+	}
+	go agent.Serve()
+
+	for state := range agent.StateChannel {
+		if state == StateDone {
+			logrus.Info("main: Shutdown.")
+			os.Exit(ExitOk)
+		}
+	}
+}

--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -153,7 +153,7 @@ func (agent *Agent) HandleClaim(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (agent *Agent) HandleProvision(w http.ResponseWriter, r *http.Request) error {
+func (agent *Agent) HandleProvision(w http.ResponseWriter, r *http.Request) (err error) {
 	agent.GuardState(StateProvision)
 
 	if r.Method != "PUT" {
@@ -167,7 +167,12 @@ func (agent *Agent) HandleProvision(w http.ResponseWriter, r *http.Request) erro
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
 		0400,
 	)
-	defer dst.Close()
+
+	defer func() {
+		if cerr := dst.Close(); cerr != nil {
+			err = cerr
+		}
+	}()
 
 	if err != nil {
 		return fmt.Errorf("Agent.HandleProvision: Failed to open manifest.json.")

--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -240,8 +240,7 @@ func (builder *Builder) HandleBuild(w http.ResponseWriter, r *http.Request) erro
 
 	args := []string{
 		"--store", path.Join(argBuildPath, "store"),
-		"--cache-max-size", "unlimited",
-		"--checkpoint", "*",
+		"--cache-max-size", "0",
 		"--output-directory", path.Join(argBuildPath, "export"),
 	}
 

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -97,7 +97,7 @@ func init() {
 }
 
 func main() {
-	logrus.Info("main: Starting up.")
+	logrus.Info("main: Starting up")
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -113,16 +113,16 @@ func main() {
 			logrus.WithFields(
 				logrus.Fields{
 					"signal": sig,
-				}).Info("main: Exiting on signal.")
+				}).Info("main: Exiting on signal")
 			os.Exit(ExitSignal)
 		case err := <-errs:
 			logrus.WithFields(
 				logrus.Fields{
 					"error": err,
-				}).Info("main: Exiting on error.")
+				}).Info("main: Exiting on error")
 			os.Exit(ExitError)
 		case <-done:
-			logrus.Info("main: Shutting down succesfully.")
+			logrus.Info("main: Shutting down succesfully")
 			os.Exit(ExitOk)
 		}
 	}
@@ -179,7 +179,7 @@ func Request(method string, path string, body []byte) (*http.Response, error) {
 		return nil, err
 	}
 
-	logrus.Debugf("Request: Making a %s request to %s.", method, url)
+	logrus.Debugf("Request: Making a %s request to %s", method, url)
 
 	for {
 		res, err := cli.Do(req)
@@ -225,11 +225,11 @@ func StepClaim() error {
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			errs <- fmt.Errorf("StepClaim: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+			errs <- fmt.Errorf("StepClaim: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusOK)
 			return
 		}
 
-		logrus.Info("StepClaim: Done.")
+		logrus.Info("StepClaim: Done")
 
 		close(done)
 	})
@@ -247,11 +247,11 @@ func StepProvision(manifest []byte) error {
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusCreated {
-			errs <- fmt.Errorf("StepProvision: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusCreated)
+			errs <- fmt.Errorf("StepProvision: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusCreated)
 			return
 		}
 
-		logrus.Info("StepProvision: Done.")
+		logrus.Info("StepProvision: Done")
 
 		close(done)
 	})
@@ -269,11 +269,11 @@ func StepPopulate() error {
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusOK {
-			errs <- fmt.Errorf("StepPopulate: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+			errs <- fmt.Errorf("StepPopulate: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusOK)
 			return
 		}
 
-		logrus.Info("StepPopulate: Done.")
+		logrus.Info("StepPopulate: Done")
 
 		close(done)
 	})
@@ -302,11 +302,11 @@ func StepBuild() error {
 		defer res.Body.Close()
 
 		if res.StatusCode != http.StatusCreated {
-			errs <- fmt.Errorf("StepBuild: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+			errs <- fmt.Errorf("StepBuild: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusOK)
 			return
 		}
 
-		logrus.Info("StepBuild: Done.")
+		logrus.Info("StepBuild: Done")
 
 		close(done)
 	})
@@ -325,20 +325,20 @@ func StepProgress() error {
 			defer res.Body.Close()
 
 			if res.StatusCode == http.StatusAccepted {
-				logrus.Info("StepProgress: Build is pending. Retry.")
+				logrus.Info("StepProgress: Build is pending. Retry")
 				time.Sleep(5 * time.Second)
 				continue
 			}
 
 			if res.StatusCode != http.StatusOK {
-				errs <- fmt.Errorf("StepProgress: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+				errs <- fmt.Errorf("StepProgress: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusOK)
 				return
 			}
 
 			break
 		}
 
-		logrus.Info("StepProgress: Done.")
+		logrus.Info("StepProgress: Done")
 
 		close(done)
 	})
@@ -357,7 +357,7 @@ func StepExport() error {
 			defer res.Body.Close()
 
 			if res.StatusCode != http.StatusOK {
-				errs <- fmt.Errorf("StepExport: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+				errs <- fmt.Errorf("StepExport: Got an unexpected response %d while expecting %d. Exiting", res.StatusCode, http.StatusOK)
 				return
 			}
 
@@ -368,19 +368,19 @@ func StepExport() error {
 			)
 
 			if err != nil {
-				errs <- fmt.Errorf("StepExport: Failed to open destination response: %s.", err)
+				errs <- fmt.Errorf("StepExport: Failed to open destination response: %s", err)
 				return
 			}
 
 			_, err = io.Copy(dst, res.Body)
 
 			if err != nil {
-				errs <- fmt.Errorf("StepExport: Failed to copy response: %s.", err)
+				errs <- fmt.Errorf("StepExport: Failed to copy response: %s", err)
 				return
 			}
 		}
 
-		logrus.Info("StepExport: Done.")
+		logrus.Info("StepExport: Done")
 
 		close(done)
 	})

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -1,0 +1,387 @@
+// # `jobsite-manager`
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"path"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	ExitOk int = iota
+	ExitError
+	ExitTimeout
+	ExitSignal
+)
+
+type ArgumentList []string
+
+func (AL *ArgumentList) String() string {
+	return ""
+}
+
+func (AL *ArgumentList) Set(value string) error {
+	*AL = append(*AL, value)
+	return nil
+}
+
+var (
+	argJSON bool
+
+	argJobsiteHost string
+	argJobsitePort int
+	argBuilderHost string
+	argBuilderPort int
+
+	argTimeoutClaim     int
+	argTimeoutProvision int
+	argTimeoutPopulate  int
+	argTimeoutBuild     int
+	argTimeoutProgress  int
+	argTimeoutExport    int
+
+	argPipelines    ArgumentList
+	argEnvironments ArgumentList
+	argExports      ArgumentList
+	argOutputPath   string
+)
+
+type BuildRequest struct {
+	Pipelines    []string `json:"pipelines"`
+	Environments []string `json:"environments"`
+}
+
+type Step func(chan<- struct{}, chan<- error)
+
+func init() {
+	flag.BoolVar(&argJSON, "json", false, "Enable JSON output")
+
+	flag.StringVar(&argJobsiteHost, "manager-host", "localhost", "Hostname or IP where this program will listen on.")
+	flag.IntVar(&argJobsitePort, "manager-port", 3333, "Port this program will listen on.")
+
+	flag.StringVar(&argBuilderHost, "builder-host", "localhost", "Hostname or IP of a jobsite-builder that this program will connect to.")
+	flag.IntVar(&argBuilderPort, "builder-port", 3333, "Port of a jobsite-builder that this program will connect to.")
+
+	flag.IntVar(&argTimeoutClaim, "timeout-claim", 600, "Timeout before the claim phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutProvision, "timeout-provision", 30, "Timeout before the provision phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutPopulate, "timeout-populate", 30, "Timeout before the populate phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutBuild, "timeout-build", 30, "Timeout before the build phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutProgress, "timeout-progress", 3600, "Timeout before the progress phase needs to be completed in seconds.")
+	flag.IntVar(&argTimeoutExport, "timeout-export", 1800, "Timeout before the export phase needs to be completed in seconds.")
+
+	flag.Var(&argPipelines, "pipeline", "Pipelines to export. Can be passed multiple times.")
+	flag.Var(&argEnvironments, "environment", "Environments to add. Can be passed multiple times.")
+	flag.Var(&argExports, "export", "Files to export. Can be passed multiple times.")
+	flag.StringVar(&argOutputPath, "output", "/dev/null", "Output directory to write to.")
+
+	flag.Parse()
+
+	logrus.SetLevel(logrus.InfoLevel)
+
+	if argJSON {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	}
+}
+
+func main() {
+	logrus.Info("main: Starting up.")
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	done := make(chan struct{}, 1)
+	errs := make(chan error, 1)
+
+	go Dance(done, errs)
+
+	for {
+		select {
+		case sig := <-sigs:
+			logrus.WithFields(
+				logrus.Fields{
+					"signal": sig,
+				}).Info("main: Exiting on signal.")
+			os.Exit(ExitSignal)
+		case err := <-errs:
+			logrus.WithFields(
+				logrus.Fields{
+					"error": err,
+				}).Info("main: Exiting on error.")
+			os.Exit(ExitError)
+		case <-done:
+			logrus.Info("main: Shutting down succesfully.")
+			os.Exit(ExitOk)
+		}
+	}
+}
+
+func Dance(done chan<- struct{}, errs chan<- error) {
+	manifest, err := io.ReadAll(os.Stdin)
+
+	if err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepClaim(); err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepProvision(manifest); err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepPopulate(); err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepBuild(); err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepProgress(); err != nil {
+		errs <- err
+		return
+	}
+
+	if err := StepExport(); err != nil {
+		errs <- err
+		return
+	}
+
+	close(done)
+}
+
+func Request(method string, path string, body []byte) (*http.Response, error) {
+	cli := &http.Client{}
+	url := fmt.Sprintf("http://%s:%d/%s", argBuilderHost, argBuilderPort, path)
+
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("Request: Making a %s request to %s.", method, url)
+
+	res, err := cli.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func Wait(timeout int, fn Step) error {
+	done := make(chan struct{}, 1)
+	errs := make(chan error, 1)
+
+	go fn(done, errs)
+
+	select {
+	case <-time.After(time.Duration(timeout) * time.Second):
+		return fmt.Errorf("timeout")
+	case <-done:
+		return nil
+	case err := <-errs:
+		return err
+	}
+}
+
+func StepClaim() error {
+	return Wait(argTimeoutClaim, func(done chan<- struct{}, errs chan<- error) {
+		for {
+			res, err := Request("POST", "claim", []byte(""))
+
+			if err != nil {
+				if errors.Is(err, syscall.ECONNREFUSED) {
+					logrus.Info("StepClaim: Got ECONNREFUSED, the builder is likely not yet up. Retry.")
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				errs <- err
+				return
+			}
+
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("StepClaim: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+				return
+			}
+
+			break
+		}
+
+		logrus.Info("StepClaim: Done.")
+
+		close(done)
+	})
+}
+
+func StepProvision(manifest []byte) error {
+	return Wait(argTimeoutProvision, func(done chan<- struct{}, errs chan<- error) {
+		res, err := Request("PUT", "provision", manifest)
+
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			errs <- fmt.Errorf("StepProvision: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusCreated)
+			return
+		}
+
+		logrus.Info("StepProvision: Done.")
+
+		close(done)
+	})
+}
+
+func StepPopulate() error {
+	return Wait(argTimeoutPopulate, func(done chan<- struct{}, errs chan<- error) {
+		res, err := Request("POST", "populate", []byte(""))
+
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			errs <- fmt.Errorf("StepPopulate: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+			return
+		}
+
+		logrus.Info("StepPopulate: Done.")
+
+		close(done)
+	})
+}
+
+func StepBuild() error {
+	return Wait(argTimeoutBuild, func(done chan<- struct{}, errs chan<- error) {
+		arg := BuildRequest{
+			Pipelines:    argPipelines,
+			Environments: argEnvironments,
+		}
+
+		dat, err := json.Marshal(arg)
+
+		if err != nil {
+			logrus.Fatalf("StepBuild: Failed to marshal data: %s", err)
+		}
+
+		res, err := Request("POST", "build", dat)
+
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusCreated {
+			errs <- fmt.Errorf("StepBuild: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+			return
+		}
+
+		logrus.Info("StepBuild: Done.")
+
+		close(done)
+	})
+}
+
+func StepProgress() error {
+	return Wait(argTimeoutProgress, func(done chan<- struct{}, errs chan<- error) {
+		for {
+			res, err := Request("GET", "progress", []byte(""))
+
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			defer res.Body.Close()
+
+			if res.StatusCode == http.StatusAccepted {
+				logrus.Info("StepProgress: Build is pending. Retry.")
+				time.Sleep(5 * time.Second)
+				continue
+			}
+
+			if res.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("StepProgress: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+				return
+			}
+
+			break
+		}
+
+		logrus.Info("StepProgress: Done.")
+
+		close(done)
+	})
+}
+
+func StepExport() error {
+	return Wait(argTimeoutExport, func(done chan<- struct{}, errs chan<- error) {
+		for _, export := range argExports {
+			res, err := Request("GET", fmt.Sprintf("export?path=%s", export), []byte(""))
+
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			defer res.Body.Close()
+
+			if res.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("StepExport: Got an unexpected response %d while expecting %d. Exiting.", res.StatusCode, http.StatusOK)
+				return
+			}
+
+			dst, err := os.OpenFile(
+				path.Join(argOutputPath, export),
+				os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+				0400,
+			)
+
+			if err != nil {
+				errs <- fmt.Errorf("StepExport: Failed to open destination response: %s.", err)
+				return
+			}
+
+			_, err = io.Copy(dst, res.Body)
+
+			if err != nil {
+				errs <- fmt.Errorf("StepExport: Failed to copy response: %s.", err)
+				return
+			}
+		}
+
+		logrus.Info("StepExport: Done.")
+
+		close(done)
+	})
+}

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -81,9 +81,10 @@ func init() {
 	flag.IntVar(&argTimeoutProgress, "timeout-progress", 3600, "Timeout before the progress phase needs to be completed in seconds.")
 	flag.IntVar(&argTimeoutExport, "timeout-export", 1800, "Timeout before the export phase needs to be completed in seconds.")
 
-	flag.Var(&argPipelines, "pipeline", "Pipelines to export. Can be passed multiple times.")
+	flag.Var(&argPipelines, "export", "Pipelines to export. Can be passed multiple times.")
+	flag.Var(&argExports, "export-file", "Files to export. Can be passed multiple times.")
+
 	flag.Var(&argEnvironments, "environment", "Environments to add. Can be passed multiple times.")
-	flag.Var(&argExports, "export", "Files to export. Can be passed multiple times.")
 	flag.StringVar(&argOutputPath, "output", "/dev/null", "Output directory to write to.")
 
 	flag.Parse()

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path"
@@ -347,7 +348,7 @@ func StepProgress() error {
 func StepExport() error {
 	return Wait(argTimeoutExport, func(done chan<- struct{}, errs chan<- error) {
 		for _, export := range argExports {
-			res, err := Request("GET", fmt.Sprintf("export?path=%s", export), []byte(""))
+			res, err := Request("GET", fmt.Sprintf("export?path=%s", url.PathEscape(export)), []byte(""))
 
 			if err != nil {
 				errs <- err

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -103,6 +103,8 @@ export LDFLAGS="${LDFLAGS} -X 'github.com/osbuild/osbuild-composer/internal/comm
 
 %gobuild ${GOTAGS:+-tags=$GOTAGS} -o _bin/osbuild-composer %{goipath}/cmd/osbuild-composer
 %gobuild ${GOTAGS:+-tags=$GOTAGS} -o _bin/osbuild-worker %{goipath}/cmd/osbuild-worker
+%gobuild ${GOTAGS:+-tags=$GOTAGS} -o _bin/osbuild-jobsite-manager %{goipath}/cmd/osbuild-jobsite-manager
+%gobuild ${GOTAGS:+-tags=$GOTAGS} -o _bin/osbuild-jobsite-builder %{goipath}/cmd/osbuild-jobsite-builder
 
 make man
 
@@ -137,6 +139,8 @@ go build -tags="integration${GOTAGS:+,$GOTAGS}" -ldflags="${TEST_LDFLAGS}" -o _b
 install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/osbuild-composer
 install -m 0755 -vp _bin/osbuild-composer                          %{buildroot}%{_libexecdir}/osbuild-composer/
 install -m 0755 -vp _bin/osbuild-worker                            %{buildroot}%{_libexecdir}/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-jobsite-manager                   %{buildroot}%{_libexecdir}/osbuild-composer/
+install -m 0755 -vp _bin/osbuild-jobsite-builder                   %{buildroot}%{_libexecdir}/osbuild-composer/
 install -m 0755 -vp dnf-json                                       %{buildroot}%{_libexecdir}/osbuild-composer/
 
 # Only include repositories for the distribution and release
@@ -318,6 +322,8 @@ The worker for osbuild-composer
 
 %files worker
 %{_libexecdir}/osbuild-composer/osbuild-worker
+%{_libexecdir}/osbuild-composer/osbuild-jobsite-manager
+%{_libexecdir}/osbuild-composer/osbuild-jobsite-builder
 %{_unitdir}/osbuild-worker@.service
 %{_unitdir}/osbuild-remote-worker@.service
 


### PR DESCRIPTION
WIP, commit messages are not yet complete; TODO below.

Has to be done:


- [ ] Check subdir for export on `builder` side.
- [ ] Comments and documentation (a README probably).
- [ ] Some simple tests.
- [x] CI linters need offerings.
- [x] Add new binaries to RPM spec.
- [x] Disable caching on the builder for osbuild.
- [x] Retry HTTP requests on network errors (but not HTTP errors).

Can be followup:

- [ ] Logs need to be sent over in the `/progress` endpoint on the `builder` and handled in the `manager`.
- [ ] Defining JSON responses for all the routes in the `builder`.
- [ ] Only one export is allowed.
- [ ] How to handle the exports, currently both `-pipeline` and `-export` have to be defined and it feels very awkward?

This PR implements a new concept in `osbuild-composer`: the `jobsite`. The `jobsite` is an isolated set of services to run builds in. They can be separated from the rest of the system through network segmentation or other means. The `jobsite` and what's in it are only available to things inside it. One `jobsite` is used for each build, after which all resources used in it are removed again.

In the case of `osbuild-composer` the worker can set up a network, start a separate virtual machine containing the `builder` and then spawn the `manager` to point at it.

This implements the `jobsite-manager` and `jobsite-builder`. The `builder` is a thin wrapper around `osbuild` itself, it takes in a manifest; build options and allows to exports things.

The `manager` is responsible for sending the manifest and retrieving exports from the `builder`.

Because these commands are potentially running in untrusted environments they are quite picky about what they accept. Both will exit on any kind of error. The `builder` can only be used in the correct order, any out-of-order access will terminate the `builder`. This pickiness extends to file paths not existing or already existing when they're not expected to exist.

## Steps

The `manager` and `builder` know a concept of "states". These are the steps that they both go through in lockstep. The steps are:

1. claim
2. provision
3. populate
4. build
5. progress
6. export

During the **claim**-step the `manager` takes ownership of the `builder`, this is currently a no-op but can contain some jobsite-lifetime secrets. After this the `manager` sends the manifest to the `builder` in the **provision** step. In the **populate** step the `manager` can send any required sources and other inputs to the `builder`, this is currently a no-op but something we want to do soon. The `manager` then instructs the `builder` to start through the **build** step, where it also tells the `builder` what things to export and some other tidbits related to the build.

The `manager` can now start polling the **progress** step. This endpoint will contain logs and progress information as it becomes available during build. Once the **progress** is done we transition into the **export** step where the `manager` retrieves the built artifacts from the `builder`. When this is done both exit and the jobsite can be torn down.