### PR TITLE
store: add ID to the source config

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -58,6 +58,7 @@ type Store struct {
 
 type SourceConfig struct {
 	Name           string   `json:"name" toml:"name"`
+	ID             string   `json:"id" toml:"id"`
 	Type           string   `json:"type" toml:"type"`
 	URL            string   `json:"url" toml:"url"`
 	CheckGPG       bool     `json:"check_gpg" toml:"check_gpg"`


### PR DESCRIPTION
Customers expect the source object to include the id of the source and not just the name.

See: https://issues.redhat.com/browse/RHEL-18034