### PR TITLE
worker-executor followups: fix oneshot service and secure instance for non-default vpcs

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -73,6 +73,37 @@ func (a *AWS) RunSecureInstance(iamProfile string) (*SecureInstance, error) {
 		return nil, err
 	}
 
+	descrSubnetsOutput, err := a.ec2.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(vpcID),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(descrSubnetsOutput.Subnets) == 0 {
+		return nil, fmt.Errorf("Expected at least 1 subnet in the VPC, got 0")
+	}
+
+	// For creating a fleet in a non-default VPC, AWS needs the subnets, and at most 1 subnet per AZ.
+	// If a VPC has multiple subnets for a single AZ, only pick the first one.
+	overrides := []*ec2.FleetLaunchTemplateOverridesRequest{}
+	availZones := map[string]struct{}{}
+	for _, subnet := range descrSubnetsOutput.Subnets {
+		az := *subnet.AvailabilityZone
+		if _, ok := availZones[az]; !ok {
+			overrides = append(overrides, &ec2.FleetLaunchTemplateOverridesRequest{
+				SubnetId: subnet.SubnetId,
+			})
+			availZones[az] = struct{}{}
+		}
+	}
+
 	createFleetOutput, err := a.ec2.CreateFleet(&ec2.CreateFleetInput{
 		LaunchTemplateConfigs: []*ec2.FleetLaunchTemplateConfigRequest{
 			&ec2.FleetLaunchTemplateConfigRequest{
@@ -80,6 +111,7 @@ func (a *AWS) RunSecureInstance(iamProfile string) (*SecureInstance, error) {
 					LaunchTemplateId: aws.String(secureInstance.LTID),
 					Version:          aws.String("1"),
 				},
+				Overrides: overrides,
 			},
 		},
 		TagSpecifications: []*ec2.TagSpecification{

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-/usr/local/bin/aws secretsmanager get-secret-value \
-  --secret-id executor-subscription-manager-command | jq -r ".SecretString" > /tmp/subscription_manager_command.json
-jq -r ".subscription_manager_command" /tmp/subscription_manager_command.json | bash
-rm -f /tmp/subscription_manager_command.json
+# Don't subscribe on fedora
+source /etc/os-release
+if [ "$ID" != fedora ]; then
+  /usr/local/bin/aws secretsmanager get-secret-value \
+    --secret-id executor-subscription-manager-command | jq -r ".SecretString" > /tmp/subscription_manager_command.json
+  jq -r ".subscription_manager_command" /tmp/subscription_manager_command.json | bash
+  rm -f /tmp/subscription_manager_command.json
+fi
 
 echo "Starting osbuild-jobsite-builder."
 /usr/libexec/osbuild-composer/osbuild-jobsite-builder

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -19,7 +19,6 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/get_koji_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_oci_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_pulp_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
-ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_builder.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
+++ b/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
@@ -24,3 +24,13 @@
   with_fileglob:
     - "{{ playbook_dir }}/roles/common/files/worker-initialization-scripts/*"
 
+- name: Copy worker executor service
+  copy:
+    src: "{{ playbook_dir }}/roles/common/files/worker-executor.service"
+    dest: /etc/systemd/system/
+
+- name: Enable worker executor service
+  systemd:
+    name: worker-executor.service
+    enabled: yes
+    daemon_reload: yes


### PR DESCRIPTION
 cloud/awscloud: specify subnets when creating secure instance
    
 For non-default VPCs, AWS needs the subnets it can launch the instance
 in, otherwise it will try to launch the instance in the default VPC,
 even if the supplied security groups are attached to a non-default VPC.
    
 Furthermore there can only be 1 subnet specified per availability zone,
 so query the subnets in the VPC of the host (as the instance needs to be
 launched in the same network), and pick 1 of the VPC's subnets per AZ.
