### PR TITLE
cloud/awscloud: max 4 overrides are allowed when creating a fleet

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -102,6 +102,10 @@ func (a *AWS) RunSecureInstance(iamProfile string) (*SecureInstance, error) {
 			})
 			availZones[az] = struct{}{}
 		}
+		// A maximum of 4 overrides are allowed
+		if len(overrides) == 4 {
+			break
+		}
 	}
 
 	createFleetOutput, err := a.ec2.CreateFleet(&ec2.CreateFleetInput{


### PR DESCRIPTION
```
InvalidParameterValue: Your request contains more than the maximum allowed number of InstanceRequirements (4)
```