### PR TITLE
templates/packer: set -builder-path to /var/cache/osbuild-builder

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -11,4 +11,5 @@ if [ "$ID" != fedora ]; then
 fi
 
 echo "Starting osbuild-jobsite-builder."
-/usr/libexec/osbuild-composer/osbuild-jobsite-builder -builder-host 0.0.0.0
+mkdir -p /var/cache/osbuild-builder
+/usr/libexec/osbuild-composer/osbuild-jobsite-builder -builder-host 0.0.0.0 -build-path /var/cache/osbuild-builder


### PR DESCRIPTION
The builder uses `/run/osbuild` as a default path for this argument. Yet this directory doesn't exist when the builder writes the manifest. But osbuild should own this directory, not the builder.

Furthermore `/run` is a tmpfs, so the executor might run into memory issues if we use `/run` as the store and output directory (on the "host" workers these are in `/var/cache`).

While `/tmp` might seem like a good candidate on RHEL, it's a tmpfs on Fedora, so it's also to be avoided.

