### PR TITLE
cmd/osbuild-jobsite: capture osbuild's stdout

### DIFF
--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -335,6 +335,11 @@ func StepProgress() error {
 				return
 			}
 
+			_, err = io.Copy(os.Stdout, res.Body)
+			if err != nil {
+				errs <- fmt.Errorf("StepProgress: Unable to write response body to stdout: %v", err)
+			}
+
 			break
 		}
 


### PR DESCRIPTION
Write osbuild's stdout in the progress step. The manager can just copy it to stdout and the executor will be able to parse the output into an osbuild result.

