### PR TITLE
templates/packer: rename executor log group

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -25,7 +25,7 @@ type = "aws_cloudwatch_logs"
 inputs = [ "journald" ]
 region = "${REGION}"
 endpoint = "${CLOUDWATCH_ENDPOINT}"
-group_name = "osbuild-executor"
+group_name = "osbuild-executor-log-group"
 stream_name = "osbuild_executor_syslog_${HOSTNAME}"
 encoding.codec = "json"
 EOF


### PR DESCRIPTION
In app-interface the output resource names need to be unique, and the log group name is already shared with the role.

