### PR TITLE
RHEL-16006: improve error on missing package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 /rpmbuild
 
 /tools/appsre-ansible/inventory
+
+/docs/osbuild-composer.7

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,6 @@ worker-key-pair: ca
 .PHONY: unit-tests
 unit-tests:
 	go test -race ./...
-	go test -race ./internal/dnfjson/... -force-dnf
 
 #
 # Building packages

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ help:
 	@echo "targets are available:"
 	@echo
 	@echo "    help:               Print this usage information."
+	@echo "    build:              Build all binaries"
+	@echo "    clean:              Remove all built binaries"
 	@echo "    man:                Generate all man-pages"
 	@echo "    unit-tests:         Run unit tests"
 
@@ -108,31 +110,30 @@ man: $(MANPAGES_TROFF)
 #
 
 .PHONY: build
-build:
-	- mkdir -p bin
-	go build -o bin/osbuild-composer ./cmd/osbuild-composer/
-	go build -o bin/osbuild-worker ./cmd/osbuild-worker/
-	go build -o bin/osbuild-upload-azure ./cmd/osbuild-upload-azure/
-	go build -o bin/osbuild-upload-aws ./cmd/osbuild-upload-aws/
-	go build -o bin/osbuild-upload-gcp ./cmd/osbuild-upload-gcp/
-	go build -o bin/osbuild-upload-oci ./cmd/osbuild-upload-oci/
-	go build -o bin/osbuild-upload-generic-s3 ./cmd/osbuild-upload-generic-s3/
-	go build -o bin/osbuild-mock-openid-provider ./cmd/osbuild-mock-openid-provider
-	go build -o bin/osbuild-service-maintenance ./cmd/osbuild-service-maintenance
-	go test -c -tags=integration -o bin/osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
-	go test -c -tags=integration -o bin/osbuild-weldr-tests ./internal/client/
-	go test -c -tags=integration -o bin/osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
-	go test -c -tags=integration -o bin/osbuild-image-tests ./cmd/osbuild-image-tests/
-	go test -c -tags=integration -o bin/osbuild-auth-tests ./cmd/osbuild-auth-tests/
-	go test -c -tags=integration -o bin/osbuild-koji-tests ./cmd/osbuild-koji-tests/
-	go test -c -tags=integration -o bin/osbuild-composer-dbjobqueue-tests ./cmd/osbuild-composer-dbjobqueue-tests/
-	go test -c -tags=integration -o bin/osbuild-composer-maintenance-tests ./cmd/osbuild-service-maintenance/
+build: $(BUILDDIR)/bin/
+	go build -o $<osbuild-composer ./cmd/osbuild-composer/
+	go build -o $<osbuild-worker ./cmd/osbuild-worker/
+	go build -o $<osbuild-upload-azure ./cmd/osbuild-upload-azure/
+	go build -o $<osbuild-upload-aws ./cmd/osbuild-upload-aws/
+	go build -o $<osbuild-upload-gcp ./cmd/osbuild-upload-gcp/
+	go build -o $<osbuild-upload-oci ./cmd/osbuild-upload-oci/
+	go build -o $<osbuild-upload-generic-s3 ./cmd/osbuild-upload-generic-s3/
+	go build -o $<osbuild-mock-openid-provider ./cmd/osbuild-mock-openid-provider
+	go build -o $<osbuild-service-maintenance ./cmd/osbuild-service-maintenance
+	go test -c -tags=integration -o $<osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
+	go test -c -tags=integration -o $<osbuild-weldr-tests ./internal/client/
+	go test -c -tags=integration -o $<osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go
+	go test -c -tags=integration -o $<osbuild-image-tests ./cmd/osbuild-image-tests/
+	go test -c -tags=integration -o $<osbuild-auth-tests ./cmd/osbuild-auth-tests/
+	go test -c -tags=integration -o $<osbuild-koji-tests ./cmd/osbuild-koji-tests/
+	go test -c -tags=integration -o $<osbuild-composer-dbjobqueue-tests ./cmd/osbuild-composer-dbjobqueue-tests/
+	go test -c -tags=integration -o $<osbuild-composer-maintenance-tests ./cmd/osbuild-service-maintenance/
 
 .PHONY: install
-install:
+install: build
 	- mkdir -p /usr/libexec/osbuild-composer
-	cp bin/osbuild-composer /usr/libexec/osbuild-composer/
-	cp bin/osbuild-worker /usr/libexec/osbuild-composer/
+	cp $(BUILDDIR)/bin/osbuild-composer /usr/libexec/osbuild-composer/
+	cp $(BUILDDIR)/bin/osbuild-worker /usr/libexec/osbuild-composer/
 	cp dnf-json /usr/libexec/osbuild-composer/
 	- mkdir -p /usr/share/osbuild-composer/repositories
 	cp repositories/* /usr/share/osbuild-composer/repositories
@@ -143,6 +144,10 @@ install:
 	cp distribution/*.service /etc/systemd/system/
 	cp distribution/*.socket /etc/systemd/system/
 	systemctl daemon-reload
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)/bin/
 
 CERT_DIR=/etc/osbuild-composer
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ At build-time, the following software is required:
  * `go >= 1.19`
  * `python-docutils >= 0.13`
  * `krb5-devel` for fedora/rhel or `libkrb5-dev` for debian/ubuntu`
+ * `btrfs-progs-devel` for fedora/rhel or `libbtrfs-dev` for debian/ubuntu
+ * `device-mapper-devel` for fedora/rhel or `libdevmapper-dev` for debian/ubuntu
+ * `gpgme-devel` for fedora/rhel or `libgpgme-dev` for debian/ubuntu
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ The man-pages require `python-docutils` and can be built via:
 make man
 ```
 
+### Run Tests
+
+To run our tests locally just call
+
+```sh
+make unit-tests
+```
+
 ### Repository:
 
  - **web**:   <https://github.com/osbuild/osbuild-composer>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ At build-time, the following software is required:
  * `btrfs-progs-devel` for fedora/rhel or `libbtrfs-dev` for debian/ubuntu
  * `device-mapper-devel` for fedora/rhel or `libdevmapper-dev` for debian/ubuntu
  * `gpgme-devel` for fedora/rhel or `libgpgme-dev` for debian/ubuntu
+ * `rpmdevtools` (only for `make push-check`)
+ * `rpmlint` (only for `make push-check`)
 
 ### Build
 
@@ -86,6 +88,12 @@ To run our tests locally just call
 
 ```sh
 make unit-tests
+```
+
+Before pushing something for a pull request you should run this check to avoid problems with required github actions
+
+```sh
+make push-check
 ```
 
 ### Repository:

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -105,7 +105,7 @@ func (b *Blueprint) Initialize() error {
 		if len(p.Name) == 0 {
 			var errMsg string
 			if len(p.Version) == 0 {
-				errMsg = fmt.Sprintf("Entry #%d has neither version nor name.", i+1)
+				errMsg = fmt.Sprintf("Entry #%d has no name.", i+1)
 			} else {
 				errMsg = fmt.Sprintf("Entry #%d has version '%v' but no name.", i+1, p.Version)
 			}

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -101,13 +101,13 @@ func (b *Blueprint) Initialize() error {
 		return fmt.Errorf("Error hashing passwords: %s", err.Error())
 	}
 
-	for i, p := range b.Packages {
-		if len(p.Name) == 0 {
+	for i, pkg := range b.Packages {
+		if pkg.Name == "" {
 			var errMsg string
-			if len(p.Version) == 0 {
+			if pkg.Version == "" {
 				errMsg = fmt.Sprintf("Entry #%d has no name.", i+1)
 			} else {
-				errMsg = fmt.Sprintf("Entry #%d has version '%v' but no name.", i+1, p.Version)
+				errMsg = fmt.Sprintf("Entry #%d has version '%v' but no name.", i+1, pkg.Version)
 			}
 			return fmt.Errorf("All package entries need to contain the name of the package. %s", errMsg)
 		}

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -101,6 +101,18 @@ func (b *Blueprint) Initialize() error {
 		return fmt.Errorf("Error hashing passwords: %s", err.Error())
 	}
 
+	for i, p := range b.Packages {
+		if len(p.Name) == 0 {
+			var errMsg string
+			if len(p.Version) == 0 {
+				errMsg = fmt.Sprintf("Entry #%d has neither version nor name.", i+1)
+			} else {
+				errMsg = fmt.Sprintf("Entry #%d has version '%v' but no name.", i+1, p.Version)
+			}
+			return fmt.Errorf("All package entries need to contain the name of the package. %s", errMsg)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -1229,3 +1229,56 @@ func TestBlueprintChangeV1(t *testing.T) {
 	require.NotNil(t, bp, "GET blueprint change failed: missing blueprint")
 	assert.Equal(t, bp.Version, "0.0.1")
 }
+
+func TestEmptyPackageNameBlueprintJsonV0(t *testing.T) {
+	bp := `{
+		"name": "test-emptypackage-blueprint-v0",
+		"description": "TestEmptyPackageNameBlueprintV0",
+		"version": "0.0.1",
+		"packages": [{"name": "", "version": "1.32.1"}]
+	}`
+
+	// Push a blueprint
+	resp, err := PostJSONBlueprintV0(testState.socket, bp)
+	require.NoError(t, err, "failed with a client error")
+	require.False(t, resp.Status, "Negative status expected.")
+	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+}
+
+func TestEmptyPackageNameBlueprintV0(t *testing.T) {
+	bp := `name = "EMPTY-PACKAGE-NAME"
+           description = "empty package name"
+           version = "0.0.1"
+           modules = []
+           groups = []
+           distro = "test-distro"
+
+           [[packages]]
+           version = "*"
+           `
+
+	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
+	require.NoError(t, err, "failed with a client error")
+	require.False(t, resp.Status, "Negative status expected.")
+	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+}
+
+func TestEmptyPackageNameAndVersionBlueprintV0(t *testing.T) {
+	bp := `name = "EMPTY-PACKAGE-NAME"
+           description = "empty package name"
+           version = "0.0.1"
+           modules = []
+           groups = []
+           distro = "test-distro"
+
+           [[packages]]
+           `
+
+	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
+	require.NoError(t, err, "failed with a client error")
+	require.False(t, resp.Status, "Negative status expected.")
+	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+}

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -1256,9 +1256,7 @@ func TestEmptyPackageNameBlueprintJsonV0(t *testing.T) {
 		require.NoError(t, err, "failed with a client error")
 		require.False(t, resp.Status, "Negative status expected.")
 		require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-		reasoning := "I expected the error message\n" + expectedErr +
-			"\nnot\n" + resp.Errors[0].String()
-		assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErr), reasoning)
+		require.Equal(t, resp.Errors[0].String(), expectedErr, "Error message shall match exactly")
 	}
 }
 
@@ -1287,8 +1285,6 @@ func TestEmptyPackageNameBlueprintTOMLV0(t *testing.T) {
 		require.NoError(t, err, "failed with a client error")
 		require.False(t, resp.Status, "Negative status expected.")
 		require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-		reasoning := "I expected the error message\n" + expectedErr +
-			"\nnot\n" + resp.Errors[0].String()
-		assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErr), reasoning)
+		require.Equal(t, resp.Errors[0].String(), expectedErr, "Error message shall match exactly")
 	}
 }

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -1231,59 +1231,46 @@ func TestBlueprintChangeV1(t *testing.T) {
 }
 
 func TestEmptyPackageNameBlueprintJsonV0(t *testing.T) {
-	bp := `{
+	for _, packageSnippet := range []string{
+		`"packages": [{"name": "", "version": "*"}]`,
+		`"packages": [{"name": ""}]`,
+	} {
+		bp := `{
 		"name": "test-emptypackage-blueprint-v0",
 		"description": "TestEmptyPackageNameBlueprintV0",
 		"version": "0.0.1",
-		"packages": [{"name": "", "version": "1.32.1"}]
-	}`
+        ` + packageSnippet + `}`
 
-	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
+		expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
 
-	resp, err := PostJSONBlueprintV0(testState.socket, bp)
-	require.NoError(t, err, "failed with a client error")
-	require.False(t, resp.Status, "Negative status expected.")
-	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
-		"\nnot\n" + resp.Errors[0].String()
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
+		resp, err := PostJSONBlueprintV0(testState.socket, bp)
+		require.NoError(t, err, "failed with a client error")
+		require.False(t, resp.Status, "Negative status expected.")
+		require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
+		reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
+			"\nnot\n" + resp.Errors[0].String()
+		assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
+	}
 }
 
-func TestEmptyPackageNameBlueprintV0(t *testing.T) {
-	bp := `name = "EMPTY-PACKAGE-NAME"
+func TestEmptyPackageNameBlueprintTOMLV0(t *testing.T) {
+	for _, packageSnippet := range []string{
+		"[[packages]]\nversion = \"*\"\n",
+		"[[packages]]\n",
+	} {
+		bp := `name = "EMPTY-PACKAGE-NAME"
            description = "empty package name"
            version = "0.0.1"
+           ` + packageSnippet
 
-           [[packages]]
-           version = "*"
-           `
+		expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
 
-	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
-
-	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
-	require.NoError(t, err, "failed with a client error")
-	require.False(t, resp.Status, "Negative status expected.")
-	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
-		"\nnot\n" + resp.Errors[0].String()
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
-}
-
-func TestEmptyPackageNameAndVersionBlueprintV0(t *testing.T) {
-	bp := `name = "EMPTY-PACKAGE-NAME"
-           description = "empty package name"
-           version = "0.0.1"
-
-           [[packages]]
-           `
-
-	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
-
-	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
-	require.NoError(t, err, "failed with a client error")
-	require.False(t, resp.Status, "Negative status expected.")
-	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
-		"\nnot\n" + resp.Errors[0].String()
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
+		resp, err := PostTOMLBlueprintV0(testState.socket, bp)
+		require.NoError(t, err, "failed with a client error")
+		require.False(t, resp.Status, "Negative status expected.")
+		require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
+		reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
+			"\nnot\n" + resp.Errors[0].String()
+		assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
+	}
 }

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -1238,47 +1238,52 @@ func TestEmptyPackageNameBlueprintJsonV0(t *testing.T) {
 		"packages": [{"name": "", "version": "1.32.1"}]
 	}`
 
-	// Push a blueprint
+	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
+
 	resp, err := PostJSONBlueprintV0(testState.socket, bp)
 	require.NoError(t, err, "failed with a client error")
 	require.False(t, resp.Status, "Negative status expected.")
 	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
+		"\nnot\n" + resp.Errors[0].String()
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
 }
 
 func TestEmptyPackageNameBlueprintV0(t *testing.T) {
 	bp := `name = "EMPTY-PACKAGE-NAME"
            description = "empty package name"
            version = "0.0.1"
-           modules = []
-           groups = []
-           distro = "test-distro"
 
            [[packages]]
            version = "*"
            `
 
+	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
+
 	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
 	require.NoError(t, err, "failed with a client error")
 	require.False(t, resp.Status, "Negative status expected.")
 	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
+		"\nnot\n" + resp.Errors[0].String()
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
 }
 
 func TestEmptyPackageNameAndVersionBlueprintV0(t *testing.T) {
 	bp := `name = "EMPTY-PACKAGE-NAME"
            description = "empty package name"
            version = "0.0.1"
-           modules = []
-           groups = []
-           distro = "test-distro"
 
            [[packages]]
            `
+
+	expectedErrorPrefix := "BlueprintsError: All package entries need to contain the name of the package."
 
 	resp, err := PostTOMLBlueprintV0(testState.socket, bp)
 	require.NoError(t, err, "failed with a client error")
 	require.False(t, resp.Status, "Negative status expected.")
 	require.Equal(t, len(resp.Errors), 1, "There should be exactly one error")
-	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), "BlueprintsError"), "I expect a BlueprintsError")
+	reasoning := "I expected an error message starting with\n" + expectedErrorPrefix +
+		"\nnot\n" + resp.Errors[0].String()
+	assert.True(t, strings.HasPrefix(resp.Errors[0].String(), expectedErrorPrefix), reasoning)
 }

--- a/rpmlint.config
+++ b/rpmlint.config
@@ -1,0 +1,3 @@
+# composer-cli is no spelling error
+Filters = ["spelling-error.*'cli'.*"]
+


### PR DESCRIPTION
Improves the error message if a name or (name and version) is missing.

Also introduces a test for this.

This pull request includes:

- [✔] adequate testing for the new functionality or fixed issue
- [✔] adequate documentation informing people about the change such as
  - [✔] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

https://issues.redhat.com/browse/RHEL-16006