### PR TITLE
cloud/awscloud: describe security groups using filters

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -201,8 +201,13 @@ func isInvalidGroupNotFoundErr(err error) bool {
 func (a *AWS) createOrReplaceSG(hostInstanceID, hostIP, vpcID string) (string, error) {
 	sgName := fmt.Sprintf("SG for %s (%s)", hostInstanceID, hostIP)
 	descrSGOutput, err := a.ec2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
-		GroupNames: []*string{
-			aws.String(sgName),
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("group-name"),
+				Values: []*string{
+					aws.String(sgName),
+				},
+			},
 		},
 	})
 	if err != nil && !isInvalidGroupNotFoundErr(err) {


### PR DESCRIPTION
Using the group names option only works for the default VPC, the workers are not running in the default VPC. For non-default VPCs filters should be used.

---

See https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeSecurityGroupsInput
