### PR TITLE
Tag rhel 9.2+ with SEV_LIVE_MIGRATABLE_V2

### DIFF
--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -28,6 +28,17 @@ var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeatu
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE_V2.String())},
+}
+
+// Guest OS Features for RHEL9.1 images.
+// The SEV_LIVE_MIGRATABLE_V2 support was added since RHEL-9.2
+var GuestOsFeaturesRHEL91 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
+	{Type: common.ToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
 }
 
 // Guest OS Features for RHEL9.0 images.
@@ -53,6 +64,8 @@ func GuestOsFeaturesByDistro(distroName string) []*computepb.GuestOsFeature {
 
 	case distroName == "rhel-90":
 		return GuestOsFeaturesRHEL90
+	case distroName == "rhel-91":
+		return GuestOsFeaturesRHEL91
 	case strings.HasPrefix(distroName, "centos-9"):
 		fallthrough
 	case strings.HasPrefix(distroName, "rhel-9"):


### PR DESCRIPTION
SEV-SNP capable kernels containing commit ac3f9c9f are compatible. SEV_LIVE_MIGRATABLE indicated compatibility with an older version of SEV live migration, without ac3f9c9f. See: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?id=ac3f9c9f1b37edaa7d1a9b908bc79d843955a1a2


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
