### PR TITLE
test: remove libvirt workaround

### DIFF
--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -71,13 +71,6 @@ EOFKS
     echo "============================"
 }
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/minimal-raw.sh
+++ b/test/cases/minimal-raw.sh
@@ -8,13 +8,6 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh none
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start firewalld
 greenprint "Start firewalld"
 sudo systemctl enable --now firewalld

--- a/test/cases/oscap.sh
+++ b/test/cases/oscap.sh
@@ -11,13 +11,6 @@ source /etc/os-release
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree-ignition.sh
+++ b/test/cases/ostree-ignition.sh
@@ -10,13 +10,6 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Install and start firewalld
 greenprint "🔧 Install and start firewalld"
 sudo dnf install -y firewalld

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -10,13 +10,6 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Install openshift client
 greenprint "🔧 Installing oenshift client(oc)"
 curl https://osbuild-storage.s3.amazonaws.com/oc-4.9.0-linux.tar.gz | sudo tar -xz -C /usr/local/bin/

--- a/test/cases/ostree-pulp.sh
+++ b/test/cases/ostree-pulp.sh
@@ -32,13 +32,6 @@ case "${ID}-${VERSION_ID}" in
         exit 1;;
 esac
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -10,13 +10,6 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -33,13 +33,6 @@ if [[ "$VERSION_ID" == "9.4" || "$VERSION_ID" == "9" ]]; then
 fi
 sudo systemctl restart fdo-aio
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -90,13 +90,6 @@ case "${ID}-${VERSION_ID}" in
         exit 1;;
 esac
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd

--- a/tools/libvirt_test.sh
+++ b/tools/libvirt_test.sh
@@ -34,13 +34,6 @@ function greenprint {
     echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
 }
 
-# workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=2213660
-if [[ "$VERSION_ID" == "9.3"  || "$VERSION_ID" == "9" ]]; then
-    sudo tee /etc/sysconfig/libvirtd << EOF > /dev/null
-LIBVIRTD_ARGS=
-EOF
-fi
-
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd


### PR DESCRIPTION
Related to COMPOSER-2078

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
