### PR TITLE
Add CI job to detect possible problematic usage of `trap`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
       with:
@@ -223,6 +224,20 @@ jobs:
         # don't check /etc/os-release sourcing, allow useless cats to live inside our codebase, and
         # allow seemingly unreachable commands
         SHELLCHECK_OPTS: -e SC1091 -e SC2002 -e SC2317
+
+    - name: Do not doube trap signals inside test scripts
+      run: |
+        FILES_WITH_DOUBLE_TRAP=$(grep trap test/cases/* -R | cut -f1 -d: | sort | uniq -c | grep -v 1 || echo -n)
+
+        echo "INFO: ----- files with possible double calls to 'trap' -----"
+        echo "$FILES_WITH_DOUBLE_TRAP"
+        echo "---------- END ----------"
+
+        if [ -n "$FILES_WITH_DOUBLE_TRAP" ]; then
+            echo "FAIL: Do not double 'trap' signals"
+            echo "INFO: because this may lead to cleanup() function not being executed"
+            exit 1
+        fi
 
   rpmlint:
     name: "📦 RPMlint"

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -32,6 +32,8 @@ fi
 TEMPDIR=$(mktemp -d)
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT
@@ -127,8 +129,6 @@ sudo composer-cli blueprints depsolve bash
 WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
 sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
 WORKER_JOURNAL_PID=$!
-# Stop watching the worker journal when exiting.
-trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
 # Start the compose and upload to AWS.
 greenprint "🚀 Starting compose"
@@ -155,9 +155,8 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
-# Kill the journal monitor immediately and remove the trap
+# Kill the journal monitor
 sudo pkill -P ${WORKER_JOURNAL_PID}
-trap - EXIT
 
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/container-embedding.sh
+++ b/test/cases/container-embedding.sh
@@ -14,6 +14,8 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 TEMPDIR=$(mktemp -d)
 function cleanup() {
     greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT
@@ -82,8 +84,6 @@ sudo composer-cli blueprints depsolve image
 WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
 sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
 WORKER_JOURNAL_PID=$!
-# Stop watching the worker journal when exiting.
-trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
 # Start the compose and upload to CI registry.
 greenprint "🚀 Starting compose"
@@ -111,9 +111,8 @@ greenprint "💬 Getting compose log and metadata"
 get_compose_log "$COMPOSE_ID"
 get_compose_metadata "$COMPOSE_ID"
 
-# Kill the journal monitor immediately and remove the trap
+# Kill the journal monitor
 sudo pkill -P ${WORKER_JOURNAL_PID}
-trap - EXIT
 
 # Did the compose finish with success?
 if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-ami-image.sh
+++ b/test/cases/ostree-ami-image.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd
@@ -139,8 +146,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -179,9 +184,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-ignition.sh
+++ b/test/cases/ostree-ignition.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Install and start firewalld
 greenprint "🔧 Install and start firewalld"
 sudo dnf install -y firewalld
@@ -158,8 +165,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -193,9 +198,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-iot-qcow2.sh
+++ b/test/cases/ostree-iot-qcow2.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd
@@ -136,8 +143,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -173,9 +178,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -285,10 +285,6 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
-    sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
-
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then
         redprint "Something went wrong with the compose. 😢"

--- a/test/cases/ostree-pulp.sh
+++ b/test/cases/ostree-pulp.sh
@@ -7,6 +7,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Get compose url if it's running on unsubscried RHEL
 if [[ ${ID} == "rhel" ]] && ! sudo subscription-manager status; then
     source /usr/libexec/osbuild-composer-test/define-compose-url.sh
@@ -145,8 +152,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -187,9 +192,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Start libvirtd and test it.
 greenprint "🚀 Starting libvirt daemon"
 sudo systemctl start libvirtd
@@ -178,8 +185,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -215,9 +220,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
 # Start firewalld
 sudo systemctl enable --now firewalld
 sudo pip3 install yq==v3.2.1
@@ -219,8 +226,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -256,9 +261,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree-vsphere.sh
+++ b/test/cases/ostree-vsphere.sh
@@ -10,6 +10,14 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
+
 # Install govc
 GOVC_VERSION="v0.30.5"
 sudo curl -L -o - "https://github.com/vmware/govmomi/releases/download/${GOVC_VERSION}/govc_Linux_x86_64.tar.gz" | sudo tar -C /usr/local/bin -xvzf - govc
@@ -155,8 +163,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -188,9 +194,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -7,6 +7,14 @@ ARCH=$(uname -m)
 
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
+function cleanup_on_exit() {
+    greenprint "== Script execution stopped or finished - Cleaning up =="
+    # kill dangling journalctl processes to prevent GitLab CI from hanging
+    sudo pkill journalctl || echo "Nothing killed"
+}
+trap cleanup_on_exit EXIT
+
+
 # Get compose url if it's running on unsubscried RHEL
 if [[ ${ID} == "rhel" ]] && ! sudo subscription-manager status; then
     source /usr/libexec/osbuild-composer-test/define-compose-url.sh
@@ -199,8 +207,6 @@ build_image() {
     WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
     sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
     WORKER_JOURNAL_PID=$!
-    # Stop watching the worker journal when exiting.
-    trap 'sudo pkill -P ${WORKER_JOURNAL_PID}' EXIT
 
     # Start the compose.
     greenprint "🚀 Starting compose"
@@ -233,9 +239,8 @@ build_image() {
     get_compose_log "$COMPOSE_ID"
     get_compose_metadata "$COMPOSE_ID"
 
-    # Kill the journal monitor immediately and remove the trap
+    # Kill the journal monitor
     sudo pkill -P ${WORKER_JOURNAL_PID}
-    trap - EXIT
 
     # Did the compose finish with success?
     if [[ $COMPOSE_STATUS != FINISHED ]]; then


### PR DESCRIPTION
see for example this change:
https://github.com/osbuild/osbuild-composer/pull/3681/commits/13a3ca24ceef05164a77db1c71b929e262098f41


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
