### PR TITLE
blueprint: replace container storage args with a bool

### DIFF
--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -32,7 +32,7 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	resolver.AuthFilePath = impl.AuthFilePath
 
 	for _, s := range args.Specs {
-		resolver.Add(container.SourceSpec{s.Source, s.Name, nil, s.TLSVerify, nil, nil})
+		resolver.Add(container.SourceSpec{s.Source, s.Name, nil, s.TLSVerify, false})
 	}
 
 	specs, err := resolver.Finish()

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -48,9 +48,8 @@ type Container struct {
 	Source string `json:"source,omitempty" toml:"source"`
 	Name   string `json:"name,omitempty" toml:"name,omitempty"`
 
-	TLSVerify           *bool   `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
-	ContainersTransport *string `json:"containers-transport,omitempty" toml:"containers-transport,omitempty"`
-	StoragePath         *string `json:"source-path,omitempty" toml:"source-path,omitempty"`
+	TLSVerify    *bool `json:"tls-verify,omitempty" toml:"tls-verify,omitempty"`
+	LocalStorage bool  `json:"local-storage,omitempty" toml:"local-storage,omitempty"`
 }
 
 // DeepCopy returns a deep copy of the blueprint


### PR DESCRIPTION
Simplify the way local container storage is handled by adding a boolean that specifies that a container is local. The container transport in the local case should always be containers-storage

This PR fixes up some changes to the blueprints in https://github.com/osbuild/images/pull/448.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
