### PR TITLE
osbuild-jobsite: push sources to executor (HMS-3633)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ build: $(BUILDDIR)/bin/
 	go build -o $<osbuild-upload-generic-s3 ./cmd/osbuild-upload-generic-s3/
 	go build -o $<osbuild-mock-openid-provider ./cmd/osbuild-mock-openid-provider
 	go build -o $<osbuild-service-maintenance ./cmd/osbuild-service-maintenance
+	go build -o $<osbuild-jobsite-manager ./cmd/osbuild-jobsite-manager
+	go build -o $<osbuild-jobsite-builder ./cmd/osbuild-jobsite-builder
 	go test -c -tags=integration -o $<osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
 	go test -c -tags=integration -o $<osbuild-weldr-tests ./internal/client/
 	go test -c -tags=integration -o $<osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go

--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -277,9 +277,76 @@ func (a *AWS) createOrReplaceSG(hostInstanceID, hostIP, vpcID string) (string, e
 	if len(describeSGOutput.SecurityGroups) != 1 {
 		return sgID, fmt.Errorf("Expected 1 security group, got %d", len(describeSGOutput.SecurityGroups))
 	}
+
+	if len(describeSGOutput.SecurityGroups[0].IpPermissionsEgress) != 1 {
+		return sgID, fmt.Errorf("Expected exactly 1 egress rule on the security group (got %d)", len(describeSGOutput.SecurityGroups[0].IpPermissionsEgress))
+	}
+
+	describeSGROutput, err := a.ec2.DescribeSecurityGroupRules(&ec2.DescribeSecurityGroupRulesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("group-id"),
+				Values: []*string{
+					aws.String(sgID),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return sgID, err
+	}
+
+	for _, rule := range describeSGROutput.SecurityGroupRules {
+		if *rule.IsEgress {
+			revokeOutput, err := a.ec2.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
+				GroupId: aws.String(sgID),
+				SecurityGroupRuleIds: []*string{
+					rule.SecurityGroupRuleId,
+				},
+			})
+			if err != nil {
+				return sgID, err
+			}
+			if !*revokeOutput.Return {
+				return sgID, fmt.Errorf("Failed to revoke security group %s's egress rule %s", sgID, *rule.SecurityGroupRuleId)
+			}
+		}
+	}
+
+	sgEgressOutput, err := a.ec2.AuthorizeSecurityGroupEgress(&ec2.AuthorizeSecurityGroupEgressInput{
+		GroupId: aws.String(sgID),
+		IpPermissions: []*ec2.IpPermission{
+			&ec2.IpPermission{
+				IpProtocol: aws.String(ec2.ProtocolTcp),
+				FromPort:   aws.Int64(1),
+				ToPort:     aws.Int64(65535),
+				IpRanges: []*ec2.IpRange{
+					&ec2.IpRange{
+						CidrIp: aws.String(fmt.Sprintf("%s/32", hostIP)),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return sgID, err
+	}
+	if !*sgEgressOutput.Return {
+		return sgID, fmt.Errorf("Unable to attach egress rules to SG")
+	}
+
+	describeSGOutput, err = a.ec2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{
+			aws.String(sgID),
+		},
+	})
+	if err != nil {
+		return sgID, err
+	}
+
 	// SGs are created with a predefind egress rule that allows all outgoing traffic, so expecting 1 outbound rule
 	if len(describeSGOutput.SecurityGroups[0].IpPermissions) != 1 || len(describeSGOutput.SecurityGroups[0].IpPermissionsEgress) != 1 {
-		return sgID, fmt.Errorf("Expected 3 security group rules: 1 inbound (got %d) and 1 outbound (got %d)",
+		return sgID, fmt.Errorf("Expected 2 security group rules: 1 inbound (got %d) and 1 outbound (got %d)",
 			len(describeSGOutput.SecurityGroups[0].IpPermissions), len(describeSGOutput.SecurityGroups[0].IpPermissionsEgress))
 	}
 

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -5,14 +5,6 @@ source /etc/os-release
 # /tmp/cloud_init_vars may not exist on the osbuild-executor
 source /tmp/cloud_init_vars || true
 
-# Don't subscribe on fedora
-if [ "$ID" != fedora ]; then
-  /usr/local/bin/aws secretsmanager get-secret-value \
-    --secret-id executor-subscription-manager-command | jq -r ".SecretString" > /tmp/subscription_manager_command.json
-  jq -r ".subscription_manager_command" /tmp/subscription_manager_command.json | bash
-  rm -f /tmp/subscription_manager_command.json
-fi
-
 echo "Writing vector config."
 REGION=$(curl -Ls http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
 HOSTNAME=$(hostname)


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
