### PR TITLE
Packer: make osbuild-executor worker config more configurable (HMS-3727)

### DIFF
--- a/templates/packer/ansible/roles/common/files/osbuild-worker.toml
+++ b/templates/packer/ansible/roles/common/files/osbuild-worker.toml
@@ -1,5 +1,1 @@
 base_path = "/api/image-builder-worker/v1"
-
-[osbuild_executor]
-type = "aws.ec2"
-iam_profile = "osbuild-executor"

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+source /tmp/cloud_init_vars
+
+echo "Writing osbuild_executor config to worker configuration."
+OSBUILD_EXECUTOR_IAM_PROFILE=${OSBUILD_EXECUTOR_IAM_PROFILE:-osbuild-executor}
+sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
+[osbuild_executor]
+type = "aws.ec2"
+iam_profile = "${OSBUILD_EXECUTOR_IAM_PROFILE}"
+EOF

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Don't subscribe on fedora
 source /etc/os-release
+source /tmp/cloud_init_vars
+
+# Don't subscribe on fedora
 if [ "$ID" != fedora ]; then
   /usr/local/bin/aws secretsmanager get-secret-value \
     --secret-id executor-subscription-manager-command | jq -r ".SecretString" > /tmp/subscription_manager_command.json
@@ -14,6 +16,8 @@ echo "Writing vector config."
 REGION=$(curl -Ls http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
 HOSTNAME=$(hostname)
 CLOUDWATCH_ENDPOINT="https://logs.$REGION.amazonaws.com"
+OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-osbuild-executor-log-group}
+
 sudo mkdir -p /etc/vector
 sudo tee /etc/vector/vector.toml > /dev/null << EOF
 [sources.journald]
@@ -25,7 +29,7 @@ type = "aws_cloudwatch_logs"
 inputs = [ "journald" ]
 region = "${REGION}"
 endpoint = "${CLOUDWATCH_ENDPOINT}"
-group_name = "osbuild-executor-log-group"
+group_name = "${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}"
 stream_name = "osbuild_executor_syslog_${HOSTNAME}"
 encoding.codec = "json"
 EOF

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -9,6 +9,7 @@ Type=oneshot
 ExecStart=touch /etc/worker-first-boot
 ExecStart=/usr/local/libexec/worker-initialization-scripts/set_hostname.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/vector.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_config.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/offline_token.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/client_credentials.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/subscription_manager.sh


### PR DESCRIPTION
We need to use custom IAM policy name used by the worker for osbuild-executor on Fedora workers (in prod vs. stage). And we have the same requirement for the CloudWatch log group used by the osbuild-executor.

Modify the Ansible playbook used by Packer to use the values from /tmp/cloud_init_vars if set and defaulting to the current values if not set.

Related to https://github.com/osbuild/image-builder-terraform/pull/436

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
