### PR TITLE
Drop distro aliases and dot-notation tests (HMS-3710)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -588,46 +588,6 @@ API-module-hotfixes:
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
 
-API-no-dot-notation:
-  stage: test
-  extends: .terraform
-  rules:
-    - !reference [.upstream_rules_all, rules]
-    # note: cloud API is not supported for on-prem installations so
-    # don't run this test case for nightly trees
-  script:
-    - schutzbot/deploy.sh
-    - /usr/libexec/tests/osbuild-composer/api.sh "${IMAGE_TYPE}"
-  parallel:
-    matrix:
-      - IMAGE_TYPE:
-          - aws
-        RUNNER:
-          - aws/rhel-8.9-ga-x86_64
-          - aws/rhel-9.3-ga-x86_64
-        INTERNAL_NETWORK: ["true"]
-        TEST_NO_DOT_NOTATION: [1]
-
-API-distro-alias:
-  stage: test
-  extends: .terraform
-  rules:
-    - !reference [.upstream_rules_all, rules]
-    # note: cloud API is not supported for on-prem installations so
-    # don't run this test case for nightly trees
-  script:
-    - schutzbot/deploy.sh
-    - /usr/libexec/tests/osbuild-composer/api.sh "${IMAGE_TYPE}"
-  parallel:
-    matrix:
-      - IMAGE_TYPE:
-          - aws-sap-rhui
-        RUNNER:
-          - aws/rhel-8.9-ga-x86_64
-          - aws/rhel-9.3-ga-x86_64
-        INTERNAL_NETWORK: ["true"]
-        TEST_DISTRO_ALIAS: [1]
-
 .libvirt_integration:
   stage: test
   extends: .terraform/gcp

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -22,9 +22,7 @@ CLOUD_PROVIDER_OCI="oci"
 # Supported Image type names
 #
 export IMAGE_TYPE_AWS="aws"
-export IMAGE_TYPE_AWS_SAP_RHUI="aws-sap-rhui"
 export IMAGE_TYPE_AZURE="azure"
-export IMAGE_TYPE_AZURE_SAP_RHUI="azure-sap-rhui"
 export IMAGE_TYPE_EDGE_COMMIT="edge-commit"
 export IMAGE_TYPE_EDGE_CONTAINER="edge-container"
 export IMAGE_TYPE_EDGE_INSTALLER="edge-installer"
@@ -53,50 +51,14 @@ IMAGE_TYPE="$1"
 # set TEST_MODULE_HOTFIXES to 1 to enable module hotfixes for the test
 TEST_MODULE_HOTFIXES="${TEST_MODULE_HOTFIXES:-0}"
 
-# set TEST_NO_DOT_NOTATION to 1 to disable dot notation in the test
-# Not using the dot notation means that the dot separating the major and minor
-# version in the distro name will be removed.
-#
-# This test variant is mutually exclusive with TEST_DISTRO_ALIAS.
-TEST_NO_DOT_NOTATION="${TEST_NO_DOT_NOTATION:-0}"
-
-# set TEST_DISTRO_ALIAS to 1 to test configuring and using a distro alias
-# when submitting composer request.
-#
-# This test variant deliberately uses the SAP image to test that the alias
-# works as expected. The reason is that the SAP image will always have DNF
-# configuration pinned down to a specific OS version and the version is the
-# same as the distro definition used to generate the manifest.
-# Specifically, the `/etc/dnf/vars/releasever` file will contain `X.Y`.
-#
-# This test variant is mutually exclusive with TEST_NO_DOT_NOTATION.
-export TEST_DISTRO_ALIAS="${TEST_DISTRO_ALIAS:-0}"
-
-# TEST_NO_DOT_NOTATION and TEST_DISTRO_ALIAS are mutually exclusive
-if [[ "$TEST_NO_DOT_NOTATION" == "1" && "$TEST_DISTRO_ALIAS" == "1" ]]; then
-    echo "TEST_NO_DOT_NOTATION and TEST_DISTRO_ALIAS are mutually exclusive"
-    exit 1
-fi
-
-# TEST_DISTRO_ALIAS requires that the IMAGE_TYPE is a SAP image
-if [[ "$TEST_DISTRO_ALIAS" == "1" ]]; then
-    case "${IMAGE_TYPE}" in
-        "$IMAGE_TYPE_AWS_SAP_RHUI"|"IMAGE_TYPE_AZURE_SAP_RHUI")
-            ;;
-        *)
-            echo "TEST_DISTRO_ALIAS can only be used with SAP images"
-            exit 1
-    esac
-fi
-
 # select cloud provider based on image type
 #
 # the supported image types are listed in the api spec (internal/cloudapi/v2/openapi.v2.yml)
 case ${IMAGE_TYPE} in
-    "$IMAGE_TYPE_AWS"|"$IMAGE_TYPE_AWS_SAP_RHUI")
+    "$IMAGE_TYPE_AWS")
         CLOUD_PROVIDER="${CLOUD_PROVIDER_AWS}"
         ;;
-    "$IMAGE_TYPE_AZURE"|"IMAGE_TYPE_AZURE_SAP_RHUI")
+    "$IMAGE_TYPE_AZURE")
         CLOUD_PROVIDER="${CLOUD_PROVIDER_AZURE}"
         ;;
     "$IMAGE_TYPE_GCP")
@@ -127,54 +89,14 @@ ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
-export DISTRO="${DISTRO_CODE}"
-
 # Container image used for cloud provider CLI tools
 export CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"
-
-WORKDIR=$(mktemp -d)
-KILL_PIDS=()
-function cleanups() {
-  greenprint "Cleaning up"
-  set +eu
-
-  cleanup
-
-  # dump the DB here to ensure that it gets dumped even if the test fails
-  dump_db
-
-  sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
-  sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
-
-  sudo rm -rf "$WORKDIR"
-
-  for P in "${KILL_PIDS[@]}"; do
-      sudo pkill -P "$P"
-  done
-  set -eu
-}
-trap cleanups EXIT
 
 #
 # Provision the software under test.
 #
 
-# Path to a file with extra composer configuration
-EXTRA_COMPOSER_CONF=""
-
-# Configure distro alias for the host distro in composer without the minor
-# version.
-if [[ "${TEST_DISTRO_ALIAS}" == "1" ]]; then
-    DISTRO_ALIAS="${ID}-${VERSION_ID%.*}"
-    EXTRA_COMPOSER_CONF="$(mktemp -p "${WORKDIR}")"
-
-    cat <<EOF | tee "${EXTRA_COMPOSER_CONF}" >/dev/null
-[distro_aliases]
-${DISTRO_ALIAS} = "${DISTRO}"
-EOF
-fi
-
-/usr/libexec/osbuild-composer-test/provision.sh tls "${EXTRA_COMPOSER_CONF}"
+/usr/libexec/osbuild-composer-test/provision.sh
 
 #
 # Set up the database queue
@@ -212,9 +134,7 @@ PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PG
     "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
 popd
 
-# TODO: move this to the tools/provision.sh and don't override composer config
-COMPOSER_CONFIG="/etc/osbuild-composer/osbuild-composer.toml"
-cat <<EOF | sudo tee "${COMPOSER_CONFIG}"
+cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
 log_level = "debug"
 [koji]
 allowed_domains = [ "localhost", "client.osbuild.org" ]
@@ -230,10 +150,6 @@ pg_password = "foobar"
 pg_ssl_mode = "disable"
 pg_max_conns = 10
 EOF
-
-if [[ "${TEST_DISTRO_ALIAS}" == "1" ]]; then
-    cat "${EXTRA_COMPOSER_CONF}" | sudo tee -a "${COMPOSER_CONFIG}"
-fi
 
 sudo systemctl restart osbuild-composer
 
@@ -285,6 +201,29 @@ function dump_db() {
   sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \
     | sudo tee "${ARTIFACTS}/build-result.txt"
 }
+
+WORKDIR=$(mktemp -d)
+KILL_PIDS=()
+function cleanups() {
+  greenprint "Cleaning up"
+  set +eu
+
+  cleanup
+
+  # dump the DB here to ensure that it gets dumped even if the test fails
+  dump_db
+
+  sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
+  sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
+
+  sudo rm -rf "$WORKDIR"
+
+  for P in "${KILL_PIDS[@]}"; do
+      sudo pkill -P "$P"
+  done
+  set -eu
+}
+trap cleanups EXIT
 
 # make a dummy rpm and repo to test payload_repositories
 greenprint "Setting up dummy rpm and repo"
@@ -374,19 +313,7 @@ else
 fi
 export SSH_USER
 
-if [[ "$TEST_NO_DOT_NOTATION" == "1" ]]; then
-  # This removes dot from VERSION_ID.
-  # ID == rhel   && VERSION_ID == 8.6 => DISTRO == rhel-86
-  # ID == centos && VERSION_ID == 8   => DISTRO == centos-8
-  # ID == fedora && VERSION_ID == 35  => DISTRO == fedora-35
-  DISTRO_NAME="$ID-${VERSION_ID//./}"
-elif [[ "$TEST_DISTRO_ALIAS" == "1" ]]; then
-  DISTRO_NAME="$DISTRO_ALIAS"
-else
-  DISTRO_NAME="$DISTRO"
-fi
-export DISTRO_NAME
-
+export DISTRO="$ID-${VERSION_ID}"
 SUBSCRIPTION_BLOCK=
 
 # Only RHEL need subscription block.
@@ -564,9 +491,6 @@ function collectMetrics(){
 }
 
 function sendCompose() {
-    echo "Compose request:"
-    cat "$1"
-
     OUTPUT=$(mktemp)
     HTTPSTATUS=$(curl \
                  --silent \

--- a/test/cases/api/aws.sh
+++ b/test/cases/api/aws.sh
@@ -36,7 +36,7 @@ function createReqFile() {
 
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "filesystem": [
       {

--- a/test/cases/api/azure.sh
+++ b/test/cases/api/azure.sh
@@ -68,7 +68,7 @@ function createReqFile() {
 
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "filesystem": [
       {

--- a/test/cases/api/common/common.sh
+++ b/test/cases/api/common/common.sh
@@ -75,16 +75,6 @@ function _instanceCheck() {
   else
       echo "firewalld not available on host, that's fine"
   fi
-
-  if [[ "${TEST_DISTRO_ALIAS}" == "1" ]]; then
-      echo "✔️ Checking DNF config of an image built using distro alias"
-      DNF_VARS_RELEASEVER=$($_ssh cat /etc/dnf/vars/releasever)
-      if [[ "$DNF_VARS_RELEASEVER" != "$VERSION_ID" ]]; then
-          echo "DNF config of an image built using distro alias has wrong releasever: $DNF_VARS_RELEASEVER"
-          echo "Expected: $VERSION_ID"
-          exit 1
-      fi
-  fi
 }
 
 WORKER_REFRESH_TOKEN_PATH="/etc/osbuild-worker/token"

--- a/test/cases/api/common/s3.sh
+++ b/test/cases/api/common/s3.sh
@@ -16,7 +16,7 @@ function createReqFileEdge() {
 
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "payload_repositories": [
       {
@@ -62,7 +62,7 @@ EOF
 function createReqFileGuest() {
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "payload_repositories": [
       {
@@ -103,7 +103,7 @@ EOF
 function createReqFileVSphere() {
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "payload_repositories": [
       {

--- a/test/cases/api/container.registry.sh
+++ b/test/cases/api/container.registry.sh
@@ -42,7 +42,7 @@ EOF
 function createReqFile() {
       cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "payload_repositories": [
       {

--- a/test/cases/api/gcp.sh
+++ b/test/cases/api/gcp.sh
@@ -55,7 +55,7 @@ function createReqFile() {
 
   cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "filesystem": [
       {

--- a/test/cases/api/oci.sh
+++ b/test/cases/api/oci.sh
@@ -60,7 +60,7 @@ function installClient() {
 function createReqFile() {
     cat > "$REQUEST_FILE" << EOF
 {
-  "distribution": "$DISTRO_NAME",
+  "distribution": "$DISTRO",
   "customizations": {
     "filesystem": [
       {


### PR DESCRIPTION
This reverts commit 2fe5e01d4d421d4d41e31f217c9b952d2e644aff.

This functionality is covered by unit tests in osbuild/images: https://github.com/osbuild/images/blob/aaa53adc3c1570bb54e65b15b9aa090991e74afb/pkg/distrofactory/distrofactory_test.go#L9