### PR TITLE
Test/Koji: test only combinations that we run in the service (HMS-3710)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -391,20 +391,20 @@ koji.sh (cloud upload):
   parallel:
     matrix:
       - RUNNER:
-          # Brew workers use RHEL-8.7
           - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: aws
         IMAGE_TYPE: aws-rhui
       - RUNNER:
-          # Brew workers use RHEL-8.6
           - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: azure
         IMAGE_TYPE: azure-rhui
       - RUNNER:
-          # Brew workers use RHEL-8.6
           - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         CLOUD_TARGET: gcp
         IMAGE_TYPE: gcp-rhui
@@ -416,6 +416,13 @@ koji.sh (cloudapi):
     - !reference [.upstream_rules_all, rules]
   variables:
     SCRIPT: koji.sh
+  parallel:
+    matrix:
+      - *fedora_runners
+      - RUNNER:
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
+        INTERNAL_NETWORK: ["true"]
 
 aws.sh:
   extends: .integration


### PR DESCRIPTION
Test `koji.sh` with cloud upload on the latest RHEL-8.9 and RHEL9.3 GA releases, which we use on our Brew workers.

Test the `koji.sh` only on the latest RHEL-8.9, RHEL-9.3 and Fedora releases, which we use on our Brew and Koji workers.

There's no value in testing this case on CentOS Stream, RHEL EUS releases or nightly composes.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
