### PR TITLE
osbuild-worker: Convert osbuild raw json error to a string for logging

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -533,7 +533,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	if !osbuildJobResult.OSBuildOutput.Success {
 		var osbErrors []error
 		if osbuildJobResult.OSBuildOutput.Error != nil {
-			osbErrors = append(osbErrors, fmt.Errorf("osbuild error: %v", osbuildJobResult.OSBuildOutput.Error))
+			osbErrors = append(osbErrors, fmt.Errorf("osbuild error: %s", string(osbuildJobResult.OSBuildOutput.Error)))
 		}
 		if osbuildJobResult.OSBuildOutput.Errors != nil {
 			for _, err := range osbuildJobResult.OSBuildOutput.Errors {


### PR DESCRIPTION
Without this you get an array of bytes in the logs. Convert the raw json output from osbuild to a string so there is some hope that it is readable.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs
