### PR TITLE
Worker: allow configuring executor CloudWatch group (HMS-3727)

### DIFF
--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -72,9 +72,10 @@ type pulpConfig struct {
 }
 
 type executorConfig struct {
-	Type       string `toml:"type"`
-	IAMProfile string `toml:"iam_profile"`
-	KeyName    string `toml:"key_name"`
+	Type            string `toml:"type"`
+	IAMProfile      string `toml:"iam_profile"`
+	KeyName         string `toml:"key_name"`
+	CloudWatchGroup string `toml:"cloudwatch_group"`
 }
 
 type workerConfig struct {

--- a/cmd/osbuild-worker/config_test.go
+++ b/cmd/osbuild-worker/config_test.go
@@ -69,12 +69,21 @@ offline_token = "/etc/osbuild-worker/offline_token"
 [pulp]
 credentials = "/etc/osbuild-worker/pulp-creds"
 server_address = "https://example.com/pulp"
+
+[osbuild_executor]
+type = "aws.ec2"
+iam_profile = "osbuild-worker"
+key_name = "osbuild-worker"
+cloudwatch_group = "osbuild-worker"
 `,
 			want: &workerConfig{
 				BasePath: "/api/image-builder-worker/v1",
 				DNFJson:  "/usr/libexec/osbuild-depsolve-dnf",
 				OSBuildExecutor: &executorConfig{
-					Type: "host",
+					Type:            "aws.ec2",
+					IAMProfile:      "osbuild-worker",
+					KeyName:         "osbuild-worker",
+					CloudWatchGroup: "osbuild-worker",
 				},
 				Composer: &composerConfig{
 					Proxy: "http://proxy.example.com",

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -77,9 +77,10 @@ type PulpConfiguration struct {
 }
 
 type ExecutorConfiguration struct {
-	Type       string
-	IAMProfile string
-	KeyName    string
+	Type            string
+	IAMProfile      string
+	KeyName         string
+	CloudWatchGroup string
 }
 
 type OSBuildJobImpl struct {
@@ -489,7 +490,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 	case "host":
 		executor = osbuildexecutor.NewHostExecutor()
 	case "aws.ec2":
-		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName)
+		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName, impl.OSBuildExecutor.CloudWatchGroup)
 	default:
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, "No osbuild executor defined", nil)
 		return err

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -474,9 +474,10 @@ func main() {
 			Store:  store,
 			Output: output,
 			OSBuildExecutor: ExecutorConfiguration{
-				Type:       config.OSBuildExecutor.Type,
-				IAMProfile: config.OSBuildExecutor.IAMProfile,
-				KeyName:    config.OSBuildExecutor.KeyName,
+				Type:            config.OSBuildExecutor.Type,
+				IAMProfile:      config.OSBuildExecutor.IAMProfile,
+				KeyName:         config.OSBuildExecutor.KeyName,
+				CloudWatchGroup: config.OSBuildExecutor.CloudWatchGroup,
 			},
 			KojiServers: kojiServers,
 			GCPConfig:   gcpConfig,

--- a/internal/cloud/awscloud/secure-instance_test.go
+++ b/internal/cloud/awscloud/secure-instance_test.go
@@ -1,0 +1,43 @@
+package awscloud
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSecureInstanceUserData(t *testing.T) {
+	type testCase struct {
+		CloudWatchGroup  string
+		ExpectedUserData string
+	}
+
+	testCases := []testCase{
+		{
+			ExpectedUserData: `#cloud-config
+write_files:
+  - path: /tmp/worker-run-executor-service
+    content: ''
+`,
+		},
+		{
+			CloudWatchGroup: "test-group",
+			ExpectedUserData: `#cloud-config
+write_files:
+  - path: /tmp/worker-run-executor-service
+    content: ''
+  - path: /tmp/cloud_init_vars
+    content: |
+      OSBUILD_EXECUTOR_CLOUDWATCH_GROUP='test-group'
+`,
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("Test case %d", idx), func(t *testing.T) {
+			userData := SecureInstanceUserData(tc.CloudWatchGroup)
+			if userData != tc.ExpectedUserData {
+				t.Errorf("Expected: %s, got: %s", tc.ExpectedUserData, userData)
+			}
+		})
+	}
+}

--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -13,8 +13,9 @@ import (
 )
 
 type awsEC2Executor struct {
-	iamProfile string
-	keyName    string
+	iamProfile      string
+	keyName         string
+	cloudWatchGroup string
 }
 
 func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, store, outputDirectory string, exports, exportPaths, checkpoints,
@@ -29,7 +30,7 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, store, outputDirectory s
 		return nil, err
 	}
 
-	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName)
+	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName, ec2e.cloudWatchGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -92,9 +93,10 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, store, outputDirectory s
 	return &osbuildResult, nil
 }
 
-func NewAWSEC2Executor(iamProfile, keyName string) Executor {
+func NewAWSEC2Executor(iamProfile, keyName, cloudWatchGroup string) Executor {
 	return &awsEC2Executor{
 		iamProfile,
 		keyName,
+		cloudWatchGroup,
 	}
 }

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
@@ -5,8 +5,16 @@ source /tmp/cloud_init_vars
 
 echo "Writing osbuild_executor config to worker configuration."
 OSBUILD_EXECUTOR_IAM_PROFILE=${OSBUILD_EXECUTOR_IAM_PROFILE:-osbuild-executor}
+OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-}
+
+CLOUDWATCH_GROUP_CONFIG=""
+if [ -n "${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}" ]; then
+    CLOUDWATCH_GROUP_CONFIG="cloudwatch_group = \"${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}\"\n"
+fi
+
 sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 [osbuild_executor]
 type = "aws.ec2"
 iam_profile = "${OSBUILD_EXECUTOR_IAM_PROFILE}"
+${CLOUDWATCH_GROUP_CONFIG}
 EOF

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 source /etc/os-release
-# TODO: uncomment, when the cloud_init_vars file is created on the executor
-#source /tmp/cloud_init_vars
+# /tmp/cloud_init_vars may not exist on the osbuild-executor
+source /tmp/cloud_init_vars || true
 
 # Don't subscribe on fedora
 if [ "$ID" != fedora ]; then


### PR DESCRIPTION
We need the ability to use different CloudWatch group for the osbuild-executor on Fedora workers in staging and production environment.

Extend the worker confguration to allow configuring the CloudWatch group name used by the osbuild-executor. Extend the secure instance code to instruct cloud-init via user data to create /tmp/cloud_init_vars file with the CloudWatch group name in the osbuild-executor instance, to make it possible for the executor to configure its logging differently based on the value.

Cover new changes by unit tests.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
