### PR TITLE
Minor user customization test improvements

### DIFF
--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -20,7 +20,7 @@ func TestCheckAllowed(t *testing.T) {
 	GID := 321
 
 	expectedUsers := []UserCustomization{
-		UserCustomization{
+		{
 			Name:        "John",
 			Description: &Desc,
 			Password:    &Pass,
@@ -33,7 +33,7 @@ func TestCheckAllowed(t *testing.T) {
 		},
 	}
 
-	var expectedHostname = "Hostname"
+	expectedHostname := "Hostname"
 
 	x := Customizations{Hostname: &expectedHostname, User: expectedUsers}
 
@@ -50,8 +50,7 @@ func TestCheckAllowed(t *testing.T) {
 }
 
 func TestGetHostname(t *testing.T) {
-
-	var expectedHostname = "Hostname"
+	expectedHostname := "Hostname"
 
 	TestCustomizations := Customizations{
 		Hostname: &expectedHostname,
@@ -59,11 +58,9 @@ func TestGetHostname(t *testing.T) {
 
 	retHostname := TestCustomizations.GetHostname()
 	assert.Equal(t, &expectedHostname, retHostname)
-
 }
 
 func TestGetKernel(t *testing.T) {
-
 	expectedKernel := KernelCustomization{
 		Append: "--test",
 		Name:   "kernel",
@@ -79,9 +76,8 @@ func TestGetKernel(t *testing.T) {
 }
 
 func TestSSHKey(t *testing.T) {
-
 	expectedSSHKeys := []SSHKeyCustomization{
-		SSHKeyCustomization{
+		{
 			User: "test-user",
 			Key:  "test-key",
 		},
@@ -95,11 +91,9 @@ func TestSSHKey(t *testing.T) {
 
 	assert.Equal(t, expectedSSHKeys[0].User, retUser)
 	assert.Equal(t, expectedSSHKeys[0].Key, retKey)
-
 }
 
 func TestGetUsers(t *testing.T) {
-
 	Desc := "Test descritpion"
 	Pass := "testpass"
 	Key := "testkey"
@@ -113,7 +107,7 @@ func TestGetUsers(t *testing.T) {
 	ExpireDate := 12345
 
 	expectedUsers := []UserCustomization{
-		UserCustomization{
+		{
 			Name:        "John",
 			Description: &Desc,
 			Password:    &Pass,
@@ -137,10 +131,9 @@ func TestGetUsers(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
-
 	GID := 1234
 	expectedGroups := []GroupCustomization{
-		GroupCustomization{
+		{
 			Name: "TestGroup",
 			GID:  &GID,
 		},
@@ -156,7 +149,6 @@ func TestGetGroups(t *testing.T) {
 }
 
 func TestGetTimezoneSettings(t *testing.T) {
-
 	expectedTimezone := "testZONE"
 	expectedNTPServers := []string{
 		"server",
@@ -175,11 +167,9 @@ func TestGetTimezoneSettings(t *testing.T) {
 
 	assert.Equal(t, expectedTimezone, *retTimezone)
 	assert.Equal(t, expectedNTPServers, retNTPServers)
-
 }
 
 func TestGetPrimaryLocale(t *testing.T) {
-
 	expectedLanguages := []string{
 		"enUS",
 	}
@@ -201,7 +191,6 @@ func TestGetPrimaryLocale(t *testing.T) {
 }
 
 func TestGetFirewall(t *testing.T) {
-
 	expectedPorts := []string{"22", "9090"}
 
 	expectedServices := FirewallServicesCustomization{
@@ -226,7 +215,6 @@ func TestGetFirewall(t *testing.T) {
 }
 
 func TestGetServices(t *testing.T) {
-
 	expectedServices := ServicesCustomization{
 		Enabled:  []string{"cockpit", "osbuild-composer"},
 		Disabled: []string{"sshd", "ftp"},
@@ -252,12 +240,10 @@ func TestError(t *testing.T) {
 	retError := expectedError.Error()
 
 	assert.Equal(t, expectedError.Message, retError)
-
 }
 
 // This tests calling all the functions on a Blueprint with no Customizations
 func TestNoCustomizationsInBlueprint(t *testing.T) {
-
 	TestBP := Blueprint{}
 
 	assert.Nil(t, TestBP.Customizations.GetHostname())
@@ -278,8 +264,7 @@ func TestNoCustomizationsInBlueprint(t *testing.T) {
 
 // This tests additional scenarios where GetPrimaryLocale() returns nil values
 func TestNilGetPrimaryLocale(t *testing.T) {
-
-	//Case empty Customization
+	// Case empty Customization
 	TestCustomizationsEmpty := Customizations{}
 
 	retLanguage, retKeyboard := TestCustomizationsEmpty.GetPrimaryLocale()
@@ -287,7 +272,7 @@ func TestNilGetPrimaryLocale(t *testing.T) {
 	assert.Nil(t, retLanguage)
 	assert.Nil(t, retKeyboard)
 
-	//Case empty Languages
+	// Case empty Languages
 	expectedKeyboard := "en"
 	expectedLocaleCustomization := LocaleCustomization{
 		Keyboard: &expectedKeyboard,
@@ -301,12 +286,10 @@ func TestNilGetPrimaryLocale(t *testing.T) {
 
 	assert.Nil(t, retLanguage)
 	assert.Equal(t, expectedKeyboard, *retKeyboard)
-
 }
 
 // This tests additional scenario where GetTimezoneSEtting() returns nil values
 func TestNilGetTimezoneSettings(t *testing.T) {
-
 	TestCustomizationsEmpty := Customizations{}
 
 	retTimezone, retNTPServers := TestCustomizationsEmpty.GetTimezoneSettings()
@@ -316,7 +299,6 @@ func TestNilGetTimezoneSettings(t *testing.T) {
 }
 
 func TestGetOpenSCAPConfig(t *testing.T) {
-
 	expectedOscap := OpenSCAPCustomization{
 		DataStream: "test-data-stream.xml",
 		ProfileID:  "test_profile",

--- a/internal/blueprint/customizations_test.go
+++ b/internal/blueprint/customizations_test.go
@@ -110,6 +110,7 @@ func TestGetUsers(t *testing.T) {
 	}
 	UID := 123
 	GID := 321
+	ExpireDate := 12345
 
 	expectedUsers := []UserCustomization{
 		UserCustomization{
@@ -122,6 +123,7 @@ func TestGetUsers(t *testing.T) {
 			Groups:      Groups,
 			UID:         &UID,
 			GID:         &GID,
+			ExpireDate:  &ExpireDate,
 		},
 	}
 


### PR DESCRIPTION
Extend user customizations to include an expiration date. This allows users to be configured to require password change on first login.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [x] submit a [PR](https://github.com/osbuild/osbuild.github.io/pull/64) for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
