### PR TITLE
Remove rhel-10.0 alias from the openshift template

### DIFF
--- a/templates/composer.yml
+++ b/templates/composer.yml
@@ -499,4 +499,4 @@ parameters:
     description: Name of the secret for connecting to sentry/glitchtip
   - description: Distro name aliases
     name: DISTRO_ALIASES
-    value: "rhel-7=rhel-7.9,rhel-8=rhel-8.9,rhel-9=rhel-9.3,rhel-10.0=rhel-9.4"
+    value: "rhel-7=rhel-7.9,rhel-8=rhel-8.9,rhel-9=rhel-9.3"


### PR DESCRIPTION
We now have a proper rhel-10.0 distribution, and this alias is clashing
with it, so we are seeing the following message in production:

failed to configure distro aliases: invalid aliases: ["alias 'rhel-10.0' masks an existing distro"]

Let's fix it by removing the alias, it's obviously not needed anymore.