### PR TITLE
osbuild-jobsite-manager: close writer before sending the store

### DIFF
--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -284,6 +284,8 @@ func StepPopulate() error {
 			errs <- err
 			return
 		}
+		defer os.Remove(file.Name())
+
 		tw := tar.NewWriter(file)
 		defer tw.Close()
 		err = filepath.Walk(argStore, func(filePath string, fi os.FileInfo, err error) error {

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -319,6 +319,13 @@ func StepPopulate() error {
 			errs <- err
 			return
 		}
+
+		err = tw.Close()
+		if err != nil {
+			errs <- err
+			return
+		}
+
 		_, err = file.Seek(0, io.SeekStart)
 		if err != nil {
 			errs <- err

--- a/cmd/osbuild-jobsite-manager/main.go
+++ b/cmd/osbuild-jobsite-manager/main.go
@@ -174,12 +174,17 @@ func Dance(done chan<- struct{}, errs chan<- error) {
 	close(done)
 }
 
-func Request(method string, path string, body io.Reader) (*http.Response, error) {
+func Request(method string, path string, body io.Reader, bodySeeker io.ReadSeeker) (*http.Response, error) {
 	cli := &http.Client{}
 	url := fmt.Sprintf("http://%s:%d/%s", argBuilderHost, argBuilderPort, path)
 
-	req, err := http.NewRequest(method, url, body)
-
+	var req *http.Request
+	var err error
+	if bodySeeker != nil {
+		req, err = http.NewRequest(method, url, bodySeeker)
+	} else {
+		req, err = http.NewRequest(method, url, body)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -195,6 +200,12 @@ func Request(method string, path string, body io.Reader) (*http.Response, error)
 
 		if err != nil {
 			if errors.Is(err, syscall.ECONNABORTED) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) {
+				if bodySeeker != nil {
+					_, err = bodySeeker.Seek(0, io.SeekStart)
+					if err != nil {
+						return nil, err
+					}
+				}
 				time.Sleep(1 * time.Second)
 				continue
 			}
@@ -224,7 +235,7 @@ func Wait(timeout int, fn Step) error {
 
 func StepClaim() error {
 	return Wait(argTimeoutClaim, func(done chan<- struct{}, errs chan<- error) {
-		res, err := Request("POST", "claim", nil)
+		res, err := Request("POST", "claim", nil, nil)
 
 		if err != nil {
 			errs <- err
@@ -246,7 +257,7 @@ func StepClaim() error {
 
 func StepProvision(manifest []byte) error {
 	return Wait(argTimeoutProvision, func(done chan<- struct{}, errs chan<- error) {
-		res, err := Request("PUT", "provision", bytes.NewBuffer(manifest))
+		res, err := Request("PUT", "provision", bytes.NewBuffer(manifest), nil)
 
 		if err != nil {
 			errs <- err
@@ -332,7 +343,7 @@ func StepPopulate() error {
 			return
 		}
 
-		res, err := Request("POST", "populate", file)
+		res, err := Request("POST", "populate", nil, file)
 		if err != nil {
 			errs <- err
 			return
@@ -363,7 +374,7 @@ func StepBuild() error {
 			logrus.Fatalf("StepBuild: Failed to marshal data: %s", err)
 		}
 
-		res, err := Request("POST", "build", bytes.NewBuffer(dat))
+		res, err := Request("POST", "build", bytes.NewBuffer(dat), nil)
 
 		if err != nil {
 			errs <- err
@@ -386,7 +397,7 @@ func StepBuild() error {
 func StepProgress() error {
 	return Wait(argTimeoutProgress, func(done chan<- struct{}, errs chan<- error) {
 		for {
-			res, err := Request("GET", "progress", nil)
+			res, err := Request("GET", "progress", nil, nil)
 
 			if err != nil {
 				errs <- err
@@ -423,7 +434,7 @@ func StepProgress() error {
 func StepExport() error {
 	return Wait(argTimeoutExport, func(done chan<- struct{}, errs chan<- error) {
 		for _, export := range argExports {
-			res, err := Request("GET", fmt.Sprintf("export?path=%s", url.PathEscape(export)), nil)
+			res, err := Request("GET", fmt.Sprintf("export?path=%s", url.PathEscape(export)), nil, nil)
 
 			if err != nil {
 				errs <- err


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
