### PR TITLE
osbuild-jobsite-builder: disable http.Server timeouts

### DIFF
--- a/cmd/osbuild-jobsite-builder/main.go
+++ b/cmd/osbuild-jobsite-builder/main.go
@@ -423,13 +423,10 @@ func (builder *Builder) Serve() error {
 
 	mux.HandleFunc("/export", builder.RegisterHandler(builder.HandleExport))
 
+	/* #nosec G112 */
 	builder.net = &http.Server{
-		ReadTimeout:       1 * time.Second,
-		WriteTimeout:      1800 * time.Second,
-		IdleTimeout:       30 * time.Second,
-		ReadHeaderTimeout: 1 * time.Second,
-		Addr:              fmt.Sprintf("%s:%d", builder.Host, builder.Port),
-		Handler:           mux,
+		Addr:    fmt.Sprintf("%s:%d", builder.Host, builder.Port),
+		Handler: mux,
 	}
 
 	return builder.net.ListenAndServe()


### PR DESCRIPTION
Let's just rely on the timeouts surrounding the whole step.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
