### PR TITLE
Create a nightly pipeline for GA/EUS releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,11 +60,15 @@ init:
 
 .upstream_rules_all:
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/'
 
 .upstream_rules_x86_64:
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER =~ "/^.*(x86_64).*$/"'
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER =~ "/^.*(x86_64).*$/" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/'
+
+.upstream_and_ga_rules_all:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER'
 
 .nightly_rules_all:
   rules:
@@ -73,6 +77,14 @@ init:
 .nightly_rules_x86_64:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.5-[^ga][\S]+/ && $RUNNER =~ "/^.*(x86_64).*$/" && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
+
+.ga_rules_all:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/ && $NIGHTLY == "false"'
+
+.ga_rules_x86_64:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/ && $RUNNER =~ "/^.*(x86_64).*$/" && $NIGHTLY == "false"'
 
 
 .RPM_RUNNERS_RHEL: &RPM_RUNNERS_RHEL
@@ -87,6 +99,7 @@ RPM:
   extends: .terraform
   rules:
     - !reference [.build_rules, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - sh "schutzbot/mockbuild.sh"
   parallel:
@@ -123,7 +136,8 @@ Container:
   stage: rpmbuild
   extends: .terraform
   rules:
-    - !reference [.build_rules, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - sh "schutzbot/containerbuild.sh"
   parallel:
@@ -135,7 +149,8 @@ Packer:
   stage: test
   extends: .terraform
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - tools/ci-build-worker-packer.sh
   variables:
@@ -167,6 +182,7 @@ Base:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/base_tests.sh
@@ -192,6 +208,7 @@ Base:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -229,23 +246,28 @@ regression-composer-works-behind-satellite:
 
 regression-excluded-dependency:
   extends: .regression
-  rules: 
-    # WHITELIST
-    - if: $RUNNER =~ "/^.*(rhel-8.*|rhel-9.*|centos-stream-9).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+  rules:
+    # WHITELIST & BLACKLIST: excluding GA runners from the PR pipeline
+    - if: $RUNNER =~ "/^.*(rhel-8.*|rhel-9.*|centos-stream-9).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   variables:
     SCRIPT: regression-excluded-dependency.sh
 
 regression-include-excluded-packages:
   extends: .regression
   rules: 
-    # BLACKLIST: Skipped on fedora systems
-    - if: $RUNNER !~ "/^.*(fedora).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    # BLACKLIST: Skipped on fedora systems & excluding GA runners from the PR pipeline
+    - if: $RUNNER !~ "/^.*(fedora).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   variables:
     SCRIPT: regression-include-excluded-packages.sh
 
 regression-old-worker-new-composer:
+  rules:
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   parallel:
     matrix:
       - RUNNER:
@@ -259,9 +281,10 @@ regression-old-worker-new-composer:
 regression-insecure-repo:
   extends: .regression
   rules:
-    # WHITELIST
-    - if: $RUNNER =~ "/^.*(rhel-*).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    # WHITELIST & BLACKLIST: excluding GA runners from the PR pipeline
+    - if: $RUNNER =~ "/^.*(rhel-*).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   variables:
     SCRIPT: regression-insecure-repo.sh
 
@@ -269,9 +292,10 @@ regression-insecure-repo:
 regression-no-explicit-rootfs-definition:
   extends: .regression
   rules: 
-    # BLACKLIST: Skipped on fedora systems
-    - if: $RUNNER !~ "/^.*(fedora).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    # BLACKLIST: Skipped on fedora systems & excluding GA runners from the PR pipeline
+    - if: $RUNNER !~ "/^.*(fedora).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   variables:
     SCRIPT: regression-no-explicit-rootfs-definition.sh
 
@@ -308,6 +332,7 @@ Trigger-rhel-edge-ci:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -348,7 +373,8 @@ koji.sh (cloud upload):
   stage: test
   extends: .terraform
   rules:
-    - !reference [.upstream_rules_all, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/koji.sh cloud-upload ${CLOUD_TARGET} ${IMAGE_TYPE}
@@ -377,7 +403,8 @@ koji.sh (cloudapi):
   extends: .integration
   # Not supported in nightly pipelines
   rules:
-    - !reference [.upstream_rules_all, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   variables:
     SCRIPT: koji.sh
   parallel:
@@ -391,7 +418,7 @@ koji.sh (cloudapi):
 aws.sh:
   extends: .integration
   rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-8.4-[\S]+/'
+    - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.5-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
   variables:
     SCRIPT: aws.sh
@@ -401,6 +428,7 @@ oci.sh:
   rules:
     # Run only on x86_64
     - !reference [.upstream_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: oci.sh
 
@@ -422,6 +450,7 @@ azure.sh:
     # Run only on x86_64
     - !reference [.upstream_rules_x86_64, rules]
     - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: azure.sh
 
@@ -431,6 +460,7 @@ azure.sh_hyperv_gen2:
     # Run only on x86_64
     - !reference [.upstream_rules_x86_64, rules]
     - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: azure_hyperv_gen2.sh
 
@@ -440,6 +470,7 @@ gcp.sh:
   rules: 
     - !reference [.upstream_rules_x86_64, rules]
     - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: gcp.sh
 
@@ -449,6 +480,7 @@ vmware.sh_vmdk:
     # Run only on x86_64
     - !reference [.upstream_rules_x86_64, rules]
     - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: vmware.sh vmdk
 
@@ -458,6 +490,7 @@ vmware.sh_ova:
     # Run only on x86_64
     - !reference [.upstream_rules_x86_64, rules]
     - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
   variables:
     SCRIPT: vmware.sh ova
 
@@ -492,7 +525,8 @@ API:
   stage: test
   extends: .terraform
   rules:
-    - !reference [.upstream_rules_all, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
     # note: cloud API is not supported for on-prem installations so
     # don't run this test case for nightly trees
   script:
@@ -523,7 +557,8 @@ API-module-hotfixes:
   stage: test
   extends: .terraform
   rules:
-    - !reference [.upstream_rules_all, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
     # note: cloud API is not supported for on-prem installations so
     # don't run this test case for nightly trees
   script:
@@ -551,6 +586,7 @@ API-module-hotfixes:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/${SCRIPT}
@@ -576,6 +612,7 @@ ubi-wsl.sh:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ubi-wsl.sh
@@ -592,6 +629,7 @@ weldr-distro-dot-notation+aliases:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/weldr-distro-dot-notation-and-aliases.sh
@@ -606,8 +644,9 @@ weldr-distro-dot-notation+aliases:
   extends: .libvirt_integration
   rules:
     # BLACKLIST
-    - if: $RUNNER !~ "/^.*(rhel-9.5).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $NIGHTLY != "true"
+    - if: $RUNNER !~ "/^.*(rhel-9.5).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $NIGHTLY != "true" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
 
 generic_s3_http.sh:
   extends: .generic_s3
@@ -633,7 +672,8 @@ RHEL 9 on 8:
   stage: test
   extends: .terraform
   rules:
-    - !reference [.upstream_rules_all, rules]
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/koji.sh
@@ -673,7 +713,7 @@ NIGHTLY_FAIL:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
       when: on_failure
   script:
-    - schutzbot/slack_notification.sh FAILED ":big-sad:"
+    - schutzbot/slack_notification.sh FAILED ":big-sad:" nightly
 
 NIGHTLY_SUCCESS:
   stage: finish
@@ -682,7 +722,26 @@ NIGHTLY_SUCCESS:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY == "true"'
   script:
-    - schutzbot/slack_notification.sh SUCCESS ":partymeow:"
+    - schutzbot/slack_notification.sh SUCCESS ":partymeow:" nightly
+
+GA_FAIL:
+  stage: finish
+  tags:
+    - shell
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY== "false"'
+      when: on_failure
+  script:
+    - schutzbot/slack_notification.sh FAILED ":big-sad:" ga
+
+GA_SUCCESS:
+  stage: finish
+  tags:
+    - shell
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY== "false"'
+  script:
+    - schutzbot/slack_notification.sh SUCCESS ":partymeow:" ga
 
 Installer:
   stage: test
@@ -690,6 +749,7 @@ Installer:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/installers.sh
@@ -704,6 +764,7 @@ ContainerUpload:
   extends: .terraform
   rules:
     - !reference [.upstream_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/container-upload.sh
@@ -718,6 +779,7 @@ ContainerEmbedding:
   rules:
     - !reference [.upstream_rules_all, rules]
     - !reference [.nightly_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/container-embedding.sh
@@ -734,6 +796,7 @@ WorkerExecutor:
   extends: .terraform
   rules:
     - !reference [.upstream_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/worker-executor.sh

--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -9,7 +9,11 @@ fi
 
 COMPOSE_ID=$(cat COMPOSE_ID)
 COMPOSER_NVR=$(cat COMPOSER_NVR)
-MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""
+if [ "$3" == "ga" ]; then
+    MESSAGE="\"GA composes pipeline execution finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL \""
+else
+    MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""
+fi
 
 curl \
     -X POST \


### PR DESCRIPTION
Separate RHEL GA/EUS releases testing to nightly pipeline from the pipeline ran on every PR.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
