### PR TITLE
main: journald support with external correlation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__
 /containers/config/
 /bin
 /rpmbuild
+/osbuild-composer
+/osbuild-worker
 
 /tools/appsre-ansible/inventory
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,8 @@
 onto a system. We recommend doing this by building rpms, with:
 
 ```
+dnf install fedora-packager
+dnf builddep osbuild-composer
 make rpm
 ```
 
@@ -94,4 +96,22 @@ To rebuild the containers after a change, add the `--build` flag to the `docker-
 
 ```
 docker-compose up --build
+```
+
+## Shortening the loop
+
+For some components, it is possible to install distribution packages first and then only to replace binaries which may or may not work for smaller changes.
+
+```
+systemctl stop osbuild-composer.service osbuild-composer.socket osbuild-local-worker.socket
+make build && sudo install -m755 bin/osbuild-composer bin/osbuild-worker /usr/libexec/osbuild-composer/
+systemctl start osbuild-composer.socket osbuild-local-worker.socket
+```
+
+## Accessing Cloud API
+
+You can use curl to access the Cloud API:
+
+```
+curl --unix-socket /run/cloudapi/api.socket -XGET http://localhost/api/image-builder-composer/v2/openapi
 ```

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -129,7 +129,7 @@ func GetDefaultConfig() *ComposerConfigFile {
 			"rhel-10": "rhel-10.0",
 		},
 		LogLevel:  "info",
-		LogFormat: "text",
+		LogFormat: "journal",
 		DNFJson:   "/usr/libexec/osbuild-depsolve-dnf",
 	}
 }

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -77,7 +77,7 @@ func TestDefaultConfig(t *testing.T) {
 	}
 	require.Equal(t, expectedDistroAliases, defaultConfig.DistroAliases)
 
-	require.Equal(t, "text", defaultConfig.LogFormat)
+	require.Equal(t, "journal", defaultConfig.LogFormat)
 }
 
 func TestConfig(t *testing.T) {

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -50,6 +50,8 @@ func main() {
 	logLevel, err := logrus.ParseLevel(config.LogLevel)
 
 	logrus.SetReportCaller(true)
+	// Add context hook to log operation_id and external_id
+	logrus.AddHook(&common.ContextHook{})
 
 	if err == nil {
 		logrus.SetLevel(logLevel)

--- a/internal/common/context_hook.go
+++ b/internal/common/context_hook.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type ContextHook struct{}
+
+func (h *ContextHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *ContextHook) Fire(e *logrus.Entry) error {
+	if e.Context == nil {
+		return nil
+	}
+
+	if val := e.Context.Value(operationIDKeyCtx); val != nil {
+		e.Data["operation_id"] = val
+	}
+	if val := e.Context.Value(externalIDKeyCtx); val != nil {
+		e.Data["external_id"] = val
+	}
+
+	return nil
+}

--- a/internal/common/echo_logrus.go
+++ b/internal/common/echo_logrus.go
@@ -1,39 +1,42 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 
-	"github.com/labstack/gommon/log"
+	lslog "github.com/labstack/gommon/log"
 	"github.com/sirupsen/logrus"
 )
 
 // EchoLogrusLogger extend logrus.Logger
 type EchoLogrusLogger struct {
 	*logrus.Logger
+	Ctx context.Context
 }
 
 var commonLogger = &EchoLogrusLogger{
 	Logger: logrus.StandardLogger(),
+	Ctx:    context.Background(),
 }
 
 func Logger() *EchoLogrusLogger {
 	return commonLogger
 }
 
-func toEchoLevel(level logrus.Level) log.Lvl {
+func toEchoLevel(level logrus.Level) lslog.Lvl {
 	switch level {
 	case logrus.DebugLevel:
-		return log.DEBUG
+		return lslog.DEBUG
 	case logrus.InfoLevel:
-		return log.INFO
+		return lslog.INFO
 	case logrus.WarnLevel:
-		return log.WARN
+		return lslog.WARN
 	case logrus.ErrorLevel:
-		return log.ERROR
+		return lslog.ERROR
 	}
 
-	return log.OFF
+	return lslog.OFF
 }
 
 func (l *EchoLogrusLogger) Output() io.Writer {
@@ -44,11 +47,11 @@ func (l *EchoLogrusLogger) SetOutput(w io.Writer) {
 	// disable operations that would change behavior of global logrus logger.
 }
 
-func (l *EchoLogrusLogger) Level() log.Lvl {
+func (l *EchoLogrusLogger) Level() lslog.Lvl {
 	return toEchoLevel(l.Logger.Level)
 }
 
-func (l *EchoLogrusLogger) SetLevel(v log.Lvl) {
+func (l *EchoLogrusLogger) SetLevel(v lslog.Lvl) {
 	// disable operations that would change behavior of global logrus logger.
 }
 
@@ -63,113 +66,117 @@ func (l *EchoLogrusLogger) SetPrefix(p string) {
 }
 
 func (l *EchoLogrusLogger) Print(i ...interface{}) {
-	l.Logger.Print(i...)
+	l.Logger.WithContext(l.Ctx).Print(i...)
 }
 
 func (l *EchoLogrusLogger) Printf(format string, args ...interface{}) {
-	l.Logger.Printf(format, args...)
+	l.Logger.WithContext(l.Ctx).Printf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Printj(j log.JSON) {
+func (l *EchoLogrusLogger) Printj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Println(string(b))
+	l.Logger.WithContext(l.Ctx).Println(string(b))
 }
 
 func (l *EchoLogrusLogger) Debug(i ...interface{}) {
-	l.Logger.Debug(i...)
+	l.Logger.WithContext(l.Ctx).Debug(i...)
 }
 
 func (l *EchoLogrusLogger) Debugf(format string, args ...interface{}) {
-	l.Logger.Debugf(format, args...)
+	l.Logger.WithContext(l.Ctx).Debugf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Debugj(j log.JSON) {
+func (l *EchoLogrusLogger) Debugj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Debugln(string(b))
+	l.Logger.WithContext(l.Ctx).Debugln(string(b))
 }
 
 func (l *EchoLogrusLogger) Info(i ...interface{}) {
-	l.Logger.Info(i...)
+	l.Logger.WithContext(l.Ctx).Info(i...)
 }
 
 func (l *EchoLogrusLogger) Infof(format string, args ...interface{}) {
-	l.Logger.Infof(format, args...)
+	l.Logger.WithContext(l.Ctx).Infof(format, args...)
 }
 
-func (l *EchoLogrusLogger) Infoj(j log.JSON) {
+func (l *EchoLogrusLogger) Infoj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Infoln(string(b))
+	l.Logger.WithContext(l.Ctx).Infoln(string(b))
 }
 
 func (l *EchoLogrusLogger) Warn(i ...interface{}) {
-	l.Logger.Warn(i...)
+	l.Logger.WithContext(l.Ctx).Warn(i...)
 }
 
 func (l *EchoLogrusLogger) Warnf(format string, args ...interface{}) {
-	l.Logger.Warnf(format, args...)
+	l.Logger.WithContext(l.Ctx).Warnf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Warnj(j log.JSON) {
+func (l *EchoLogrusLogger) Warnj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Warnln(string(b))
+	l.Logger.WithContext(l.Ctx).Warnln(string(b))
 }
 
 func (l *EchoLogrusLogger) Error(i ...interface{}) {
-	l.Logger.Error(i...)
+	l.Logger.WithContext(l.Ctx).Error(i...)
 }
 
 func (l *EchoLogrusLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+	l.Logger.WithContext(l.Ctx).Errorf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Errorj(j log.JSON) {
+func (l *EchoLogrusLogger) Errorj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Errorln(string(b))
+	l.Logger.WithContext(l.Ctx).Errorln(string(b))
 }
 
 func (l *EchoLogrusLogger) Fatal(i ...interface{}) {
-	l.Logger.Fatal(i...)
+	l.Logger.WithContext(l.Ctx).Fatal(i...)
 }
 
 func (l *EchoLogrusLogger) Fatalf(format string, args ...interface{}) {
-	l.Logger.Fatalf(format, args...)
+	l.Logger.WithContext(l.Ctx).Fatalf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Fatalj(j log.JSON) {
+func (l *EchoLogrusLogger) Fatalj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Fatalln(string(b))
+	l.Logger.WithContext(l.Ctx).Fatalln(string(b))
 }
 
 func (l *EchoLogrusLogger) Panic(i ...interface{}) {
-	l.Logger.Panic(i...)
+	l.Logger.WithContext(l.Ctx).Panic(i...)
 }
 
 func (l *EchoLogrusLogger) Panicf(format string, args ...interface{}) {
-	l.Logger.Panicf(format, args...)
+	l.Logger.WithContext(l.Ctx).Panicf(format, args...)
 }
 
-func (l *EchoLogrusLogger) Panicj(j log.JSON) {
+func (l *EchoLogrusLogger) Panicj(j lslog.JSON) {
 	b, err := json.Marshal(j)
 	if err != nil {
 		panic(err)
 	}
-	l.Logger.Panicln(string(b))
+	l.Logger.WithContext(l.Ctx).Panicln(string(b))
+}
+
+func (l *EchoLogrusLogger) Write(p []byte) (n int, err error) {
+	return l.Logger.WithContext(l.Ctx).Writer().Write(p)
 }

--- a/internal/common/external_id.go
+++ b/internal/common/external_id.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"context"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+const ExternalIDKey string = "externalID"
+const externalIDKeyCtx ctxKey = ctxKey(ExternalIDKey)
+
+// Extracts HTTP header X-External-Id and sets it as a request context value
+func ExternalIDMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		eid := c.Request().Header.Get("X-External-Id")
+		if eid == "" {
+			return next(c)
+		}
+
+		eid = strings.TrimSuffix(eid, "\n")
+		c.Set(ExternalIDKey, eid)
+
+		ctx := c.Request().Context()
+		ctx = context.WithValue(ctx, externalIDKeyCtx, eid)
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		return next(c)
+	}
+}

--- a/internal/common/journal_hook.go
+++ b/internal/common/journal_hook.go
@@ -1,0 +1,70 @@
+// Inspired by github.com/wercker/journalhook (MIT license)
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-systemd/journal"
+	logrus "github.com/sirupsen/logrus"
+)
+
+type JournalHook struct{}
+
+var (
+	severityMap = map[logrus.Level]journal.Priority{
+		logrus.DebugLevel: journal.PriDebug,
+		logrus.InfoLevel:  journal.PriInfo,
+		logrus.WarnLevel:  journal.PriWarning,
+		logrus.ErrorLevel: journal.PriErr,
+		logrus.FatalLevel: journal.PriCrit,
+		logrus.PanicLevel: journal.PriEmerg,
+	}
+)
+
+func stringifyOp(r rune) rune {
+	switch {
+	case r >= 'A' && r <= 'Z':
+		return r
+	case r >= '0' && r <= '9':
+		return r
+	case r == '_':
+		return r
+	case r >= 'a' && r <= 'z':
+		return r - 32
+	default:
+		return rune('_')
+	}
+}
+
+func stringifyKey(key string) string {
+	key = strings.Map(stringifyOp, key)
+	key = strings.TrimPrefix(key, "_")
+	return key
+}
+
+// Journal wants strings but logrus takes anything.
+func stringifyEntries(data map[string]interface{}) map[string]string {
+	entries := make(map[string]string)
+	for k, v := range data {
+
+		key := stringifyKey(k)
+		entries[key] = fmt.Sprint(v)
+	}
+	return entries
+}
+
+func (hook *JournalHook) Fire(entry *logrus.Entry) error {
+	return journal.Send(entry.Message, severityMap[entry.Level], stringifyEntries(entry.Data))
+}
+
+func (hook *JournalHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+		logrus.DebugLevel,
+	}
+}

--- a/internal/common/journal_hook_test.go
+++ b/internal/common/journal_hook_test.go
@@ -1,0 +1,27 @@
+package common
+
+import "testing"
+
+func TestStringifyEntries(t *testing.T) {
+	input := map[string]interface{}{
+		"foo":     "bar",
+		"baz":     123,
+		"foo-foo": "x",
+		"-bar":    "1",
+	}
+
+	output := stringifyEntries(input)
+	if output["FOO"] != "bar" {
+		t.Fatalf("%v", output)
+		t.Fatalf("expected value 'bar'. Got %q", output["FOO"])
+	}
+	if output["BAZ"] != "123" {
+		t.Fatalf("expected value '123'. Got %q", output["BAZ"])
+	}
+	if output["FOO_FOO"] != "x" {
+		t.Fatalf("expected value 'x'. Got %q", output["FOO_FOO"])
+	}
+	if output["BAR"] != "1" {
+		t.Fatalf("expected value 'x'. Got %q", output["BAR"])
+	}
+}

--- a/internal/common/logger_middleware.go
+++ b/internal/common/logger_middleware.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
+)
+
+// Store context in request logger to propagate correlation ids
+func LoggerMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.SetLogger(&EchoLogrusLogger{
+			Logger: logrus.StandardLogger(),
+			Ctx:    c.Request().Context(),
+		})
+
+		return next(c)
+	}
+}

--- a/internal/common/operation_id.go
+++ b/internal/common/operation_id.go
@@ -1,18 +1,29 @@
 package common
 
 import (
+	"context"
+
 	"github.com/labstack/echo/v4"
 	"github.com/segmentio/ksuid"
 )
 
+type ctxKey string
+
 const OperationIDKey string = "operationID"
+const operationIDKeyCtx ctxKey = ctxKey(OperationIDKey)
 
 // Adds a time-sortable globally unique identifier to an echo.Context if not already set
 func OperationIDMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		if c.Get(OperationIDKey) == nil {
-			c.Set(OperationIDKey, GenerateOperationID())
+			oid := GenerateOperationID()
+			c.Set(OperationIDKey, oid)
+
+			ctx := c.Request().Context()
+			ctx = context.WithValue(ctx, operationIDKeyCtx, oid)
+			c.SetRequest(c.Request().WithContext(ctx))
 		}
+
 		return next(c)
 	}
 }

--- a/vendor/github.com/coreos/go-systemd/journal/journal.go
+++ b/vendor/github.com/coreos/go-systemd/journal/journal.go
@@ -1,0 +1,225 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package journal provides write bindings to the local systemd journal.
+// It is implemented in pure Go and connects to the journal directly over its
+// unix socket.
+//
+// To read from the journal, see the "sdjournal" package, which wraps the
+// sd-journal a C API.
+//
+// http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
+package journal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+)
+
+// Priority of a journal message
+type Priority int
+
+const (
+	PriEmerg Priority = iota
+	PriAlert
+	PriCrit
+	PriErr
+	PriWarning
+	PriNotice
+	PriInfo
+	PriDebug
+)
+
+var (
+	// This can be overridden at build-time:
+	// https://github.com/golang/go/wiki/GcToolchainTricks#including-build-information-in-the-executable
+	journalSocket = "/run/systemd/journal/socket"
+
+	// unixConnPtr atomically holds the local unconnected Unix-domain socket.
+	// Concrete safe pointer type: *net.UnixConn
+	unixConnPtr unsafe.Pointer
+	// onceConn ensures that unixConnPtr is initialized exactly once.
+	onceConn sync.Once
+)
+
+func init() {
+	onceConn.Do(initConn)
+}
+
+// Enabled checks whether the local systemd journal is available for logging.
+func Enabled() bool {
+	onceConn.Do(initConn)
+
+	if (*net.UnixConn)(atomic.LoadPointer(&unixConnPtr)) == nil {
+		return false
+	}
+
+	if _, err := net.Dial("unixgram", journalSocket); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Send a message to the local systemd journal. vars is a map of journald
+// fields to values.  Fields must be composed of uppercase letters, numbers,
+// and underscores, but must not start with an underscore. Within these
+// restrictions, any arbitrary field name may be used.  Some names have special
+// significance: see the journalctl documentation
+// (http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html)
+// for more details.  vars may be nil.
+func Send(message string, priority Priority, vars map[string]string) error {
+	conn := (*net.UnixConn)(atomic.LoadPointer(&unixConnPtr))
+	if conn == nil {
+		return errors.New("could not initialize socket to journald")
+	}
+
+	socketAddr := &net.UnixAddr{
+		Name: journalSocket,
+		Net:  "unixgram",
+	}
+
+	data := new(bytes.Buffer)
+	appendVariable(data, "PRIORITY", strconv.Itoa(int(priority)))
+	appendVariable(data, "MESSAGE", message)
+	for k, v := range vars {
+		appendVariable(data, k, v)
+	}
+
+	_, _, err := conn.WriteMsgUnix(data.Bytes(), nil, socketAddr)
+	if err == nil {
+		return nil
+	}
+	if !isSocketSpaceError(err) {
+		return err
+	}
+
+	// Large log entry, send it via tempfile and ancillary-fd.
+	file, err := tempFd()
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.Copy(file, data)
+	if err != nil {
+		return err
+	}
+	rights := syscall.UnixRights(int(file.Fd()))
+	_, _, err = conn.WriteMsgUnix([]byte{}, rights, socketAddr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Print prints a message to the local systemd journal using Send().
+func Print(priority Priority, format string, a ...interface{}) error {
+	return Send(fmt.Sprintf(format, a...), priority, nil)
+}
+
+func appendVariable(w io.Writer, name, value string) {
+	if err := validVarName(name); err != nil {
+		fmt.Fprintf(os.Stderr, "variable name %s contains invalid character, ignoring\n", name)
+	}
+	if strings.ContainsRune(value, '\n') {
+		/* When the value contains a newline, we write:
+		 * - the variable name, followed by a newline
+		 * - the size (in 64bit little endian format)
+		 * - the data, followed by a newline
+		 */
+		fmt.Fprintln(w, name)
+		binary.Write(w, binary.LittleEndian, uint64(len(value)))
+		fmt.Fprintln(w, value)
+	} else {
+		/* just write the variable and value all on one line */
+		fmt.Fprintf(w, "%s=%s\n", name, value)
+	}
+}
+
+// validVarName validates a variable name to make sure journald will accept it.
+// The variable name must be in uppercase and consist only of characters,
+// numbers and underscores, and may not begin with an underscore:
+// https://www.freedesktop.org/software/systemd/man/sd_journal_print.html
+func validVarName(name string) error {
+	if name == "" {
+		return errors.New("Empty variable name")
+	} else if name[0] == '_' {
+		return errors.New("Variable name begins with an underscore")
+	}
+
+	for _, c := range name {
+		if !(('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_') {
+			return errors.New("Variable name contains invalid characters")
+		}
+	}
+	return nil
+}
+
+// isSocketSpaceError checks whether the error is signaling
+// an "overlarge message" condition.
+func isSocketSpaceError(err error) bool {
+	opErr, ok := err.(*net.OpError)
+	if !ok || opErr == nil {
+		return false
+	}
+
+	sysErr, ok := opErr.Err.(*os.SyscallError)
+	if !ok || sysErr == nil {
+		return false
+	}
+
+	return sysErr.Err == syscall.EMSGSIZE || sysErr.Err == syscall.ENOBUFS
+}
+
+// tempFd creates a temporary, unlinked file under `/dev/shm`.
+func tempFd() (*os.File, error) {
+	file, err := ioutil.TempFile("/dev/shm/", "journal.XXXXX")
+	if err != nil {
+		return nil, err
+	}
+	err = syscall.Unlink(file.Name())
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+// initConn initializes the global `unixConnPtr` socket.
+// It is meant to be called exactly once, at program startup.
+func initConn() {
+	autobind, err := net.ResolveUnixAddr("unixgram", "")
+	if err != nil {
+		return
+	}
+
+	sock, err := net.ListenUnixgram("unixgram", autobind)
+	if err != nil {
+		return
+	}
+
+	atomic.StorePointer(&unixConnPtr, unsafe.Pointer(sock))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,8 @@ github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 ## explicit
 github.com/coreos/go-systemd/activation
-# github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f
+github.com/coreos/go-systemd/journal
+# github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46
 ## explicit
 github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer
 # github.com/cyphar/filepath-securejoin v0.2.4

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -437,7 +437,7 @@ github.com/coreos/go-semver/semver
 ## explicit
 github.com/coreos/go-systemd/activation
 github.com/coreos/go-systemd/journal
-# github.com/cyberphone/json-canonicalization v0.0.0-20231011164504-785e29786b46
+# github.com/cyberphone/json-canonicalization v0.0.0-20231217050601-ba74d44ecf5f
 ## explicit
 github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer
 # github.com/cyphar/filepath-securejoin v0.2.4


### PR DESCRIPTION
This patch adds native journald support through logrus which enables to work with structured logs. It uses a dependency that is already in the project (`coreos/systemd-go`) which is a pure Go implementation. New log type is introduced named "journal" and it is now the default with fallback to "text" if journald is not present on the system.

Structured logging enabled me to work with logrus fields that can help with correlating log records on standalone or hosted deployments. Already existing "operation_id" field (random string) is now fully propagated via echo context logger and new logrus hook extracts it from Go standard context.

A new field called "external_id" is extracted from HTTP header `X-External-Id` when present. The idea is to set this to X-Edge-Request-Id on hosted image builder so logs can be easily correlated across both services.

Additionally, each cloud API request is now logged using the built-in echo logging middleware which creates entries like `Processed request GET /path`. Together with journald this can be tested end-to-end:

```
# curl -H "X-External-Id: XXXX" --unix-socket /run/cloudapi/api.socket -XGET http://localhost/api/image-builder-composer/v2/openapi
```

This will create the following entries:

```
# journalctl -e -o json-pretty --output-fields=OPERATION_ID,MESSAGE,EXTERNAL_ID
{
        "OPERATION_ID" : "2eJwe1mdLa9s2rB3PVZbVAttQi1",
        "EXTERNAL_ID" : "XXXX",
        "MESSAGE" : "Returning OpenAPI document"
}
{
        "MESSAGE" : "Processed request GET /api/image-builder-composer/v2/openapi",
        "EXTERNAL_ID" : "XXXX",
        "OPERATION_ID" : "2eJwe1mdLa9s2rB3PVZbVAttQi1",
}
```

Users can easily dig logs per request or operation:

```
# journalctl -u osbuild-composer OPERATION_ID=2eJwe1mdLa9s2rB3PVZbVAttQi1 -o cat
Returning OpenAPI document
Processed request GET /api/image-builder-composer/v2/openapi
```

TODO

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

