### PR TITLE
templates/packer: set http(s)_proxy environment variable in unit HMS-3798

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
@@ -4,5 +4,16 @@ source /tmp/cloud_init_vars
 
 echo "Starting worker service."
 
+http_proxy=${http_proxy:-}
+https_proxy=${https_proxy:-}
+if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
+   sudo mkdir /etc/systemd/system/osbuild-remote-worker@.service.d/
+   sudo tee -a /etc/systemd/system/osbuild-remote-worker@.service.d/override.conf <<EOF
+[Service]
+Environment="http_proxy=$http_proxy"
+Environment="https_proxy=$https_proxy"
+EOF
+fi
+
 # Prepare osbuild-composer's remote worker services and sockets.
 systemctl enable --now "osbuild-remote-worker@${COMPOSER_HOST}:${COMPOSER_PORT}"


### PR DESCRIPTION
The snapshotted repositories on stage are behind a VPN + a proxy. 