### PR TITLE
go.mod: update to go v1.20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: "1.20"
     - env:
         PGUSER: postgres
         PGPASSWORD: foobar
@@ -105,10 +105,10 @@ jobs:
     name: "⌨ Golang Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
         id: go
 
       - name: Check out code into the Go module directory
@@ -163,10 +163,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.20"
         id: go
 
       - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The requirements for this project are:
 
 At build-time, the following software is required:
 
- * `go >= 1.19`
+ * `go >= 1.20`
  * `python-docutils >= 0.13`
  * `krb5-devel` for fedora/rhel or `libkrb5-dev` for debian/ubuntu`
  * `btrfs-progs-devel` for fedora/rhel or `libbtrfs-dev` for debian/ubuntu

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/osbuild-composer
 
-go 1.19
+go 1.20
 
 exclude github.com/mattn/go-sqlite3 v2.0.3+incompatible
 

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -774,8 +774,9 @@ func TestBlueprintsDelete(t *testing.T) {
 func TestBlueprintsChanges(t *testing.T) {
 	api, sf := createTestWeldrAPI(t.TempDir(), test_distro.TestDistro1Name, test_distro.TestArchName, rpmmd_mock.BaseFixture, nil)
 	t.Cleanup(sf.Cleanup)
-	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	/* #nosec G404 */
 	id := strconv.Itoa(rand.Int())
 	ignoreFields := []string{"commit", "timestamp"}
@@ -800,8 +801,9 @@ func TestBlueprintsChanges(t *testing.T) {
 func TestBlueprintChange(t *testing.T) {
 	api, sf := createTestWeldrAPI(t.TempDir(), test_distro.TestDistro1Name, test_distro.TestArchName, rpmmd_mock.BaseFixture, nil)
 	t.Cleanup(sf.Cleanup)
-	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	/* #nosec G404 */
 	id := strconv.Itoa(rand.Int())
 
@@ -860,8 +862,9 @@ func TestBlueprintsDepsolve(t *testing.T) {
 func TestOldBlueprintsUndo(t *testing.T) {
 	api, sf := createTestWeldrAPI(t.TempDir(), test_distro.TestDistro1Name, test_distro.TestArchName, rpmmd_mock.OldChangesFixture, nil)
 	t.Cleanup(sf.Cleanup)
-	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	/* #nosec G404 */
 	ignoreFields := []string{"commit", "timestamp"}
 
@@ -895,8 +898,9 @@ func TestOldBlueprintsUndo(t *testing.T) {
 func TestNewBlueprintsUndo(t *testing.T) {
 	api, sf := createTestWeldrAPI(t.TempDir(), test_distro.TestDistro1Name, test_distro.TestArchName, rpmmd_mock.BaseFixture, nil)
 	t.Cleanup(sf.Cleanup)
-	rand.Seed(time.Now().UnixNano())
 	// math/rand is good enough in this case
+	/* #nosec G404 */
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	/* #nosec G404 */
 	id := strconv.Itoa(rand.Int())
 	ignoreFields := []string{"commit", "timestamp"}

--- a/pkg/splunk_logger/go.mod
+++ b/pkg/splunk_logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/osbuild-composer/pkg/splunk_logger
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.5

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.19.11
+GO_VERSION=1.20.12
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
Go 1.20 is included in all currently supported distro versions.

Newer versions of a lot of our dependencies now require go 1.20, which is making dependabot PRs fail.
