### PR TITLE
worker: support http proxy for depsolve and osbuild sources job HMS-3798

### DIFF
--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -83,6 +83,7 @@ type repositoryMTLSConfig struct {
 	CA             string `toml:"ca"`
 	MTLSClientKey  string `toml:"mtls_client_key"`
 	MTLSClientCert string `toml:"mtls_client_cert"`
+	Proxy          string `toml:"proxy"`
 }
 
 type workerConfig struct {

--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -19,6 +19,7 @@ type RepositoryMTLSConfig struct {
 	CA             string
 	MTLSClientKey  string
 	MTLSClientCert string
+	Proxy          *url.URL
 }
 
 func (rmc *RepositoryMTLSConfig) CompareBaseURL(baseURLStr string) (bool, error) {
@@ -51,6 +52,12 @@ type DepsolveJobImpl struct {
 // (matching map keys).
 func (impl *DepsolveJobImpl) depsolve(packageSets map[string][]rpmmd.PackageSet, modulePlatformID, arch, releasever string) (map[string][]rpmmd.PackageSpec, map[string][]rpmmd.RepoConfig, error) {
 	solver := impl.Solver.NewWithConfig(modulePlatformID, releasever, arch, "")
+	if impl.RepositoryMTLSConfig.Proxy != nil {
+		err := solver.SetProxy(impl.RepositoryMTLSConfig.Proxy.String())
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	repoConfigs := make(map[string][]rpmmd.RepoConfig)

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -491,6 +491,9 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		}
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_KEY=%s", impl.RepositoryMTLSConfig.MTLSClientKey))
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT=%s", impl.RepositoryMTLSConfig.MTLSClientCert))
+		if impl.RepositoryMTLSConfig.Proxy != nil {
+			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_PROXY=%s", impl.RepositoryMTLSConfig.Proxy.String()))
+		}
 	}
 
 	// Run osbuild and handle two kinds of errors

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -440,11 +440,21 @@ func main() {
 		if err != nil {
 			logrus.Fatalf("Repository MTL baseurl not valid: %v", err)
 		}
+
+		var proxyURL *url.URL
+		if config.RepositoryMTLSConfig.Proxy != "" {
+			proxyURL, err = url.Parse(config.RepositoryMTLSConfig.Proxy)
+			if err != nil {
+				logrus.Fatalf("Repository Proxy url not valid: %v", err)
+			}
+		}
+
 		repositoryMTLSConfig = &RepositoryMTLSConfig{
 			BaseURL:        baseURL,
 			CA:             config.RepositoryMTLSConfig.CA,
 			MTLSClientKey:  config.RepositoryMTLSConfig.MTLSClientKey,
 			MTLSClientCert: config.RepositoryMTLSConfig.MTLSClientCert,
+			Proxy:          proxyURL,
 		}
 	}
 

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
@@ -17,6 +17,7 @@ MTLS_CERT=$(jq -r ".cert" /tmp/ldap_service_account_mtls_credentials.json)
 MTLS_KEY=$(jq -r ".key" /tmp/ldap_service_account_mtls_credentials.json)
 BASEURL=$(jq -r ".baseurl" /tmp/ldap_service_account_mtls_credentials.json)
 CA=$(jq -r ".ca" /tmp/ldap_service_account_mtls_credentials.json)
+PROXY=$(jq -r ".proxy" /tmp/ldap_service_account_mtls_credentials.json)
 rm /tmp/ldap_service_account_mtls_credentials.json
 
 sudo tee /etc/osbuild-worker/image_builder_sa_mtls_cert.pem > /dev/null << EOF
@@ -32,6 +33,7 @@ sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 baseurl = "$BASEURL"
 mtls_client_key = "/etc/osbuild-worker/image_builder_sa_mtls_key.pem"
 mtls_client_cert = "/etc/osbuild-worker/image_builder_sa_mtls_cert.pem"
+proxy = "$PROXY"
 EOF
 
 if [ "$CA" != null ]; then

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_service.sh
@@ -4,16 +4,5 @@ source /tmp/cloud_init_vars
 
 echo "Starting worker service."
 
-http_proxy=${http_proxy:-}
-https_proxy=${https_proxy:-}
-if [ -n "$http_proxy" ] || [ -n "$https_proxy" ]; then
-   sudo mkdir /etc/systemd/system/osbuild-remote-worker@.service.d/
-   sudo tee -a /etc/systemd/system/osbuild-remote-worker@.service.d/override.conf <<EOF
-[Service]
-Environment="http_proxy=$http_proxy"
-Environment="https_proxy=$https_proxy"
-EOF
-fi
-
 # Prepare osbuild-composer's remote worker services and sockets.
 systemctl enable --now "osbuild-remote-worker@${COMPOSER_HOST}:${COMPOSER_PORT}"


### PR DESCRIPTION

The AWS sdk fails to get the instance identity document when the proxy
is configured. The proxy will need to be configured explicitly for the
depsolve job and osbuild (sources) job.

