### PR TITLE
ci_details: add volumes and fs info

### DIFF
--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -33,9 +33,13 @@ CI MACHINE SPECS
 EOF
 echo -e "\033[0m"
 
+echo "Volume and file system info:"
+sudo lsblk
+sudo findmnt
+echo "------------------------------------------------------------------------------"
+
 echo "List of system repositories:"
 sudo yum repolist -v
-
 echo "------------------------------------------------------------------------------"
 
 echo "List of installed packages:"


### PR DESCRIPTION
This is my attempt to gather some intel about how storage is configured on build nodes. My ideas include adding `noatime` or other fs optimalizations to `/etc/fstab` or formatting and mounting ephemeral volumes on instances which have it available to speed up builds.

I maintained http://koji.katello.org/koji/index for a while (Satellite upstream builder) and after we migrated to instances with ephemeral SSD storage, builds were much faster.

Note for myself: [should be visible here](https://github.com/osbuild/osbuild-composer/blob/main/.gitlab-ci.yml#L11).