### PR TITLE
osbuild-worker: fix nil pointer in depsolve job

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -52,7 +52,7 @@ type DepsolveJobImpl struct {
 // (matching map keys).
 func (impl *DepsolveJobImpl) depsolve(packageSets map[string][]rpmmd.PackageSet, modulePlatformID, arch, releasever string) (map[string][]rpmmd.PackageSpec, map[string][]rpmmd.RepoConfig, error) {
 	solver := impl.Solver.NewWithConfig(modulePlatformID, releasever, arch, "")
-	if impl.RepositoryMTLSConfig.Proxy != nil {
+	if impl.RepositoryMTLSConfig != nil && impl.RepositoryMTLSConfig.Proxy != nil {
 		err := solver.SetProxy(impl.RepositoryMTLSConfig.Proxy.String())
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Yesterday in an effort to get the snapshotting to work quickly, I ignored the results of the api tests, turns out that was a bad idea.

