### PR TITLE
test: execute dmesg task as privileged user

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -506,6 +506,7 @@
     # case: check dmesg error and failed log
     - name: check dmesg output
       command: dmesg
+      become: yes
       register: result_dmesg
 
     - name: save dmesg output to log file
@@ -517,6 +518,7 @@
     - name: check dmesg error and fail log
       shell: dmesg --notime | grep -i "error\|fail" || true
       register: result_dmesg_error
+      become: yes
 
     - name: check embeded container image with podman
       command: podman images


### PR DESCRIPTION
This pull request includes:

We have seen edge-commit-f39 and edge-installer-f39 failing in CI due to `"dmesg: read kernel buffer failed: Operation not permitted"`

```
TASK [check dmesg output] ******************************************************
fatal: [192.168.100.50]: FAILED! => {"changed": true, "cmd": ["dmesg"], "delta": "0:00:00.004286", "end": "2024-04-19 15:07:24.268256", "msg": "non-zero return code", "rc": 1, "start": "2024-04-19 15:07:24.263970", "stderr": "dmesg: read kernel buffer failed: Operation not permitted", "stderr_lines": ["dmesg: read kernel buffer failed: Operation not permitted"], "stdout": "", "stdout_lines": []}
```

This PR suggests to execute dmesg playbook task as privileged user.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
