### PR TITLE
templates/packer: fix proxy config in ldap service account init

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
@@ -33,8 +33,13 @@ sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 baseurl = "$BASEURL"
 mtls_client_key = "/etc/osbuild-worker/image_builder_sa_mtls_key.pem"
 mtls_client_cert = "/etc/osbuild-worker/image_builder_sa_mtls_cert.pem"
+EOF
+
+if [ "$PROXY" != null ]; then
+    sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 proxy = "$PROXY"
 EOF
+fi
 
 if [ "$CA" != null ]; then
     sudo tee /etc/osbuild-worker/image_builder_sa_ca.pem > /dev/null << EOF


### PR DESCRIPTION
"null" as proxy isn't valid, which is the value proxy gets in case jq can't find the proxy defined in the secret.