### PR TITLE
templates/packer: add failure script

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/on_exit.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/on_exit.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$SERVICE_RESULT" == "success" ]; then
+    exit 0
+fi
+
+echo "Worker initialization failed,  setting instance state to unhealthy"
+INSTANCE_ID=$(curl -Ls http://169.254.169.254/latest/meta-data/instance-id)
+/usr/local/bin/aws autoscaling set-instance-health --instance-id "$INSTANCE_ID" --health-status Unhealthy

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -21,6 +21,7 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/get_oci_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_pulp_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
+ExecStopPost=/usr/local/libexec/worker-initialization-scripts/on_exit.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In case the service failed, set the instance to unhealthy.

