### PR TITLE
test/old-worker-new-composer: reset osbuild repo for image-info

### DIFF
--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -394,6 +394,8 @@ $AWS_CMD s3api put-object-tagging \
 greenprint "✅ Successfully tagged S3 object"
 
 setup_repo osbuild-composer "$COMPOSER_LATEST_COMMIT_SHA" 10
+OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.["'"${ID}-${VERSION_ID}"'"].dependencies.osbuild.commit')
+setup_repo osbuild "$OSBUILD_GIT_COMMIT" 10
 
 greenprint "Installing osbuild-composer-tests for image-info"
 sudo dnf install -y $VERIFICATION_COMPOSER_RPM


### PR DESCRIPTION
Image-info is installed via the latest test rpms, which need a newer osbuild version.
