### PR TITLE
Revert "Disable F40 CI (CVE-2024-3094 response)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,6 +100,8 @@ RPM:
           - aws/fedora-38-aarch64
           - aws/fedora-39-x86_64
           - aws/fedora-39-aarch64
+          - aws/fedora-40-x86_64
+          - aws/fedora-40-aarch64
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
           - aws/rhel-8.9-ga-x86_64
@@ -546,6 +548,8 @@ API:
         RUNNER:
           - aws/fedora-39-x86_64
           - aws/fedora-39-aarch64
+          - aws/fedora-40-x86_64
+          - aws/fedora-40-aarch64
       - IMAGE_TYPE: ["aws"]
         RUNNER:
           - aws/rhel-8.9-ga-aarch64

--- a/Schutzfile
+++ b/Schutzfile
@@ -132,14 +132,14 @@
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-rawhide-20240101"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-x86_64-branched-20240515"
           }
         ],
         "aarch64": [
           {
             "title": "fedora",
             "name": "fedora",
-            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-rawhide-20240101"
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f40/f40-aarch64-branched-20240515"
           }
         ]
       }


### PR DESCRIPTION
F40 is safe to use again

This reverts commit 0cc7cc99e69272acbcf357516688512a9654b95d.

