### PR TITLE
osbuild-worker: improve error "reason" in case of stage failures (HMS-1442)

### DIFF
--- a/cmd/osbuild-worker/export_test.go
+++ b/cmd/osbuild-worker/export_test.go
@@ -1,3 +1,6 @@
 package main
 
-var WorkerClientErrorFrom = workerClientErrorFrom
+var (
+	WorkerClientErrorFrom         = workerClientErrorFrom
+	MakeJobErrorFromOsbuildOutput = makeJobErrorFromOsbuildOutput
+)

--- a/cmd/osbuild-worker/jobimpl-depsolve_test.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve_test.go
@@ -18,8 +18,7 @@ func TestWorkerClientErrorFromDnfJson(t *testing.T) {
 	}
 	clientErr, err := worker.WorkerClientErrorFrom(dnfJsonErr)
 	assert.NoError(t, err)
-	// XXX: this is duplicating the details, see https://github.com/osbuild/images/issues/727
-	assert.Equal(t, clientErr.String(), `Code: 20, Reason: DNF error occurred: DepsolveError: something is terribly wrong, Details: something is terribly wrong`)
+	assert.Equal(t, `Code: 20, Reason: DNF error occurred: DepsolveError, Details: something is terribly wrong`, clientErr.String())
 }
 
 func TestWorkerClientErrorFromOtherError(t *testing.T) {
@@ -28,13 +27,12 @@ func TestWorkerClientErrorFromOtherError(t *testing.T) {
 	// XXX: this is probably okay but it seems slightly dangerous to
 	// assume that any "error" we get there is coming from rpmmd, can
 	// we generate a more typed error from dnfjson here for rpmmd errors?
-	assert.EqualError(t, err, "rpmmd error in depsolve job: some error")
-	assert.Equal(t, clientErr.String(), `Code: 23, Reason: rpmmd error in depsolve job: some error, Details: <nil>`)
+	assert.EqualError(t, err, "some error")
+	assert.Equal(t, `Code: 23, Reason: rpmmd error in depsolve job, Details: some error`, clientErr.String())
 }
 
 func TestWorkerClientErrorFromNil(t *testing.T) {
 	clientErr, err := worker.WorkerClientErrorFrom(nil)
-	// XXX: this is wrong, it should generate an internal error
-	assert.EqualError(t, err, "rpmmd error in depsolve job: <nil>")
-	assert.Equal(t, clientErr.String(), `Code: 23, Reason: rpmmd error in depsolve job: <nil>, Details: <nil>`)
+	assert.EqualError(t, err, "workerClientErrorFrom expected an error to be processed. Not nil")
+	assert.Equal(t, `Code: 23, Reason: rpmmd error in depsolve job, Details: <nil>`, clientErr.String())
 }

--- a/cmd/osbuild-worker/jobimpl-osbuild_test.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild_test.go
@@ -1,0 +1,81 @@
+package main_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+
+	main "github.com/osbuild/osbuild-composer/cmd/osbuild-worker"
+)
+
+func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
+	tests := []struct {
+		inputData *osbuild.Result
+		expected  string
+	}{
+		{
+			inputData: &osbuild.Result{
+				Success: false,
+				Log: map[string]osbuild.PipelineResult{
+					"fake-os": []osbuild.StageResult{
+						{
+							Type:    "good-stage",
+							Success: true,
+							Output:  "good-output",
+						},
+						{
+							Type:    "bad-stage",
+							Success: false,
+							Output:  "bad-failure",
+						},
+					},
+				},
+			},
+			expected: `Code: 10, Reason: osbuild build failed in stage:
+bad-stage, Details: []`,
+		},
+		{
+			inputData: &osbuild.Result{
+				Success: false,
+				Log: map[string]osbuild.PipelineResult{
+					"fake-os": []osbuild.StageResult{},
+				},
+			},
+			expected: `Code: 10, Reason: osbuild build failed, Details: []`,
+		},
+		{
+			inputData: &osbuild.Result{
+				Error:   json.RawMessage("some_osbuild_error"),
+				Success: false,
+				Log: map[string]osbuild.PipelineResult{
+					"fake-os": []osbuild.StageResult{},
+				},
+			},
+			expected: `Code: 10, Reason: osbuild build failed, Details: [osbuild error: some_osbuild_error]`,
+		},
+		{
+			inputData: &osbuild.Result{
+				Errors: []osbuild.ValidationError{
+					{
+						Message: "validation error message",
+						Path:    []string{"error path"},
+					},
+				},
+				Success: false,
+				Log: map[string]osbuild.PipelineResult{
+					"fake-os": []osbuild.StageResult{},
+				},
+			},
+			expected: `Code: 10, Reason: osbuild build failed, Details: [manifest validation error: {validation error message [error path]}]`,
+		},
+	}
+	for _, testData := range tests {
+		fakeOsbuildResult := testData.inputData
+
+		wce := main.MakeJobErrorFromOsbuildOutput(fakeOsbuildResult)
+		require.Equal(t, testData.expected, wce.String())
+	}
+}


### PR DESCRIPTION
This should improve the error in the frontend from

![stage_error_before](https://github.com/osbuild/osbuild-composer/assets/8057963/e69547a3-df60-4c47-9f9f-fcddf39d40b5)

to

![stage_error_after](https://github.com/osbuild/osbuild-composer/assets/8057963/16034952-cedb-4610-84bb-6dcb90a620f7)

There is no test framework to test changes like this, right?