### PR TITLE
templates/openshift/maintenance: service account & parameter fixes

### DIFF
--- a/templates/openshift/maintenance.yml
+++ b/templates/openshift/maintenance.yml
@@ -28,7 +28,7 @@ objects:
       spec:
         template:
           spec:
-            serviceAccountName: image-builder
+            serviceAccountName: image-builder-maintenance
             restartPolicy: Never
             containers:
             - image: "${IMAGE_NAME}:${IMAGE_TAG}"
@@ -155,6 +155,13 @@ objects:
                 value: "${ENABLE_DB_MAINTENANCE}"
               - name: MAX_CONCURRENT_REQUESTS
                 value: "${MAINTENANCE_MAX_CONCURRENT_REQUESTS}"
+
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: image-builder-maintenance
+  imagePullSecrets:
+  - name: quay.io
 
 parameters:
   - description: maintenance image name

--- a/templates/openshift/maintenance.yml
+++ b/templates/openshift/maintenance.yml
@@ -196,6 +196,10 @@ parameters:
     # don't change this value, overwrite it in app-interface for a specific namespace
     value: "false"
     required: true
+  - description: postgres sslmode to use when connecting to the db
+    name: PGSSLMODE
+    value: "require"
+    required: true
   - description: composer-maintenance max concurrent requests
     name: MAINTENANCE_MAX_CONCURRENT_REQUESTS
     value: "10"


### PR DESCRIPTION
Current runs fail because the ssl mode isn't set, and the service account is missing (in the workers-stage ns).