### PR TITLE
test: skip ostree-remount due to issue RHEL-25249

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -499,9 +499,9 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      # Skipping playbook task in CS9 due to bug https://issues.redhat.com/browse/RHEL-25249
+      # Skipping playbook task in CS9 and RHEL 9 due to bug https://issues.redhat.com/browse/RHEL-25249
       when: (edge_type == "none") and ((ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '<')) or
-            ((ansible_facts['distribution'] == 'CentOS') and ansible_facts['distribution_version'] is version('9', '!=')) or (ansible_facts['distribution'] == 'RedHat'))
+            ((ansible_facts['distribution'] == 'CentOS') and ansible_facts['distribution_version'] is version('9', '!=')) or (ansible_facts['distribution'] != 'RedHat'))
 
     # case: check dmesg error and failed log
     - name: check dmesg output


### PR DESCRIPTION
This pull request includes:

We suggest to skip ostree-remount playbook task due to issue https://issues.redhat.com/browse/RHEL-25249 also detected recently in RHEL-9.4 

https://github.com/osbuild/rhel-edge-ci/actions/runs/8889962119/job/24409179382 
https://github.com/osbuild/rhel-edge-ci/actions/runs/8889962119/job/24409179480 


- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
