### PR TITLE
clientdetails: handle error interfaces in `Details` somewhat

### DIFF
--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -1,6 +1,7 @@
 package clienterrors
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
@@ -56,6 +57,26 @@ type Error struct {
 
 func (e *Error) String() string {
 	return fmt.Sprintf("Code: %d, Reason: %s, Details: %v", e.ID, e.Reason, e.Details)
+}
+
+func (e *Error) MarshalJSON() ([]byte, error) {
+	var details interface{}
+	switch v := e.Details.(type) {
+	case error:
+		details = v.Error()
+	default:
+		details = v
+	}
+
+	return json.Marshal(&struct {
+		ID      ClientErrorCode `json:"id"`
+		Reason  string          `json:"reason"`
+		Details interface{}     `json:"details,omitempty"`
+	}{
+		ID:      e.ID,
+		Reason:  e.Reason,
+		Details: details,
+	})
 }
 
 const (

--- a/internal/worker/clienterrors/errors_test.go
+++ b/internal/worker/clienterrors/errors_test.go
@@ -34,5 +34,5 @@ func TestErrorJSONMarshal(t *testing.T) {
 
 	json, err := json.Marshal(clienterrors.WorkerClientError(2, "details", err))
 	assert.NoError(t, err)
-	assert.Equal(t, `{"id":2,"reason":"details","details":{"some-error"}}`, string(json))
+	assert.Equal(t, `{"id":2,"reason":"details","details":"some-error"}`, string(json))
 }

--- a/internal/worker/clienterrors/errors_test.go
+++ b/internal/worker/clienterrors/errors_test.go
@@ -1,6 +1,7 @@
 package clienterrors_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -26,4 +27,12 @@ func TestErrorInterface(t *testing.T) {
 		wce := clienterrors.WorkerClientError(2, "details", tc.err)
 		assert.Equal(t, fmt.Sprintf("Code: 2, Reason: details, Details: %s", tc.expectedStr), wce.String())
 	}
+}
+
+func TestErrorJSONMarshal(t *testing.T) {
+	err := fmt.Errorf("some-error")
+
+	json, err := json.Marshal(clienterrors.WorkerClientError(2, "details", err))
+	assert.NoError(t, err)
+	assert.Equal(t, `{"id":2,"reason":"details","details":{"some-error"}}`, string(json))
 }

--- a/internal/worker/clienterrors/errors_test.go
+++ b/internal/worker/clienterrors/errors_test.go
@@ -1,0 +1,29 @@
+package clienterrors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+type customErr struct{}
+
+func (ce *customErr) Error() string {
+	return "customErr"
+}
+
+func TestErrorInterface(t *testing.T) {
+	for _, tc := range []struct {
+		err         error
+		expectedStr string
+	}{
+		{fmt.Errorf("some error"), "some error"},
+		{&customErr{}, "customErr"},
+	} {
+		wce := clienterrors.WorkerClientError(2, "details", tc.err)
+		assert.Equal(t, fmt.Sprintf("Code: 2, Reason: details, Details: %s", tc.expectedStr), wce.String())
+	}
+}


### PR DESCRIPTION
The clienterror report has no tests right now, that is not ideal so this PR adds some.

While doing that it fixes an issue that @schuellerf discovered, i.e. that when an `error` interface is passed into `clienterrors.Error.Details` the details get lost because the json.Marshaler will not know how to handler an
error interface.

So I think this is fine to merge and will improve the current state. However I think we should rework the
clienterrors.Error so that go types will help us detect issues at compile time. With this PR we will only
detect nested errorrs at runtime and error and it will not deal with nested interface of other types.

We should probably:
1. make `clienterrors.Error` a real error type, it's kinda unusual that an error does not implement the `error` interface.
2. Rethink `Details` - AFAICT all the details will be "flattended" (via `%v`) after the de-serialization anyway, so we might just make details a "string". Of course testing this requires a bit of digging into the source and maybe writting some tests that validate that we indeed just use do the flattening on the other side.

