### PR TITLE
test: update osname for edge deployments

### DIFF
--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -82,7 +82,7 @@ CONTAINER_FILENAME=container.tar
 INSTALLER_TYPE=edge-installer
 INSTALLER_FILENAME=installer.iso
 ANSIBLE_USER_FOR_BIOS="installeruser"
-OSTREE_OSNAME=rhel
+OSTREE_OSNAME=rhel-edge
 BOOT_ARGS="uefi"
 
 # Set up temporary files.

--- a/test/cases/ostree-raw-image.sh
+++ b/test/cases/ostree-raw-image.sh
@@ -81,7 +81,7 @@ CONTAINER_TYPE=edge-container
 CONTAINER_FILENAME=container.tar
 RAW_IMAGE_TYPE=edge-raw-image
 RAW_IMAGE_FILENAME=image.raw.xz
-OSTREE_OSNAME=redhat
+OSTREE_OSNAME=rhel-edge
 BOOT_ARGS="uefi"
 REF_PREFIX="rhel-edge"
 

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -562,7 +562,7 @@ EOF
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${INSTALL_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \
@@ -749,7 +749,7 @@ EOF
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${INSTALL_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \
@@ -935,7 +935,7 @@ fi
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${INSTALL_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \
@@ -1074,7 +1074,7 @@ EOF
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${REBASE_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \
@@ -1249,7 +1249,7 @@ EOF
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${INSTALL_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \
@@ -1392,7 +1392,7 @@ EOF
 
 # Test IoT/Edge OS
 sudo ansible-playbook -v -i "${TEMPDIR}"/inventory \
-    -e image_type=redhat \
+    -e image_type=rhel-edge \
     -e ostree_commit="${UPGRADE_HASH}" \
     -e skip_rollback_test="true" \
     -e edge_type=edge-simplified-installer \


### PR DESCRIPTION
This pull request includes:

In order to align with PR [distro/rhel: unify osname for edge deployments](https://github.com/osbuild/images/pull/650), it is suggested to update edge-installer, edge-simplified-installer, and edge-raw-image tests with the corresponding osname value.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
