### PR TITLE
templates/packer: invert tag logic

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/main.yml
+++ b/templates/packer/ansible/roles/common/tasks/main.yml
@@ -16,4 +16,6 @@
 - include_tasks: unregister.yml
 
 - name: Ensure SELinux contexts are updated
+  tags:
+    - always
   command: restorecon -Rv /etc

--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -2,7 +2,7 @@
 
 - name: Add osbuild-composer repository
   tags:
-    - rpmrepo_composer
+    - ci
   yum_repository:
     name: "composer"
     description: "osbuild-composer commit {{ COMPOSER_COMMIT }}"
@@ -13,8 +13,8 @@
 
 - name: Add osbuild repository
   tags:
-    - rpmrepo_osbuild
-    - rpmcopr
+    - ci
+    - fedora
   yum_repository:
     name: "osbuild"
     description: "osbuild commit {{ osbuild_commit }}"
@@ -26,6 +26,8 @@
   when: osbuild_commit is defined
 
 - name: Upgrade all packages
+  tags:
+    - always
   package:
     name: "*"
     state: latest
@@ -34,11 +36,15 @@
   until: result is success
 
 - name: Add Vector repo
+  tags:
+    - always
   copy:
     src: "{{ playbook_dir }}/roles/common/files/timber-vector.repo"
     dest: /etc/yum.repos.d/
 
 - name: Install required packages
+  tags:
+    - always
   package:
     name:
       - jq
@@ -49,6 +55,8 @@
   until: result is success
 
 - name: Download AWS CLI installer
+  tags:
+    - always
   get_url:
     url: "https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip"
     dest: /tmp/awscli.zip
@@ -57,15 +65,21 @@
   until: result is success
 
 - name: Unpack AWS CLI installer
+  tags:
+    - always
   unarchive:
     src: /tmp/awscli.zip
     dest: /tmp
     remote_src: yes
 
 - name: Run AWS installer
+  tags:
+    - always
   command: /tmp/aws/install
 
 - name: Cleanup AWS installer
+  tags:
+    - always
   file:
     path: "{{ item }}"
     state: absent
@@ -75,7 +89,7 @@
 
 - name: Create rpmbuild directory
   tags:
-    - rpmcopy
+    - rhel
   file:
     path: "{{ item }}"
     state: directory
@@ -85,7 +99,7 @@
 
 - name: Push rpms
   tags:
-    - rpmcopy
+    - rhel
   ansible.posix.synchronize:
     mode: push
     src: "{{ playbook_dir }}/roles/common/files/rpmbuild/{{ ansible_architecture }}/RPMS"
@@ -93,7 +107,7 @@
 
 - name: Add repo config
   tags:
-    - rpmcopy
+    - rhel
   copy:
     dest: /etc/yum.repos.d/osbuild.repo
     content: |
@@ -106,8 +120,8 @@
 
 - name: Install worker rpm
   tags:
-    - rpmcopy
-    - rpmrepo_osbuild
+    - ci
+    - rhel
   package:
     name:
       - osbuild-composer-worker
@@ -115,7 +129,7 @@
 
 - name: Install worker rpm from copr
   tags:
-    - rpmcopr
+    - fedora
   shell: |
     dnf copr enable -y @osbuild/osbuild-composer
     COMPOSER_COMMIT_SHORT=$(echo {{ COMPOSER_COMMIT }} | head -c 9)
@@ -128,6 +142,8 @@
     dnf install -y $COMPOSER_RPMS
 
 - name: Cleanup rpmbuild dir
+  tags:
+    - always
   file:
     path: "{{ item }}"
     state: absent

--- a/templates/packer/ansible/roles/common/tasks/subscribe.yml
+++ b/templates/packer/ansible/roles/common/tasks/subscribe.yml
@@ -3,7 +3,7 @@
 # the packer instances (RHUI, which might be older).
 - name: Subscribe
   tags:
-    - subscribe
+    - rhel
   community.general.redhat_subscription:
     activationkey: "{{ RH_ACTIVATION_KEY }}"
     org_id: "{{ RH_ORG_ID }}"
@@ -14,14 +14,14 @@
 - name: Enable repo mgmt through subman
   become: yes
   tags:
-    - subscribe
+    - rhel
   shell: >-
     subscription-manager config --rhsm.manage_repos 1
 
 - name: Enable cdn repos
   become: yes
   tags:
-    - subscribe
+    - rhel
   shell: >-
     subscription-manager repos \
       --enable rhel-9-for-{{ ansible_architecture }}-appstream-rpms \

--- a/templates/packer/ansible/roles/common/tasks/unregister.yml
+++ b/templates/packer/ansible/roles/common/tasks/unregister.yml
@@ -3,6 +3,6 @@
 - name: Unregister
   become: yes
   tags:
-    - subscribe
+    - rhel
   shell: >-
     subscription-manager unregister

--- a/templates/packer/ansible/roles/common/tasks/worker-config.yml
+++ b/templates/packer/ansible/roles/common/tasks/worker-config.yml
@@ -1,11 +1,15 @@
 ---
 
 - name: Create osbuild-worker config directory
+  tags:
+    - always
   file:
     path: /etc/osbuild-worker/
     state: directory
 
 - name: Copy worker config stub
+  tags:
+    - always
   copy:
     src: "{{ playbook_dir }}/roles/common/files/osbuild-worker.toml"
     dest: /etc/osbuild-worker/osbuild-worker.toml

--- a/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
+++ b/templates/packer/ansible/roles/common/tasks/worker-initialization-service.yml
@@ -1,22 +1,30 @@
 ---
 
 - name: Copy worker initialization service
+  tags:
+    - always
   copy:
     src: "{{ playbook_dir }}/roles/common/files/worker-initialization.service"
     dest: /etc/systemd/system/
 
 - name: Enable worker initialization service
+  tags:
+    - always
   systemd:
     name: worker-initialization.service
     enabled: yes
     daemon_reload: yes # make sure the new service is loaded before enabling it
 
 - name: Create a directory for initialization scripts
+  tags:
+    - always
   file:
     path: /usr/local/libexec/worker-initialization-scripts
     state: directory
 
 - name: Copy scripts used by the initialization service
+  tags:
+    - always
   copy:
     src: "{{ item }}"
     dest: /usr/local/libexec/worker-initialization-scripts
@@ -25,11 +33,15 @@
     - "{{ playbook_dir }}/roles/common/files/worker-initialization-scripts/*"
 
 - name: Copy worker executor service
+  tags:
+    - always
   copy:
     src: "{{ playbook_dir }}/roles/common/files/worker-executor.service"
     dest: /etc/systemd/system/
 
 - name: Enable worker executor service
+  tags:
+    - always
   systemd:
     name: worker-executor.service
     enabled: yes

--- a/templates/packer/variables.pkr.hcl
+++ b/templates/packer/variables.pkr.hcl
@@ -33,7 +33,7 @@ variable "image_users" {
 }
 
 # Skip ansible tags
-variable "ansible_skip_tags" {
+variable "ansible_tags" {
   type = string
   default = ""
 }

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -174,7 +174,7 @@ EOF
       "-e", "COMPOSER_COMMIT=${var.composer_commit}",
       "-e", "RH_ACTIVATION_KEY=${var.rh_activation_key}",
       "-e", "RH_ORG_ID=${var.rh_org_id}",
-      "--skip-tags", "${var.ansible_skip_tags}",
+      "--tags", "${var.ansible_tags}",
     ]
     inventory_directory = "${path.root}/ansible/inventory/${source.name}"
   }

--- a/tools/appsre-build-fedora-worker-packer.sh
+++ b/tools/appsre-build-fedora-worker-packer.sh
@@ -7,7 +7,7 @@ export SKIP_CREATE_AMI=false
 export BUILD_RPMS=false
 # Fedora community workers use osbuild form rpmrepo + composer from
 # copr, as the osbuild rpms from copr disappear too quickly.
-export SKIP_TAGS="rpmrepo_composer,rpmcopy,subscribe"
+export ANSIBLE_TAGS="fedora"
 FEDORA=fedora-38
 export PACKER_ONLY_EXCEPT=--only=amazon-ebs."$FEDORA"-x86_64,amazon-ebs."$FEDORA"-aarch64
 COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse HEAD)}"

--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -7,7 +7,7 @@ COMMIT_BRANCH="${COMMIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 SKIP_CREATE_AMI="${SKIP_CREATE_AMI:-false}"
 BUILD_RPMS="${BUILD_RPMS:-true}"
 # RHEL workers build their own rpms.
-SKIP_TAGS="${SKIP_TAGS:-rpmrepo_composer,rpmrepo_osbuild,rpmcopr}"
+ANSIBLE_TAGS="${ANSIBLE_TAGS:-rhel}"
 # Build rhel only
 PACKER_ONLY_EXCEPT="${PACKER_ONLY_EXCEPT:---only=amazon-ebs.rhel-9-x86_64,amazon-ebs.rhel-9-aarch64}"
 
@@ -102,7 +102,7 @@ $CONTAINER_RUNTIME run --rm \
                    -e PKR_VAR_aws_secret_key="$PACKER_AWS_SECRET_ACCESS_KEY" \
                    -e PKR_VAR_image_name="osbuild-composer-worker-$COMMIT_BRANCH-$COMMIT_SHA" \
                    -e PKR_VAR_composer_commit="$COMMIT_SHA" \
-                   -e PKR_VAR_ansible_skip_tags="$SKIP_TAGS" \
+                   -e PKR_VAR_ansible_tags="$ANSIBLE_TAGS" \
                    -e PKR_VAR_skip_create_ami="$SKIP_CREATE_AMI" \
                    -e PKR_VAR_rh_activation_key="$RH_ACTIVATION_KEY" \
                    -e PKR_VAR_rh_org_id="$RH_ORG_ID" \

--- a/tools/ci-build-worker-packer.sh
+++ b/tools/ci-build-worker-packer.sh
@@ -7,7 +7,7 @@ COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SKIP_CREATE_AMI=false
 BUILD_RPMS=false
 # Use prebuilt rpms on CI
-SKIP_TAGS="rpmcopy,rpmcopr,subscribe"
+ANSIBLE_TAGS="ci"
 
 if [ -n "$CI_COMMIT_SHA" ]; then
     COMMIT_SHA="$CI_COMMIT_SHA"
@@ -30,5 +30,5 @@ else
     PACKER_ONLY_EXCEPT=--except=amazon-ebs.dummy
 fi
 
-export COMMIT_SHA COMMIT_BRANCH SKIP_CREATE_AMI BUILD_RPMS SKIP_TAGS PACKER_ONLY_EXCEPT
+export COMMIT_SHA COMMIT_BRANCH SKIP_CREATE_AMI BUILD_RPMS ANSIBLE_TAGS PACKER_ONLY_EXCEPT
 tools/appsre-build-worker-packer.sh


### PR DESCRIPTION
With the rpmcopy or rpmrepo_osbuild tags, the `Install worker rpm` stage got skipped on RHEL and CI. Invert the tag logic and use `--tags` instead of `--skip-tags`.


---


CI
---
```
ansible-playbook  ./templates/packer/ansible/playbook.yml --tags ci --list-tasks
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

playbook: ./templates/packer/ansible/playbook.yml

  play #1 (all): all	TAGS: []
    tasks:
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      common : Add osbuild-composer repository	TAGS: [ci]
      common : Add osbuild repository	TAGS: [ci, fedora]
      common : Upgrade all packages	TAGS: [always]
      common : Add Vector repo	TAGS: [always]
      common : Install required packages	TAGS: [always]
      common : Download AWS CLI installer	TAGS: [always]
      common : Unpack AWS CLI installer	TAGS: [always]
      common : Cleanup AWS installer	TAGS: [always]
      common : Install worker rpm	TAGS: [ci, rhel]
      common : Cleanup rpmbuild dir	TAGS: [always]
      common : Create osbuild-worker config directory	TAGS: [always]
      common : Copy worker config stub	TAGS: [always]
      common : Copy worker initialization service	TAGS: [always]
      common : Enable worker initialization service	TAGS: [always]
      common : Create a directory for initialization scripts	TAGS: [always]
      common : Copy scripts used by the initialization service	TAGS: [always]
      common : Copy worker executor service	TAGS: [always]
      common : Enable worker executor service	TAGS: [always]
      common : Ensure SELinux contexts are updated	TAGS: [always]
```

fedora
---
```
ansible-playbook  ./templates/packer/ansible/playbook.yml --tags fedora --list-tasks
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

playbook: ./templates/packer/ansible/playbook.yml

  play #1 (all): all	TAGS: []
    tasks:
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      common : Add osbuild repository	TAGS: [ci, fedora]
      common : Upgrade all packages	TAGS: [always]
      common : Add Vector repo	TAGS: [always]
      common : Install required packages	TAGS: [always]
      common : Download AWS CLI installer	TAGS: [always]
      common : Unpack AWS CLI installer	TAGS: [always]
      common : Cleanup AWS installer	TAGS: [always]
      common : Install worker rpm from copr	TAGS: [fedora]
      common : Cleanup rpmbuild dir	TAGS: [always]
      common : Create osbuild-worker config directory	TAGS: [always]
      common : Copy worker config stub	TAGS: [always]
      common : Copy worker initialization service	TAGS: [always]
      common : Enable worker initialization service	TAGS: [always]
      common : Create a directory for initialization scripts	TAGS: [always]
      common : Copy scripts used by the initialization service	TAGS: [always]
      common : Copy worker executor service	TAGS: [always]
      common : Enable worker executor service	TAGS: [always]
      common : Ensure SELinux contexts are updated	TAGS: [always]
```

rhel
---
```
sanne@worky ~/workstuff/osbuild-composer (main e8303172e)$ ansible-playbook  ./templates/packer/ansible/playbook.yml --tags rhel --list-tasks
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

playbook: ./templates/packer/ansible/playbook.yml

  play #1 (all): all	TAGS: []
    tasks:
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      include_tasks	TAGS: [always]
      common : Subscribe	TAGS: [rhel]
      common : Enable repo mgmt through subman	TAGS: [rhel]
      common : Enable cdn repos	TAGS: [rhel]
      common : Upgrade all packages	TAGS: [always]
      common : Add Vector repo	TAGS: [always]
      common : Install required packages	TAGS: [always]
      common : Download AWS CLI installer	TAGS: [always]
      common : Unpack AWS CLI installer	TAGS: [always]
      common : Cleanup AWS installer	TAGS: [always]
      common : Create rpmbuild directory	TAGS: [rhel]
      common : Push rpms	TAGS: [rhel]
      common : Add repo config	TAGS: [rhel]
      common : Install worker rpm	TAGS: [ci, rhel]
      common : Cleanup rpmbuild dir	TAGS: [always]
      common : Create osbuild-worker config directory	TAGS: [always]
      common : Copy worker config stub	TAGS: [always]
      common : Copy worker initialization service	TAGS: [always]
      common : Enable worker initialization service	TAGS: [always]
      common : Create a directory for initialization scripts	TAGS: [always]
      common : Copy scripts used by the initialization service	TAGS: [always]
      common : Copy worker executor service	TAGS: [always]
      common : Enable worker executor service	TAGS: [always]
      common : Unregister	TAGS: [rhel]
      common : Ensure SELinux contexts are updated	TAGS: [always]
```