### PR TITLE
test/cases/ubi-wsl: test rhel9 ga (HMS-4207)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -622,9 +622,12 @@ ubi-wsl.sh:
   script:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/ubi-wsl.sh
-  variables:
-      RUNNER: aws/rhel-8.9-ga-x86_64
-      INTERNAL_NETWORK: "true"
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-8.9-ga-x86_64
+          - aws/rhel-9.3-ga-x86_64
+        INTERNAL_NETWORK: "true"
 
 weldr-distro-dot-notation+aliases:
   stage: test


### PR DESCRIPTION
I updated wsl in the snapshot & switched to an absolute path to wsl. Apparently there are multiple wsl executables, some of which cannot be accessed in the ssh session, and some of which can.