### PR TITLE
GH actions / containerfiles: update F37 to F40

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: "🛃 Unit tests"
     runs-on: ubuntu-20.04
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: registry.fedoraproject.org/fedora:40
 
     steps:
         # krb5-devel is needed to test internal/upload/koji package
@@ -92,7 +92,7 @@ jobs:
     name: "🐍 Lint python scripts"
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: registry.fedoraproject.org/fedora:40
     steps:
 
       - name: Install build and test dependencies
@@ -248,7 +248,7 @@ jobs:
   rpmlint:
     name: "📦 RPMlint"
     runs-on: ubuntu-20.04
-    container: registry.fedoraproject.org/fedora:37
+    container: registry.fedoraproject.org/fedora:40
     steps:
       - name: Install dependencies
         run: sudo dnf install -y rpmlint rpm-build make git-core

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,7 +263,7 @@ jobs:
           make srpm
 
       - name: Run rpmlint
-        run: rpmlint rpmbuild/SRPMS/*
+        run: rpmlint --config rpmlint.config rpmbuild/SRPMS/*
 
   gitlab-ci-helper:
     name: "Gitlab CI trigger helper"

--- a/distribution/Dockerfile-config
+++ b/distribution/Dockerfile-config
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:40
 
 RUN dnf -y install \
     openssl

--- a/distribution/Dockerfile-worker
+++ b/distribution/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM fedora:37 AS builder
+FROM fedora:40 AS builder
 ENV GOBIN=/opt/app-root/src/go/bin
 # extra packages are needed
 # to compile osbuild

--- a/tools/koji-compose.py
+++ b/tools/koji-compose.py
@@ -130,22 +130,25 @@ class ComposerAPIClient:
         resp = requests.post(self.auth_server + "/token", data={
             "grant_type": "refresh_token",
             "refresh_token": self.refresh_token,
-        })
+        }, timeout=5)
         if resp.status_code != 200:
             raise RuntimeError(f"failed to refresh token: {resp.text}")
         return resp.json()["access_token"]
 
     def submit_compose(self, request):
         return requests.post(self.api_url + "/compose", json=request,
-                             headers={"Authorization": f"Bearer {self.access_token()}"})
+                             headers={"Authorization": f"Bearer {self.access_token()}"},
+                             timeout=5)
 
     def compose_status(self, compose_id):
         return requests.get(self.api_url + f"/composes/{compose_id}",
-                            headers={"Authorization": f"Bearer {self.access_token()}"})
+                            headers={"Authorization": f"Bearer {self.access_token()}"},
+                            timeout=5)
 
     def compose_log(self, compose_id):
         return requests.get(self.api_url + f"/composes/{compose_id}/logs",
-                            headers={"Authorization": f"Bearer {self.access_token()}"})
+                            headers={"Authorization": f"Bearer {self.access_token()}"},
+                            timeout=5)
 
 
 def get_parser():


### PR DESCRIPTION
Fedora 37 has been EOL for some time.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
