### PR TITLE
Remove rhel-8.10 jobs from test matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,18 +69,14 @@ init:
 .nightly_rules_all:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.5-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.10-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
 
 .nightly_rules_x86_64:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.5-[^ga][\S]+/ && $RUNNER =~ "/^.*(x86_64).*$/" && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.10-[^ga][\S]+/ && $RUNNER =~ "/^.*(x86_64).*$/" && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
 
 
 .RPM_RUNNERS_RHEL: &RPM_RUNNERS_RHEL
   RUNNER:
-    - aws/rhel-8.10-nightly-x86_64
-    - aws/rhel-8.10-nightly-aarch64
     - aws/rhel-9.5-nightly-x86_64
     - aws/rhel-9.5-nightly-aarch64
 
@@ -164,7 +160,6 @@ Prepare-rhel-internal:
       - RUNNER:
           # NOTE: 1 runner prepares for all arches b/c subsequent jobs download
           # artifacts from all previous jobs and the last one wins
-          - aws/rhel-8.10-nightly-x86_64
           - aws/rhel-9.5-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
@@ -191,8 +186,6 @@ Base:
           - aws/rhel-9.3-ga-x86_64
           - aws/rhel-9.3-ga-aarch64
       - RUNNER:
-          - aws/rhel-8.10-nightly-x86_64
-          - aws/rhel-8.10-nightly-aarch64
           - aws/rhel-9.5-nightly-x86_64
           - aws/rhel-9.5-nightly-aarch64
           - aws/centos-stream-9-x86_64
@@ -222,8 +215,6 @@ Base:
           - aws/rhel-8.9-ga-aarch64
           - aws/rhel-9.3-ga-x86_64
           - aws/rhel-9.3-ga-aarch64
-          - aws/rhel-8.10-nightly-x86_64
-          - aws/rhel-8.10-nightly-aarch64
           - aws/rhel-9.5-nightly-x86_64
           - aws/rhel-9.5-nightly-aarch64
           - aws/centos-stream-9-x86_64
@@ -307,8 +298,6 @@ Image Tests:
       - RUNNER:
           - aws/rhel-8.4-ga-x86_64
           - aws/rhel-8.4-ga-aarch64
-          - aws/rhel-8.10-nightly-x86_64
-          - aws/rhel-8.10-nightly-aarch64
           - aws/rhel-9.5-nightly-x86_64
           - aws/rhel-9.5-nightly-aarch64
         INTERNAL_NETWORK: ["true"]
@@ -338,8 +327,6 @@ Trigger-rhel-edge-ci:
       - aws/rhel-8.4-ga-x86_64
       - aws/rhel-8.9-ga-x86_64
       - aws/rhel-9.3-ga-x86_64
-      - aws/rhel-8.10-nightly-x86_64
-      - aws/rhel-8.10-nightly-aarch64
       - aws/rhel-9.5-nightly-x86_64
       - aws/rhel-9.5-nightly-aarch64
       - aws/centos-stream-9-x86_64
@@ -419,7 +406,6 @@ aws.sh:
     # Skip rhel-8.4-ga-x86_64
     - if: '$CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-8.4-[\S]+/'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.5-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-8.10-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "8"'
   variables:
     SCRIPT: aws.sh
 
@@ -533,7 +519,6 @@ API:
         RUNNER:
           - aws/rhel-8.9-ga-x86_64
           - aws/rhel-9.3-ga-x86_64
-          - aws/rhel-8.10-nightly-x86_64
           - aws/rhel-9.5-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
       - IMAGE_TYPE: ["iot-commit"]
@@ -593,7 +578,6 @@ API-module-hotfixes:
       - RUNNER:
           - gcp/rhel-8.9-ga-x86_64
           - gcp/rhel-9.3-ga-x86_64
-          - gcp/rhel-8.10-nightly-x86_64
           - gcp/rhel-9.5-nightly-x86_64
           - gcp/centos-stream-9-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -639,7 +623,7 @@ weldr-distro-dot-notation+aliases:
   extends: .libvirt_integration
   rules:
     # BLACKLIST
-    - if: $RUNNER !~ "/^.*(rhel-8.10|rhel-9.5).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $NIGHTLY != "true"
+    - if: $RUNNER !~ "/^.*(rhel-9.5).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $NIGHTLY != "true"
     - !reference [.nightly_rules_all, rules]
 
 generic_s3_http.sh:
@@ -730,7 +714,6 @@ Installer:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/rhel-8.10-nightly-x86_64
           - rhos-01/rhel-9.5-nightly-x86_64
           - rhos-01/centos-stream-9-x86_64
 
@@ -762,8 +745,6 @@ ContainerEmbedding:
       - INTERNAL_NETWORK: "true"
         RUNNER:
         - aws/centos-stream-9-x86_64
-        - aws/rhel-8.10-nightly-x86_64
-        - aws/rhel-8.10-nightly-aarch64
         - aws/rhel-9.5-nightly-x86_64
         - aws/rhel-9.5-nightly-aarch64
 


### PR DESCRIPTION
Related: COMPOSER-2226


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
