### PR TITLE
templates/packer: use import_tasks instead of include_tasks

### DIFF
--- a/templates/packer/ansible/roles/common/tasks/main.yml
+++ b/templates/packer/ansible/roles/common/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 
 # Subscribe
-- include_tasks: subscribe.yml
+- import_tasks: subscribe.yml
 
 # Install various software packages.
-- include_tasks: packages.yml
+- import_tasks: packages.yml
 
 # Configure worker initialization service.
-- include_tasks: worker-initialization-service.yml
+- import_tasks: worker-initialization-service.yml
 
 # Configure the worker.
-- include_tasks: worker-config.yml
+- import_tasks: worker-config.yml
 
 # Unregister
-- include_tasks: unregister.yml
+- import_tasks: unregister.yml
 
 - name: Ensure SELinux contexts are updated
   tags:

--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -28,9 +28,8 @@
 - name: Upgrade all packages
   tags:
     - always
-  package:
-    name: "*"
-    state: latest
+  shell: |
+    sudo dnf -y update
   register: result
   retries: 5
   until: result is success
@@ -45,11 +44,8 @@
 - name: Install required packages
   tags:
     - always
-  package:
-    name:
-      - jq
-      - unzip
-      - vector
+  shell: |
+    sudo dnf -y install jq unzip vector
   register: result
   retries: 5
   until: result is success
@@ -122,10 +118,8 @@
   tags:
     - ci
     - rhel
-  package:
-    name:
-      - osbuild-composer-worker
-    state: present
+  shell: |
+    sudo dnf -y install osbuild-composer-worker
 
 - name: Install worker rpm from copr
   tags:

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -166,11 +166,14 @@ update-crypto-policies --set LEGACY
 EOF
   }
 
-  # Ansible is a little broken on fedora>39, needs python-six
+  # Ansible is a little broken on fedora>39, needs python-six & 3.9
+  # Installing python3.9 breaks dnf update with ansible, so do it here
+  # first
   provisioner "shell" {
     only = ["amazon-ebs.fedora-40-x86_64", "amazon-ebs.fedora-40-aarch64"]
     inline = [
-      "sudo dnf install -y python3.9"
+      "sudo dnf install -y python3.9",
+      "sudo dnf -y update"
     ]
   }
 

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -166,14 +166,12 @@ update-crypto-policies --set LEGACY
 EOF
   }
 
-  # Ansible is a little broken on fedora>39, needs python-six & 3.9
-  # Installing python3.9 breaks dnf update with ansible, so do it here
-  # first
+  # Ansible is quite broken on fedora 40, using python 3.10 + not using
+  # the dnf module seems to work.
   provisioner "shell" {
     only = ["amazon-ebs.fedora-40-x86_64", "amazon-ebs.fedora-40-aarch64"]
     inline = [
-      "sudo dnf install -y python3.9",
-      "sudo dnf -y update"
+      "sudo dnf install -y python3.10",
     ]
   }
 

--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -75,7 +75,7 @@ EOF
 
         if [[ "$item" == templates/packer/ansible/inventory/fedora* ]]; then
             tee -a "$item/group_vars/all.yml" <<EOF
-ansible_python_interpreter: /usr/bin/python3.9
+ansible_python_interpreter: /usr/bin/python3.10
 EOF
         fi
 


### PR DESCRIPTION
The tags don't get inherited through the dynamic `include_tasks` command. Use `import_tasks` to preserve the tags.

---

```
ansible-playbook  ./templates/packer/ansible/playbook.yml --tags rhel  --list-tasks



playbook: ./templates/packer/ansible/playbook.yml

  play #1 (all): all	TAGS: []
    tasks:
      common : Subscribe	TAGS: [rhel]
      common : Enable repo mgmt through subman	TAGS: [rhel]
      common : Enable cdn repos	TAGS: [rhel]
      common : Upgrade all packages	TAGS: [always]
      common : Add Vector repo	TAGS: [always]
      common : Install required packages	TAGS: [always]
      common : Download AWS CLI installer	TAGS: [always]
      common : Unpack AWS CLI installer	TAGS: [always]
      common : Run AWS installer	TAGS: [always]
      common : Cleanup AWS installer	TAGS: [always]
      common : Create rpmbuild directory	TAGS: [rhel]
      common : Push rpms	TAGS: [rhel]
      common : Add repo config	TAGS: [rhel]
      common : Install worker rpm	TAGS: [ci, rhel]
      common : Cleanup rpmbuild dir	TAGS: [always]
      common : Copy worker initialization service	TAGS: [always]
      common : Enable worker initialization service	TAGS: [always]
      common : Create a directory for initialization scripts	TAGS: [always]
      common : Copy scripts used by the initialization service	TAGS: [always]
      common : Copy worker executor service	TAGS: [always]
      common : Enable worker executor service	TAGS: [always]
      common : Create osbuild-worker config directory	TAGS: [always]
      common : Copy worker config stub	TAGS: [always]
      common : Unregister	TAGS: [rhel]
      common : Ensure SELinux contexts are updated	TAGS: [always]

```

When trying it out before I had to copy all the individual tasks to the main.yml file in the role in order for it to list properly. I thought it was a limitation of the listing command, this looks a lot better.
