### PR TITLE
Fix condition in `tools/provision.sh` for el10 and re-enable snapshot URL validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,17 +192,16 @@ jobs:
             exit "0"
           fi
 
-  # TODO: enable again once enumerating rpmrepo does not fail anymore
-  #check-snapshots:
-  #  name: "🔍 Check for valid snapshot urls"
-  #  runs-on: ubuntu-20.04
-  #  steps:
-  #    - name: Check out code into the Go module directory
-  #      uses: actions/checkout@v4
-  #      with:
-  #        ref: ${{ github.event.pull_request.head.sha }}
-  #    - name: Check for valid snapshot urls
-  #      run: ./tools/check-snapshots --errors-only .
+  check-snapshots:
+    name: "🔍 Check for valid snapshot urls"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Check for valid snapshot urls
+        run: ./tools/check-snapshots --errors-only .
 
   check-runners:
     name: "🔍 Check for missing or unused runner repos"

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -31,14 +31,14 @@ fi
 # and install koji and ansible here.
 #
 # TODO: Adjust the c10s condition, once EPEL-10 is available.
-if [[ $ID == rhel || ($ID == centos && ${VERSION_ID%.*} -lt 10) ]] && ! rpm -q epel-release; then
+if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} -lt 10 ]] && ! rpm -q epel-release; then
     curl -Ls --retry 5 --output /tmp/epel.rpm \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-"${VERSION_ID%.*}".noarch.rpm
     sudo rpm -Uvh /tmp/epel.rpm
 fi
 
 # TODO: Remove this workaround, once koji is in EPEL-10
-if [[ $ID == centos && ${VERSION_ID%.*} == 10 ]]; then
+if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} == 10 ]]; then
     sudo dnf copr enable -y @osbuild/centpkg "centos-stream-10-$(uname -m)"
 fi
 


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
