### PR TITLE
go.mod: bump osbuild/images to v0.65.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.420
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.63.0
+	github.com/osbuild/images v0.65.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -500,8 +500,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.420 h1:zC/TboLemC09T5qxSdF5IZR20wnn4
 github.com/openshift-online/ocm-sdk-go v0.1.420/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.63.0 h1:tk75nDV78Pbi+RBXCclHYQbzzJeqJDsCMVmDCWRhLcM=
-github.com/osbuild/images v0.63.0/go.mod h1:kkiJNrd0XkVfwBxrJ8wWt6/d0+Eb+tG+zZVnw/xXE/8=
+github.com/osbuild/images v0.65.0 h1:Vq6r5YQJvTYiznBPma8sHffNyPl0rx1i6hwMN+AbrIA=
+github.com/osbuild/images v0.65.0/go.mod h1:kkiJNrd0XkVfwBxrJ8wWt6/d0+Eb+tG+zZVnw/xXE/8=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1 h1:UFEJIcPa46W8gtWgOYzriRKYyy1t6SWL0BI7fPTuVvc=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1/go.mod h1:z+WA+dX6qMwc7fqY5jCzESDIlg4WR2sBQezxsoXv9Ik=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/distro.go
@@ -872,7 +872,6 @@ func newDistro(version int) distro.Distro {
 		minimalrawImgType,
 	)
 
-	// iot simplified installer was introduced in F38
 	x86_64.addImageTypes(
 		&platform.X86{
 			BasePlatform: platform.BasePlatform{
@@ -921,62 +920,59 @@ func newDistro(version int) distro.Distro {
 		iotSimplifiedInstallerImgType,
 	)
 
-	if common.VersionGreaterThanOrEqual(rd.Releasever(), "39") {
-		// bootc was introduced in F39
-		x86_64.addImageTypes(
-			&platform.X86{
-				BasePlatform: platform.BasePlatform{
-					FirmwarePackages: []string{
-						"biosdevname",
-						"iwlwifi-dvm-firmware",
-						"iwlwifi-mvm-firmware",
-						"microcode_ctl",
-					},
+	x86_64.addImageTypes(
+		&platform.X86{
+			BasePlatform: platform.BasePlatform{
+				FirmwarePackages: []string{
+					"biosdevname",
+					"iwlwifi-dvm-firmware",
+					"iwlwifi-mvm-firmware",
+					"microcode_ctl",
 				},
-				BIOS:       true,
-				UEFIVendor: "fedora",
 			},
-			iotBootableContainer,
-		)
-		aarch64.addImageTypes(
-			&platform.Aarch64{
-				BasePlatform: platform.BasePlatform{
-					FirmwarePackages: []string{
-						"arm-image-installer",
-						"bcm283x-firmware",
-						"brcmfmac-firmware",
-						"iwlwifi-mvm-firmware",
-						"realtek-firmware",
-						"uboot-images-armv8",
-					},
+			BIOS:       true,
+			UEFIVendor: "fedora",
+		},
+		iotBootableContainer,
+	)
+	aarch64.addImageTypes(
+		&platform.Aarch64{
+			BasePlatform: platform.BasePlatform{
+				FirmwarePackages: []string{
+					"arm-image-installer",
+					"bcm283x-firmware",
+					"brcmfmac-firmware",
+					"iwlwifi-mvm-firmware",
+					"realtek-firmware",
+					"uboot-images-armv8",
 				},
-				UEFIVendor: "fedora",
 			},
-			iotBootableContainer,
-		)
+			UEFIVendor: "fedora",
+		},
+		iotBootableContainer,
+	)
 
-		ppc64le.addImageTypes(
-			&platform.PPC64LE{
-				BIOS: true,
-				BasePlatform: platform.BasePlatform{
-					ImageFormat: platform.FORMAT_QCOW2,
-					QCOW2Compat: "1.1",
-				},
+	ppc64le.addImageTypes(
+		&platform.PPC64LE{
+			BIOS: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_QCOW2,
+				QCOW2Compat: "1.1",
 			},
-			iotBootableContainer,
-		)
+		},
+		iotBootableContainer,
+	)
 
-		s390x.addImageTypes(
-			&platform.S390X{
-				Zipl: true,
-				BasePlatform: platform.BasePlatform{
-					ImageFormat: platform.FORMAT_QCOW2,
-					QCOW2Compat: "1.1",
-				},
+	s390x.addImageTypes(
+		&platform.S390X{
+			Zipl: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_QCOW2,
+				QCOW2Compat: "1.1",
 			},
-			iotBootableContainer,
-		)
-	}
+		},
+		iotBootableContainer,
+	)
 
 	ppc64le.addImageTypes(
 		&platform.PPC64LE{

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
@@ -474,14 +474,6 @@ func anacondaPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	})
 
-	if common.VersionLessThan(t.arch.distro.osVersion, "39") {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"lklug-fonts", // orphaned, unavailable in F39
-			},
-		})
-	}
-
 	switch t.Arch().Name() {
 	case arch.ARCH_X86_64.String():
 		ps = ps.Append(rpmmd.PackageSet{
@@ -627,14 +619,6 @@ func containerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 
-	if common.VersionLessThan(t.arch.distro.osVersion, "39") {
-		ps = ps.Append(rpmmd.PackageSet{
-			Include: []string{
-				"fedora-repos-modular",
-			},
-		})
-	}
-
 	return ps
 }
 
@@ -705,7 +689,8 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 				"shadow-utils", // includes passwd
 			},
 		})
-	} else if common.VersionLessThan(t.arch.distro.osVersion, "40") {
+	} else {
+		// F39 only
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"passwd",

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/partition_tables.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/partition_tables.go
@@ -431,13 +431,13 @@ var iotSimplifiedInstallerPartitionTables = distro.BasePartitionTableMap{
 		},
 	},
 	arch.ARCH_AARCH64.String(): disk.PartitionTable{
-		UUID: "0xc1748067",
-		Type: "dos",
+		UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+		Type: "gpt",
 		Partitions: []disk.Partition{
 			{
-				Size:     501 * common.MebiByte,
-				Type:     "06",
-				Bootable: true,
+				Size: 501 * common.MebiByte,
+				Type: disk.EFISystemPartitionGUID,
+				UUID: disk.EFISystemPartitionUUID,
 				Payload: &disk.Filesystem{
 					Type:         "vfat",
 					UUID:         disk.EFIFilesystemUUID,

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/azure.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/azure.go
@@ -256,10 +256,14 @@ func azureRhuiPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 // Includes the common azure package set, the common SAP packages, and
 // the azure rhui sap package.
 func azureSapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	rhuiPkg := "rhui-azure-rhel8-sap-ha"
+	if t.Arch().Distro().OsVersion() == "8.10" {
+		rhuiPkg = "rhui-azure-rhel8-base-sap-ha"
+	}
 	return rpmmd.PackageSet{
 		Include: []string{
 			"firewalld",
-			"rhui-azure-rhel8-sap-ha",
+			rhuiPkg,
 		},
 	}.Append(azureCommonPackageSet(t)).Append(SapPackageSet(t))
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/systemd_unit_create_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/systemd_unit_create_stage.go
@@ -23,12 +23,13 @@ const (
 
 type Unit struct {
 	Description              string   `json:"Description,omitempty"`
-	DefaultDependencies      bool     `json:"DefaultDependencies,omitempty"`
+	DefaultDependencies      *bool    `json:"DefaultDependencies,omitempty"`
 	ConditionPathExists      []string `json:"ConditionPathExists,omitempty"`
 	ConditionPathIsDirectory []string `json:"ConditionPathIsDirectory,omitempty"`
 	Requires                 []string `json:"Requires,omitempty"`
 	Wants                    []string `json:"Wants,omitempty"`
 	After                    []string `json:"After,omitempty"`
+	Before                   []string `json:"Before,omitempty"`
 }
 
 type Service struct {

--- a/vendor/github.com/osbuild/images/pkg/policies/policies.go
+++ b/vendor/github.com/osbuild/images/pkg/policies/policies.go
@@ -85,14 +85,18 @@ var CustomFilesPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathP
 // MountpointPolicies for ostree
 var OstreeMountpointPolicies = pathpolicy.NewPathPolicies(map[string]pathpolicy.PathPolicy{
 	"/":             {},
-	"/ostree":       {Deny: true},
-	"/home":         {Deny: true},
+	"/home":         {Deny: true}, // symlink to var/home
+	"/mnt":          {Deny: true}, // symlink to var/mnt
+	"/opt":          {Deny: true}, // symlink to var/opt
+	"/ostree":       {Deny: true}, // symlink to sysroot/ostree
+	"/root":         {Deny: true}, // symlink to var/roothome
+	"/srv":          {Deny: true}, // symlink to var/srv
 	"/var/home":     {Deny: true},
-	"/var/opt":      {Deny: true},
-	"/var/srv":      {Deny: true},
-	"/var/roothome": {Deny: true},
-	"/var/usrlocal": {Deny: true},
 	"/var/mnt":      {Deny: true},
+	"/var/opt":      {Deny: true},
+	"/var/roothome": {Deny: true},
+	"/var/srv":      {Deny: true},
+	"/var/usrlocal": {Deny: true},
 })
 
 // CustomDirectoriesPolicies for ostree

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -865,7 +865,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.63.0
+# github.com/osbuild/images v0.65.0
 ## explicit; go 1.20
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
Relevant PRs included in this update:

### v0.64.0
  * dnfjson: enable loading of optional metadata when needed (https://github.com/osbuild/images/pull/702)
    * Author: Achilleas Koutsou, Reviewers: Brian C. Lane, Tomáš Hozza

### v0.65.0
  * Fedora: Change AArch64 iot-simplified-installer to gpt (https://github.com/osbuild/images/pull/735)
    * Author: Paul Whalen, Reviewers: Achilleas Koutsou
  * Remove support for Fedora 38 (https://github.com/osbuild/images/pull/728)
    * Author: Achilleas Koutsou, Reviewers: Simon de Vlieger
  * Set the chunk size for S3 upload to 64MB (https://github.com/osbuild/images/pull/717)
    * Author: Brad P. Crochet, Reviewers: Achilleas Koutsou
  * distro/rhel8: update RHUI client RPM for Azure SAP 8.10 images (COMPOSER-2254) (https://github.com/osbuild/images/pull/707)
    * Author: Achilleas Koutsou, Reviewers: Tomáš Hozza
  * osbuild/systemd-unit-create: fix DefaultDependencies option (https://github.com/osbuild/images/pull/668)
    * Author: Achilleas Koutsou, Reviewers: Michael Vogt