### PR TITLE
osbuildexecutor: allow file type `tar.TypeGNUSparse` too

### DIFF
--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -210,7 +210,7 @@ func validateOutputArchive(outputTarPath string) error {
 		}
 		// protect against someone smuggling in eg. device files
 		// XXX: should we support symlinks here?
-		if !slices.Contains([]byte{tar.TypeReg, tar.TypeDir}, hdr.Typeflag) {
+		if !slices.Contains([]byte{tar.TypeReg, tar.TypeDir, tar.TypeGNUSparse}, hdr.Typeflag) {
 			return fmt.Errorf("name %q must be a file/dir, is header type %q", hdr.Name, hdr.Typeflag)
 		}
 		// protect against executables, this implicitly protects


### PR DESCRIPTION
We need to allow files of type `tar.TypeGNUSparse` in the result that we get from the osbuild-worker-executor too.

