### PR TITLE
osbuild-worker-executor: `job-id` in control.json as hostname

### DIFF
--- a/cmd/osbuild-worker-executor/export_test.go
+++ b/cmd/osbuild-worker-executor/export_test.go
@@ -12,6 +12,14 @@ var (
 	HandleIncludedSources = handleIncludedSources
 )
 
+func MockUnixSethostname(new func([]byte) error) (restore func()) {
+	saved := unixSethostname
+	unixSethostname = new
+	return func() {
+		unixSethostname = saved
+	}
+}
+
 func MockOsbuildBinary(t *testing.T, new string) (restore func()) {
 	t.Helper()
 

--- a/cmd/osbuild-worker-executor/handler_build_test.go
+++ b/cmd/osbuild-worker-executor/handler_build_test.go
@@ -324,3 +324,30 @@ func TestBuildErrorHandlingTar(t *testing.T) {
 	assert.Contains(t, string(body), "cannot tar output directory:")
 	assert.Contains(t, loggerHook.LastEntry().Message, "cannot tar output directory:")
 }
+
+func TestBuildSethostname(t *testing.T) {
+	baseURL, baseBuildDir, _ := runTestServer(t)
+	endpoint := baseURL + "api/v1/build"
+
+	restore := main.MockOsbuildBinary(t, fmt.Sprintf(`#!/bin/sh -e
+# simulate output
+mkdir -p %[1]s/build/output/image
+echo "fake-build-result" > %[1]s/build/output/image/disk.img
+`, baseBuildDir))
+	t.Cleanup(restore)
+
+	var hostnameCalls []string
+	restore = main.MockUnixSethostname(func(hn []byte) error {
+		hostnameCalls = append(hostnameCalls, string(hn))
+		return nil
+	})
+	t.Cleanup(restore)
+
+	buf := makeTestPost(t, `{"exports": ["tree"], "job-id": "1234-56"}`, `{"fake": "manifest"}`)
+	rsp, err := http.Post(endpoint, "application/x-tar", buf)
+	assert.NoError(t, err)
+	defer func() { _, _ = io.ReadAll(rsp.Body) }()
+	defer rsp.Body.Close()
+
+	assert.Equal(t, []string{"1234-56"}, hostnameCalls)
+}

--- a/cmd/osbuild-worker-executor/main_test.go
+++ b/cmd/osbuild-worker-executor/main_test.go
@@ -55,6 +55,11 @@ func runTestServer(t *testing.T) (baseURL, buildBaseDir string, loggerHook *logr
 	buildBaseDir = t.TempDir()
 	baseURL = fmt.Sprintf("http://%s:%s/", host, port)
 
+	restore := main.MockUnixSethostname(func([]byte) error {
+		return nil
+	})
+	t.Cleanup(restore)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -526,7 +526,16 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		exportPaths = append(exportPaths, path.Join(jobTarget.OsbuildArtifact.ExportName, jobTarget.OsbuildArtifact.ExportFilename))
 	}
 
-	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, exportPaths, nil, extraEnv, true, os.Stderr)
+	opts := &osbuildexecutor.OsbuildOpts{
+		StoreDir:    impl.Store,
+		OutputDir:   outputDirectory,
+		Exports:     exports,
+		ExportPaths: exportPaths,
+		ExtraEnv:    extraEnv,
+		Result:      true,
+		JobID:       job.Id().String(),
+	}
+	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, opts, os.Stderr)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed", err.Error())

--- a/internal/osbuildexecutor/osbuild-executor.go
+++ b/internal/osbuildexecutor/osbuild-executor.go
@@ -6,6 +6,19 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
+type OsbuildOpts struct {
+	StoreDir    string
+	OutputDir   string
+	Exports     []string
+	ExportPaths []string
+	Checkpoints []string
+	ExtraEnv    []string
+	Result      bool
+
+	// not strict a osbuild opt
+	JobID string
+}
+
 type Executor interface {
-	RunOSBuild(manifest []byte, store, outputDirectory string, exports, exportPaths, checkpoints, extraEnv []string, result bool, errorWriter io.Writer) (*osbuild.Result, error)
+	RunOSBuild(manifest []byte, opts *OsbuildOpts, errorWriter io.Writer) (*osbuild.Result, error)
 }

--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -73,15 +73,17 @@ func waitForSI(ctx context.Context, host string) bool {
 	}
 }
 
-func writeInputArchive(cacheDir, store string, exports []string, manifestData []byte) (string, error) {
+func writeInputArchive(cacheDir, store, jobID string, exports []string, manifestData []byte) (string, error) {
 	archive := filepath.Join(cacheDir, "input.tar")
 	control := filepath.Join(cacheDir, "control.json")
 	manifest := filepath.Join(cacheDir, "manifest.json")
 
 	controlData := struct {
 		Exports []string `json:"exports"`
+		JobID   string   `json:"job-id"`
 	}{
 		Exports: exports,
+		JobID:   jobID,
 	}
 	controlDataBytes, err := json.Marshal(controlData)
 	if err != nil {
@@ -287,7 +289,7 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 		return nil, fmt.Errorf("Timeout waiting for executor to come online")
 	}
 
-	inputArchive, err := writeInputArchive(ec2e.tmpDir, opts.StoreDir, opts.Exports, manifest)
+	inputArchive, err := writeInputArchive(ec2e.tmpDir, opts.StoreDir, opts.JobID, opts.Exports, manifest)
 	if err != nil {
 		logrus.Errorf("Unable to write input archive: %v", err)
 		return nil, err

--- a/internal/osbuildexecutor/runner-impl-aws-ec2_test.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2_test.go
@@ -46,7 +46,7 @@ func TestWriteInputArchive(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(storeDir, "contents"), []byte("storedata"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(storeSubDir, "contents"), []byte("storedata"), 0600))
 
-	archive, err := osbuildexecutor.WriteInputArchive(cacheDir, storeDir, []string{"image"}, []byte("{\"version\": 2}"))
+	archive, err := osbuildexecutor.WriteInputArchive(cacheDir, storeDir, "some-job-id", []string{"image"}, []byte("{\"version\": 2}"))
 	require.NoError(t, err)
 
 	cmd := exec.Command("tar",
@@ -64,6 +64,10 @@ func TestWriteInputArchive(t *testing.T) {
 		"store/contents",
 		"",
 	}, strings.Split(string(out), "\n"))
+
+	output, err := exec.Command("tar", "xOf", archive, "control.json").CombinedOutput()
+	require.NoError(t, err)
+	require.Equal(t, `{"exports":["image"],"job-id":"some-job-id"}`, string(output))
 }
 
 func TestHandleBuild(t *testing.T) {

--- a/internal/osbuildexecutor/runner-impl-host.go
+++ b/internal/osbuildexecutor/runner-impl-host.go
@@ -8,9 +8,12 @@ import (
 
 type hostExecutor struct{}
 
-func (he *hostExecutor) RunOSBuild(manifest []byte, store, outputDirectory string, exports, exportPaths, checkpoints,
-	extraEnv []string, result bool, errorWriter io.Writer) (*osbuild.Result, error) {
-	return osbuild.RunOSBuild(manifest, store, outputDirectory, exports, checkpoints, extraEnv, result, errorWriter)
+func (he *hostExecutor) RunOSBuild(manifest []byte, opts *OsbuildOpts, errorWriter io.Writer) (*osbuild.Result, error) {
+	if opts == nil {
+		opts = &OsbuildOpts{}
+	}
+
+	return osbuild.RunOSBuild(manifest, opts.StoreDir, opts.OutputDir, opts.Exports, opts.Checkpoints, opts.ExtraEnv, opts.Result, errorWriter)
 }
 
 func NewHostExecutor() Executor {


### PR DESCRIPTION
This commit adds support to set the hostname to the job-id that is part of the control.json.

This is the first part, the second part will actually set this in the `internal/osbuildexecutor/runner-impl-aws-ec2.go`