### PR TITLE
golangci: fix integration tests for images

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,5 +24,5 @@ issues:
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
   exclude-rules:
-    - path: ^cmd/osbuild-worker-executor/.*_test\.go$
+    - path: ^(osbuild-composer/)?cmd/osbuild-worker-executor/.*_test\.go$
       linters: ["gosec"]


### PR DESCRIPTION
`images` also calls this linter but with `path-prefix`.
This should fix PR tests in the `images` repo
