### PR TITLE
Set executor hostname via cloud-init

### DIFF
--- a/cmd/osbuild-worker-executor/export_test.go
+++ b/cmd/osbuild-worker-executor/export_test.go
@@ -12,14 +12,6 @@ var (
 	HandleIncludedSources = handleIncludedSources
 )
 
-func MockUnixSethostname(new func([]byte) error) (restore func()) {
-	saved := unixSethostname
-	unixSethostname = new
-	return func() {
-		unixSethostname = saved
-	}
-}
-
 func MockOsbuildBinary(t *testing.T, new string) (restore func()) {
 	t.Helper()
 

--- a/cmd/osbuild-worker-executor/handler_build.go
+++ b/cmd/osbuild-worker-executor/handler_build.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"golang.org/x/exp/slices"
-	"golang.org/x/sys/unix"
 
 	"github.com/sirupsen/logrus"
 )
@@ -109,7 +108,6 @@ func runOsbuild(logger *logrus.Logger, buildDir string, control *controlJSON, ou
 type controlJSON struct {
 	Environments []string `json:"environments"`
 	Exports      []string `json:"exports"`
-	JobID        string   `json:"job-id"`
 }
 
 func mustRead(atar *tar.Reader, name string) error {
@@ -237,15 +235,6 @@ func handleIncludedSources(atar *tar.Reader, buildDir string) error {
 	}
 }
 
-var unixSethostname = unix.Sethostname
-
-func setHostname(name string) error {
-	if name == "" {
-		return nil
-	}
-	return unixSethostname([]byte(name))
-}
-
 // test for real via:
 // curl -o - --data-binary "@./test.tar" -H "Content-Type: application/x-tar"  -X POST http://localhost:8001/api/v1/build
 func handleBuild(logger *logrus.Logger, config *Config) http.Handler {
@@ -271,11 +260,6 @@ func handleBuild(logger *logrus.Logger, config *Config) http.Handler {
 			if err != nil {
 				logger.Error(err)
 				http.Error(w, "cannot decode control.json", http.StatusBadRequest)
-				return
-			}
-			if err := setHostname(control.JobID); err != nil {
-				logger.Error(err)
-				http.Error(w, "cannot set hostname", http.StatusBadRequest)
 				return
 			}
 

--- a/cmd/osbuild-worker-executor/main_test.go
+++ b/cmd/osbuild-worker-executor/main_test.go
@@ -55,11 +55,6 @@ func runTestServer(t *testing.T) (baseURL, buildBaseDir string, loggerHook *logr
 	buildBaseDir = t.TempDir()
 	baseURL = fmt.Sprintf("http://%s:%s/", host, port)
 
-	restore := main.MockUnixSethostname(func([]byte) error {
-		return nil
-	})
-	t.Cleanup(restore)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -515,7 +515,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			return err
 		}
 		defer os.RemoveAll(tmpDir)
-		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName, impl.OSBuildExecutor.CloudWatchGroup, tmpDir)
+		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName, impl.OSBuildExecutor.CloudWatchGroup, job.Id().String(), tmpDir)
 	default:
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorInvalidConfig, "No osbuild executor defined", nil)
 		return err
@@ -533,7 +533,6 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		ExportPaths: exportPaths,
 		ExtraEnv:    extraEnv,
 		Result:      true,
-		JobID:       job.Id().String(),
 	}
 	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, opts, os.Stderr)
 	// First handle the case when "running" osbuild failed

--- a/internal/cloud/awscloud/secure-instance_test.go
+++ b/internal/cloud/awscloud/secure-instance_test.go
@@ -8,6 +8,7 @@ import (
 func TestSecureInstanceUserData(t *testing.T) {
 	type testCase struct {
 		CloudWatchGroup  string
+		Hostname         string
 		ExpectedUserData string
 	}
 
@@ -21,6 +22,7 @@ write_files:
 		},
 		{
 			CloudWatchGroup: "test-group",
+			Hostname:        "test-hostname",
 			ExpectedUserData: `#cloud-config
 write_files:
   - path: /tmp/worker-run-executor-service
@@ -28,13 +30,14 @@ write_files:
   - path: /tmp/cloud_init_vars
     content: |
       OSBUILD_EXECUTOR_CLOUDWATCH_GROUP='test-group'
+      OSBUILD_EXECUTOR_HOSTNAME='test-hostname'
 `,
 		},
 	}
 
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("Test case %d", idx), func(t *testing.T) {
-			userData := SecureInstanceUserData(tc.CloudWatchGroup)
+			userData := SecureInstanceUserData(tc.CloudWatchGroup, tc.Hostname)
 			if userData != tc.ExpectedUserData {
 				t.Errorf("Expected: %s, got: %s", tc.ExpectedUserData, userData)
 			}

--- a/internal/osbuildexecutor/osbuild-executor.go
+++ b/internal/osbuildexecutor/osbuild-executor.go
@@ -14,9 +14,6 @@ type OsbuildOpts struct {
 	Checkpoints []string
 	ExtraEnv    []string
 	Result      bool
-
-	// not strict a osbuild opt
-	JobID string
 }
 
 type Executor interface {

--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -25,6 +25,7 @@ type awsEC2Executor struct {
 	iamProfile      string
 	keyName         string
 	cloudWatchGroup string
+	hostname        string
 	tmpDir          string
 }
 
@@ -268,7 +269,7 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 		return nil, fmt.Errorf("Failed to get default aws client in %s region: %w", region, err)
 	}
 
-	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName, ec2e.cloudWatchGroup)
+	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName, ec2e.cloudWatchGroup, ec2e.hostname)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start secure instance: %w", err)
 	}
@@ -317,11 +318,12 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 	return osbuildResult, nil
 }
 
-func NewAWSEC2Executor(iamProfile, keyName, cloudWatchGroup, tmpDir string) Executor {
+func NewAWSEC2Executor(iamProfile, keyName, cloudWatchGroup, hostname, tmpDir string) Executor {
 	return &awsEC2Executor{
 		iamProfile,
 		keyName,
 		cloudWatchGroup,
+		hostname,
 		tmpDir,
 	}
 }

--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -73,17 +73,15 @@ func waitForSI(ctx context.Context, host string) bool {
 	}
 }
 
-func writeInputArchive(cacheDir, store, jobID string, exports []string, manifestData []byte) (string, error) {
+func writeInputArchive(cacheDir, store string, exports []string, manifestData []byte) (string, error) {
 	archive := filepath.Join(cacheDir, "input.tar")
 	control := filepath.Join(cacheDir, "control.json")
 	manifest := filepath.Join(cacheDir, "manifest.json")
 
 	controlData := struct {
 		Exports []string `json:"exports"`
-		JobID   string   `json:"job-id"`
 	}{
 		Exports: exports,
-		JobID:   jobID,
 	}
 	controlDataBytes, err := json.Marshal(controlData)
 	if err != nil {
@@ -289,7 +287,7 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 		return nil, fmt.Errorf("Timeout waiting for executor to come online")
 	}
 
-	inputArchive, err := writeInputArchive(ec2e.tmpDir, opts.StoreDir, opts.JobID, opts.Exports, manifest)
+	inputArchive, err := writeInputArchive(ec2e.tmpDir, opts.StoreDir, opts.Exports, manifest)
 	if err != nil {
 		logrus.Errorf("Unable to write input archive: %v", err)
 		return nil, err

--- a/internal/osbuildexecutor/runner-impl-aws-ec2_test.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2_test.go
@@ -46,7 +46,7 @@ func TestWriteInputArchive(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(storeDir, "contents"), []byte("storedata"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(storeSubDir, "contents"), []byte("storedata"), 0600))
 
-	archive, err := osbuildexecutor.WriteInputArchive(cacheDir, storeDir, "some-job-id", []string{"image"}, []byte("{\"version\": 2}"))
+	archive, err := osbuildexecutor.WriteInputArchive(cacheDir, storeDir, []string{"image"}, []byte("{\"version\": 2}"))
 	require.NoError(t, err)
 
 	cmd := exec.Command("tar",
@@ -64,10 +64,6 @@ func TestWriteInputArchive(t *testing.T) {
 		"store/contents",
 		"",
 	}, strings.Split(string(out), "\n"))
-
-	output, err := exec.Command("tar", "xOf", archive, "control.json").CombinedOutput()
-	require.NoError(t, err)
-	require.Equal(t, `{"exports":["image"],"job-id":"some-job-id"}`, string(output))
 }
 
 func TestHandleBuild(t *testing.T) {

--- a/templates/packer/ansible/roles/common/files/worker-executor.service
+++ b/templates/packer/ansible/roles/common/files/worker-executor.service
@@ -6,6 +6,7 @@ After=cloud-final.service
 
 [Service]
 Type=oneshot
+ExecStart=/usr/local/libexec/worker-initialization-scripts/set_executor_hostname.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_executor.sh
 
 [Install]

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/set_executor_hostname.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/set_executor_hostname.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+if [[ -z "$OSBUILD_EXECUTOR_HOSTNAME" ]]; then
+    echo "OSBUILD_EXECUTOR_HOSTNAME not set, skipping."
+    exit 0
+fi
+
+echo "Setting system hostname to $OSBUILD_EXECUTOR_HOSTNAME."
+hostnamectl set-hostname "$OSBUILD_EXECUTOR_HOSTNAME"


### PR DESCRIPTION
This way much more of the journal will be captured under the new hostname.
