### PR TITLE
Added arch and storage_account, needed by CIV to deploy the resources…

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -219,9 +219,11 @@ tee "${TEMPDIR}/resource-file.json" <<EOF
   "instances": [
     {
       "vhd_uri": "${BLOB_URL}",
+      "arch": "${ARCH}",
       "location": "${AZURE_LOCATION}",
       "name": "${IMAGE_KEY}",
-      "hyper_v_generation": "${HYPER_V_GEN}"
+      "hyper_v_generation": "${HYPER_V_GEN}",
+      "storage_account": "${AZURE_STORAGE_ACCOUNT}"
     }
   ]
 }


### PR DESCRIPTION
… without having to check for vhd uri regex.

The regex check is now not needed since we create other shared image metadata on the fly. Plus it was not a good solution for an upstream project, as the regex was only affecting our RH teams internally.


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [x] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
