### PR TITLE
Schutzfile: move to latest osbuild with `curl --parallel` support

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [
@@ -122,7 +122,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [
@@ -148,49 +148,49 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-8.9": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-8.10": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-9.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
   "rhel-9.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
@@ -243,14 +243,14 @@
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     }
   },
  "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "2e5a9335c94228726b36f804468651e605d70a88"
+        "commit": "4697a3fb840a337438bd31b81f78cb8c5bfb14bc"
       }
     },
     "repos": [

--- a/test/cases/regression-insecure-repo.sh
+++ b/test/cases/regression-insecure-repo.sh
@@ -72,6 +72,8 @@ EOF
 mkdir -p "DUMMYRPMDIR/rpmbuild"
 rpmbuild --quiet --define "_topdir $dummyrpmdir/rpmbuild" -bb "$dummyspecfile"
 rpmsign --addsign "${dummyrpmdir}"/rpmbuild/RPMS/noarch/*.rpm
+# debug
+sha256sum "${dummyrpmdir}"/rpmbuild/RPMS/noarch/*.rpm
 
 mkdir -p "${dummyrpmdir}/repo"
 cp "${dummyrpmdir}"/rpmbuild/RPMS/noarch/*rpm "$dummyrpmdir/repo"


### PR DESCRIPTION
This commit updates osbuild so that we benefit from osbuild PR#1573 to enable `curl --parallel`. This should speed up downloading especially on fast connections as less time is spend with the connection setup/handshake etc.

