### PR TITLE
Makefile: bump golint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ RST2MAN ?= rst2man
 
 # v1.55 to get golang 1.21 (1.21.3)
 # v1.53 to get golang 1.20 (1.20.5)
-GOLANGCI_LINT_VERSION=v1.53
+GOLANGCI_LINT_VERSION=v1.55
 GOLANGCI_LINT_CACHE_DIR=$(HOME)/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION)
 GOLANGCI_COMPOSER_IMAGE=composer_golangci
 #

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRCDIR ?= .
 
 RST2MAN ?= rst2man
 
+# see https://hub.docker.com/r/docker/golangci-lint/tags
 # v1.55 to get golang 1.21 (1.21.3)
 # v1.53 to get golang 1.20 (1.20.5)
 GOLANGCI_LINT_VERSION=v1.55


### PR DESCRIPTION
followup of PR #4241
golint version should match golang version
this fixes `make lint` and implicitly fixes the github actions