### PR TITLE
osbuild-worker: rework the `workerClientErrorFrom()` error

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve_test.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osbuild/images/pkg/dnfjson"
@@ -11,28 +13,46 @@ import (
 	worker "github.com/osbuild/osbuild-composer/cmd/osbuild-worker"
 )
 
+func makeMockEntry() (*logrus.Entry, *test.Hook) {
+	logger, hook := test.NewNullLogger()
+	return logger.WithField("test", "test"), hook
+}
+
 func TestWorkerClientErrorFromDnfJson(t *testing.T) {
 	dnfJsonErr := dnfjson.Error{
 		Kind:   "DepsolveError",
 		Reason: "something is terribly wrong",
 	}
-	clientErr, err := worker.WorkerClientErrorFrom(dnfJsonErr)
-	assert.NoError(t, err)
+	entry, hook := makeMockEntry()
+	clientErr := worker.WorkerClientErrorFrom(dnfJsonErr, entry)
 	assert.Equal(t, `Code: 20, Reason: DNF error occurred: DepsolveError, Details: something is terribly wrong`, clientErr.String())
+	assert.Equal(t, 0, len(hook.AllEntries()))
+}
+
+func TestWorkerClientErrorFromDnfJsonOtherKind(t *testing.T) {
+	dnfJsonErr := dnfjson.Error{
+		Kind:   "something-else",
+		Reason: "something is terribly wrong",
+	}
+	entry, hook := makeMockEntry()
+	clientErr := worker.WorkerClientErrorFrom(dnfJsonErr, entry)
+	assert.Equal(t, `Code: 22, Reason: DNF error occurred: something-else, Details: something is terribly wrong`, clientErr.String())
+	assert.Equal(t, 1, len(hook.AllEntries()))
+	assert.Equal(t, "Unhandled dnf-json error in depsolve job: DNF error occurred: something-else: something is terribly wrong", hook.LastEntry().Message)
 }
 
 func TestWorkerClientErrorFromOtherError(t *testing.T) {
 	otherErr := fmt.Errorf("some error")
-	clientErr, err := worker.WorkerClientErrorFrom(otherErr)
-	// XXX: this is probably okay but it seems slightly dangerous to
-	// assume that any "error" we get there is coming from rpmmd, can
-	// we generate a more typed error from dnfjson here for rpmmd errors?
-	assert.EqualError(t, err, "some error")
+	entry, hook := makeMockEntry()
+	clientErr := worker.WorkerClientErrorFrom(otherErr, entry)
 	assert.Equal(t, `Code: 23, Reason: rpmmd error in depsolve job, Details: some error`, clientErr.String())
+	assert.Equal(t, 0, len(hook.AllEntries()))
 }
 
 func TestWorkerClientErrorFromNil(t *testing.T) {
-	clientErr, err := worker.WorkerClientErrorFrom(nil)
-	assert.EqualError(t, err, "workerClientErrorFrom expected an error to be processed. Not nil")
+	entry, hook := makeMockEntry()
+	clientErr := worker.WorkerClientErrorFrom(nil, entry)
 	assert.Equal(t, `Code: 23, Reason: rpmmd error in depsolve job, Details: <nil>`, clientErr.String())
+	assert.Equal(t, 1, len(hook.AllEntries()))
+	assert.Equal(t, "workerClientErrorFrom expected an error to be processed. Not nil", hook.LastEntry().Message)
 }


### PR DESCRIPTION
The workerClientErrorFrom() was returning an `*clienterrors.Error` and an `error` (if something with the conversation goes wrong.

But the calling code was expecting that even if an `error` is returned the `*clienterrors.Error` is still valid. The caller would then just log the error. As returning a valid `value` even when there is an `error` is an unexpected pattern this commit changes the code to always return a `*clienterrors.Error` and log any issue via the logger.

