### PR TITLE
osbuild-worker: tweak error to not include a \n for a failed stage

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -372,8 +372,8 @@ func makeJobErrorFromOsbuildOutput(osbuildOutput *osbuild.Result) *clienterrors.
 	}
 
 	reason := "osbuild build failed"
-	if len(failedStage) > 0 {
-		reason += " in stage:\n" + failedStage
+	if failedStage != "" {
+		reason += fmt.Sprintf(" in stage: %q", failedStage)
 	}
 	return clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, reason, osbErrors)
 }

--- a/cmd/osbuild-worker/jobimpl-osbuild_test.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild_test.go
@@ -34,8 +34,7 @@ func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
 					},
 				},
 			},
-			expected: `Code: 10, Reason: osbuild build failed in stage:
-bad-stage, Details: []`,
+			expected: `Code: 10, Reason: osbuild build failed in stage: "bad-stage", Details: []`,
 		},
 		{
 			inputData: &osbuild.Result{


### PR DESCRIPTION
Small followup for
https://github.com/osbuild/osbuild-composer/pull/4113#discussion_r1670063775

Given that the failed stage is a relatively short string the `\n` seems unneccessary and quotes are enough.


