### PR TITLE
Fix distro alias loading from ENV

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -222,7 +222,11 @@ func loadConfigFromEnv(intf interface{}) error {
 			if err != nil {
 				return err
 			}
-			fieldV.Set(reflect.ValueOf(value))
+			// Don't override the whole map, just update the keys that are present in the env.
+			// This is consistent with how loading config from the file works.
+			for k, v := range value {
+				fieldV.SetMapIndex(reflect.ValueOf(k), reflect.ValueOf(v))
+			}
 		case reflect.Struct:
 			err := loadConfigFromEnv(fieldV.Addr().Interface())
 			if err != nil {

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -170,12 +170,12 @@ func TestConfigFromEnv(t *testing.T) {
 		}
 	}()
 
-	os.Setenv("DISTRO_ALIASES", "rhel-7=rhel-7.9,rhel-8=rhel-8.9,rhel-9=rhel-9.3,rhel-10.0=rhel-9.5")
+	os.Setenv("DISTRO_ALIASES", "rhel-7=rhel-7.9,rhel-8=rhel-8.9,rhel-9=rhel-9.3")
 	expectedDistroAliases := map[string]string{
-		"rhel-7":    "rhel-7.9",
-		"rhel-8":    "rhel-8.9",
-		"rhel-9":    "rhel-9.3",
-		"rhel-10.0": "rhel-9.5",
+		"rhel-7":  "rhel-7.9",
+		"rhel-8":  "rhel-8.9",
+		"rhel-9":  "rhel-9.3",
+		"rhel-10": "rhel-10.0", // this value is from the default config
 	}
 
 	config, err := LoadConfig("")

--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -339,4 +339,4 @@ parameters:
     description: Name of the secret for connecting to sentry/glitchtip
   - description: Distro name aliases
     name: DISTRO_ALIASES
-    value: "rhel-7=rhel-7.9,rhel-8=rhel-8.10,rhel-9=rhel-9.4"
+    value: "rhel-7=rhel-7.9,rhel-8=rhel-8.10,rhel-9=rhel-9.4,rhel-10=rhel-10.0"


### PR DESCRIPTION
Composer can load configuration values defined as map from ENV. Previously, when loading the configuration from ENV, the whole map would get overridden, not just values defined in the ENV. This is however not intended and not consistent with how loading configuration from file works.

Adjust the configuration loading from ENV and adjust the unit test accordingly.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.




In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
