### PR TITLE
Fix slack GA pipeline notification job failure

### DIFF
--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -7,11 +7,11 @@ if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
     exit 0
 fi
 
-COMPOSE_ID=$(cat COMPOSE_ID)
-COMPOSER_NVR=$(cat COMPOSER_NVR)
 if [ "$3" == "ga" ]; then
     MESSAGE="\"GA composes pipeline execution finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL \""
 else
+    COMPOSE_ID=$(cat COMPOSE_ID)
+    COMPOSER_NVR=$(cat COMPOSER_NVR)
     MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""
 fi
 


### PR DESCRIPTION
The `COMPOSE_ID` and `COMPOSER_NVR` variables were causing the GA pipeline's slack notification jobs to fail due to them being undefined when the script was invoked by those two jobs. Fixing that by moving their definition into the condition.

Run where the job failed: https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/7401301891