### PR TITLE
test/api: silent dump_db()

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -199,7 +199,7 @@ checkEnv
 function dump_db() {
   # Save the result, including the manifest, for the job, straight from the db
   sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c "SELECT result FROM jobs WHERE type='manifest-id-only'" \
-    | sudo tee "${ARTIFACTS}/build-result.txt"
+    | sudo tee "${ARTIFACTS}/build-result.txt" > /dev/null
 }
 
 WORKDIR=$(mktemp -d)


### PR DESCRIPTION
When cleaning up api tests, the build job results are dumped from the database to store in build-result.txt and are printed to the runner log at the same time.  This makes it very difficult to read results as the database dump prints very long lines that flood the job log.  The result isn't really readable (or useful) unless the file is downloaded separately.

Silence the `tee` command so that the file is created but no output is printed from the db dump.

See for example [this job log](https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/7433608651) which starts with the last line of the database dump.  To see previous lines, you need to switch to the complete raw form.