### PR TITLE
Change log_format for the service to json

### DIFF
--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -248,6 +248,7 @@ objects:
         pattern: ^(${ACL_ACCOUNT_ID_TENANTS})$
     osbuild-composer.toml: |
       log_level = "info"
+      log_format = "json"
       [koji]
       enable_tls = false
       enable_mtls = false


### PR DESCRIPTION
This is to be inline with `image-builder` and to
enable decoding in splunk

@croissanne I'm still somewhat in the dark with the deployment setup :-/ is this the correct place to change the logs, going to splunk, to be json? (to support `|spath input=message` which works for `image-builder`)