### PR TITLE
Schutzfile: test CI against osbuild PR#1819

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -122,7 +122,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -148,56 +148,56 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-8.9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-8.10": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-9.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-9.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "rhel-9.5": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -243,7 +243,7 @@
   "rhel-10.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -289,14 +289,14 @@
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [
@@ -342,7 +342,7 @@
   "centos-stream-10": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "fae57533273f9d3c79817c946cf33a8408bb9669"
       }
     },
     "repos": [


### PR DESCRIPTION
The osbuild curl --parallel support is now reworked and should be ready. This is a test against the (not yet) merged code.

DO NOT MERGE (yet)
