### PR TITLE
logrus: add deployment channel as field to the logs

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -12,17 +12,18 @@ import (
 )
 
 type ComposerConfigFile struct {
-	Koji          KojiAPIConfig     `toml:"koji"`
-	Worker        WorkerAPIConfig   `toml:"worker"`
-	WeldrAPI      WeldrAPIConfig    `toml:"weldr_api"`
-	DistroAliases map[string]string `toml:"distro_aliases" env:"DISTRO_ALIASES"`
-	LogLevel      string            `toml:"log_level"`
-	LogFormat     string            `toml:"log_format"`
-	DNFJson       string            `toml:"dnf-json"`
-	SplunkHost    string            `env:"SPLUNK_HEC_HOST"`
-	SplunkPort    string            `env:"SPLUNK_HEC_PORT"`
-	SplunkToken   string            `env:"SPLUNK_HEC_TOKEN"`
-	GlitchTipDSN  string            `env:"GLITCHTIP_DSN"`
+	Koji              KojiAPIConfig     `toml:"koji"`
+	Worker            WorkerAPIConfig   `toml:"worker"`
+	WeldrAPI          WeldrAPIConfig    `toml:"weldr_api"`
+	DistroAliases     map[string]string `toml:"distro_aliases" env:"DISTRO_ALIASES"`
+	LogLevel          string            `toml:"log_level"`
+	LogFormat         string            `toml:"log_format"`
+	DNFJson           string            `toml:"dnf-json"`
+	SplunkHost        string            `env:"SPLUNK_HEC_HOST"`
+	SplunkPort        string            `env:"SPLUNK_HEC_PORT"`
+	SplunkToken       string            `env:"SPLUNK_HEC_TOKEN"`
+	GlitchTipDSN      string            `env:"GLITCHTIP_DSN"`
+	DeploymentChannel string            `env:"CHANNEL"`
 }
 
 type KojiAPIConfig struct {

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -110,6 +110,10 @@ func main() {
 		logrus.Warn("GLITCHTIP_DSN not configured, skipping initializing Sentry/Glitchtip")
 	}
 
+	if config.DeploymentChannel != "" {
+		logrus.AddHook(&common.EnvironmentHook{Channel: config.DeploymentChannel})
+	}
+
 	stateDir, ok := os.LookupEnv("STATE_DIRECTORY")
 	if !ok {
 		logrus.Fatal("STATE_DIRECTORY is not set. Is the service file missing StateDirectory=?")

--- a/internal/common/environment_hook.go
+++ b/internal/common/environment_hook.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type EnvironmentHook struct {
+	Channel string
+}
+
+func (h *EnvironmentHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *EnvironmentHook) Fire(e *logrus.Entry) error {
+	e.Data["channel"] = h.Channel
+
+	return nil
+}

--- a/internal/common/environment_hook_test.go
+++ b/internal/common/environment_hook_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func makeLogrus(buf *bytes.Buffer) *logrus.Logger {
+	return &logrus.Logger{
+		Out: buf,
+		Formatter: &logrus.TextFormatter{
+			DisableTimestamp: true,
+			DisableColors:    true,
+		},
+		Hooks: make(logrus.LevelHooks),
+		Level: logrus.DebugLevel,
+	}
+
+}
+
+func TestInfoWithEnvironment(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	l.AddHook(&EnvironmentHook{Channel: "test_framework"})
+	l.Info("test message")
+	require.Equal(t, "level=info msg=\"test message\" channel=test_framework\n", buf.String())
+}

--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -126,6 +126,8 @@ objects:
                 optional: true
           - name: DISTRO_ALIASES
             value: ${DISTRO_ALIASES}
+          - name: CHANNEL
+            value: ${CHANNEL}
           ports:
           - name: composer-api
             protocol: TCP
@@ -341,3 +343,9 @@ parameters:
   - description: Distro name aliases
     name: DISTRO_ALIASES
     value: "rhel-7=rhel-7.9,rhel-8=rhel-8.10,rhel-9=rhel-9.4,rhel-10=rhel-10.0"
+  - name: CHANNEL
+    value: "local"
+    description: >
+      Channel where this pod is deployed.
+      This is appended to the logs. Usually something like
+      "local", "staging" or "production".


### PR DESCRIPTION
As far as I saw in the openshift deployment, the parameter `"CHANNEL"` is already set implicitly by the environment (`…/environments/stage.yml` or `…/environments/production.yml`)
If something like this worked, this would be awesome for filtering logs