### PR TITLE
templates/packer: increase net.core.(w/r)mem_max

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-38": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -122,7 +122,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -148,56 +148,56 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-8.9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-8.10": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-9.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-9.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "rhel-9.5": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -243,7 +243,7 @@
   "rhel-10.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -289,14 +289,14 @@
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [
@@ -342,14 +342,14 @@
   "centos-10": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     }
   },
   "centos-stream-10": {
     "dependencies": {
       "osbuild": {
-        "commit": "df83c629201f3955dfb07016c31409d85f376a29"
+        "commit": "88c35ea306ab03b50d64939ff1d5e0ccc379a9e8"
       }
     },
     "repos": [

--- a/templates/packer/ansible/roles/common/tasks/packages.yml
+++ b/templates/packer/ansible/roles/common/tasks/packages.yml
@@ -135,6 +135,22 @@
     echo "installing rpms $COMPOSER_RPMS"
     dnf install -y $COMPOSER_RPMS
 
+# osbuild uses socket.SOCK_SEQPACKET when sending files to the build root. For very large files this
+# can cause EMSGSIZE errors.
+- ansible.posix.sysctl:
+  tags:
+    - always
+  name: net.core.wmem_max
+  value: '4194304'
+  sysctl_set: true
+
+- ansible.posix.sysctl:
+  tags:
+    - always
+  name: net.core.rmem_max
+  value: '4194304'
+  sysctl_set: true
+
 - name: Cleanup rpmbuild dir
   tags:
     - always


### PR DESCRIPTION
In conjunction with osbuild/osbuild#1833 this should fix building very large manifests.

---

- [x] https://github.com/osbuild/osbuild/pull/1833