### PR TITLE
splunk_logger: move environment hook to splunk_logger pt1

### DIFF
--- a/pkg/splunk_logger/environment_hook.go
+++ b/pkg/splunk_logger/environment_hook.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+type EnvironmentHook struct {
+	Channel string
+}
+
+func (h *EnvironmentHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *EnvironmentHook) Fire(e *logrus.Entry) error {
+	e.Data["channel"] = h.Channel
+
+	return nil
+}

--- a/pkg/splunk_logger/environment_hook_test.go
+++ b/pkg/splunk_logger/environment_hook_test.go
@@ -1,0 +1,30 @@
+package logger
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func makeLogrus(buf *bytes.Buffer) *logrus.Logger {
+	return &logrus.Logger{
+		Out: buf,
+		Formatter: &logrus.TextFormatter{
+			DisableTimestamp: true,
+			DisableColors:    true,
+		},
+		Hooks: make(logrus.LevelHooks),
+		Level: logrus.DebugLevel,
+	}
+
+}
+
+func TestInfoWithEnvironment(t *testing.T) {
+	buf := &bytes.Buffer{}
+	l := makeLogrus(buf)
+	l.AddHook(&EnvironmentHook{Channel: "test_framework"})
+	l.Info("test message")
+	require.Equal(t, "level=info msg=\"test message\" channel=test_framework\n", buf.String())
+}


### PR DESCRIPTION
this has to be in two steps:
- duplicate `environment_hook` to `splunk_logger` first
- change and use the reference from within `go.mod` and the main code

so this PR just duplicates the code to `pkg/splunk_logger` to be able to reference it from there after being on `main` (from composer as well as image-builder later on)

or can this be done in one go? (...in one "go" 😁 🙄 )