### PR TITLE
osbuild-composer: add `Requires: osbuild-dnf-json-api = 7`

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -326,6 +326,9 @@ cd $PWD/_build/src/%{goipath}
 %package core
 Summary:    The core osbuild-composer binary
 Requires:   osbuild-depsolve-dnf >= %{min_osbuild_version}
+# This version needs to get bumped everytime the osbuild-depsolve-dnf json
+# API changes in incompatible ways
+Requires:   osbuild-dnf-json-api = 7
 Provides:   %{name}-dnf-json = %{version}-%{release}
 Obsoletes:  %{name}-dnf-json < %{version}-%{release}
 


### PR DESCRIPTION
Use an exact version dependency on the `osbuild-dnf-json-api` to ensure incompatible json protocol changes cannot break composer.

See also https://github.com/osbuild/osbuild/pull/1849

