### PR TITLE
tools/appsre-ansible: retry subscribing rpmbuild machines

### DIFF
--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -29,6 +29,9 @@
 
   # RHEL mock templates don't work on RHUI, they use the CDN repos
   - name: Subscribe
+    register: result
+    retries: 5
+    until: result is success
     community.general.redhat_subscription:
       activationkey: "{{ RH_ACTIVATION_KEY }}"
       org_id: "{{ RH_ORG_ID }}"
@@ -167,3 +170,10 @@
       mode: pull
       src: /home/ec2-user/rpmbuild/RPMS
       dest: /osbuild-composer/templates/packer/ansible/roles/common/files/rpmbuild/{{ ansible_architecture }}
+
+  - name: Unsubscribe
+    register: result
+    retries: 5
+    until: result is success
+    community.general.redhat_subscription:
+      state: absent


### PR DESCRIPTION
Also unsubscribe after the build is done.

---

Packer builds are failing with
```
10:18:52 TASK [Subscribe] ***************************************************************
10:19:18 fatal: [44.203.59.246]: FAILED! => {"changed": false, "cmd": "/sbin/subscription-manager register --org **** --activationkey VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "msg": "Remote server error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.", "rc": 70, "stderr": "Remote server error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information.\n", "stderr_lines": ["Remote server error. Please check the connection details, or see /var/log/rhsm/rhsm.log for more information."], "stdout": "", "stdout_lines": []}
```
sometimes. Let's just retry like we do in the other playbook.
