### PR TITLE
cmd/osbuild-worker/main: fix worker "crashing" on connection issues during startup

### DIFF
--- a/internal/worker/client_helpers_test.go
+++ b/internal/worker/client_helpers_test.go
@@ -1,0 +1,8 @@
+// helper functions for client_test.go
+package worker
+
+func (c *Client) InvalidateAccessToken() {
+	c.tokenMu.Lock()
+	c.accessToken = ""
+	c.tokenMu.Unlock()
+}

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -2,12 +2,13 @@ package worker_test
 
 import (
 	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/jobqueue/fsjobqueue"
 	"github.com/osbuild/osbuild-composer/internal/worker"
@@ -42,14 +43,13 @@ func newTestWorkerServer(t *testing.T) (string, string, string) {
 
 	/* Check that the worker supplies the access token  */
 	calls := 0
-	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if calls == 0 {
-			require.Equal(t, "Bearer", r.Header.Get("Authorization"))
+	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") == "Bearer" {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		require.Equal(t, "Bearer "+accessToken, r.Header.Get("Authorization"))
-		handler.ServeHTTP(w, r)
+		require.Equal(t, "Bearer "+accessToken, req.Header.Get("Authorization"))
+		handler.ServeHTTP(w, req)
 	}))
 	t.Cleanup(proxySrv.Close)
 
@@ -102,38 +102,145 @@ func TestOAuth(t *testing.T) {
 }
 
 func TestProxy(t *testing.T) {
-	workerURL, oauthURL, offlineToken := newTestWorkerServer(t)
 
-	// initialize a test proxy server
-	proxy := &proxy{}
-	proxySrv := httptest.NewServer(proxy)
-	t.Cleanup(proxySrv.Close)
+	testCases := []struct {
+		name                string
+		resetAuthentication bool
+		expectedCalls       int
+	}{
+		{"Test normal startup", false, 5},
+		{"Test loosing authentication", true, 7},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workerURL, oauthURL, offlineToken := newTestWorkerServer(t)
 
-	client, err := worker.NewClient(worker.ClientConfig{
+			// initialize a test proxy server
+			proxy := &proxy{registrationSuccessful: false}
+			proxySrv := httptest.NewServer(proxy)
+			t.Cleanup(proxySrv.Close)
+
+			client, err := worker.NewClient(worker.ClientConfig{
+				BaseURL:      workerURL,
+				TlsConfig:    nil,
+				ClientId:     "rhsm-api",
+				OfflineToken: offlineToken,
+				OAuthURL:     oauthURL,
+				BasePath:     "/api/image-builder-worker/v1",
+				ProxyURL:     proxySrv.URL,
+			})
+
+			if tc.resetAuthentication {
+				client.InvalidateAccessToken()
+			}
+
+			require.NoError(t, err)
+			job, err := client.RequestJob([]string{worker.JobTypeOSBuild}, "arch")
+			require.NoError(t, err)
+			r := strings.NewReader("artifact contents")
+			require.NoError(t, job.UploadArtifact("some-artifact", r))
+			c, err := job.Canceled()
+			require.False(t, c)
+			require.NoError(t, err)
+
+			// we expect 5 or 7 calls to go through the proxy:
+			// depending, if we "loose" authentication or not
+			// * oauth call
+			// * register worker
+			// --- second testcase SNIP
+			// * request job (401 unauthorized)
+			// * oauth call
+			// ---
+			// * request job
+			// * upload artifact
+			// * cancel
+			require.Equal(t, tc.expectedCalls, proxy.calls, "We got those:\n"+strings.Join(proxy.paths, "\n"))
+
+			require.True(t, proxy.registrationSuccessful)
+		})
+	}
+}
+
+type LogCheckerHook struct {
+	checkMsgs []string
+	t         *testing.T
+	counter   int
+}
+
+func (h *LogCheckerHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
+}
+
+func (h *LogCheckerHook) Fire(e *logrus.Entry) error {
+	require.Less(h.t, h.counter, len(h.checkMsgs), "Got %s, probably unexpected", e.Message)
+	require.Contains(h.t, e.Message, h.checkMsgs[h.counter])
+	h.counter += 1
+	return nil
+}
+
+func muteLogrusDuringTest(t *testing.T) {
+	// avoid having errors on stdout - as this is expected
+	oldOut := logrus.StandardLogger().Out
+	logrus.SetOutput(io.Discard)
+	t.Cleanup(func() {
+		logrus.SetOutput(oldOut)
+	})
+
+	newHooks := make(logrus.LevelHooks)
+	originalHooks := logrus.StandardLogger().ReplaceHooks(newHooks)
+	t.Cleanup(func() {
+		logrus.StandardLogger().ReplaceHooks(originalHooks)
+	})
+}
+
+func TestFailedInitialToken(t *testing.T) {
+	muteLogrusDuringTest(t)
+
+	workerURL, _, offlineToken := newTestWorkerServer(t)
+
+	logrus.AddHook(&LogCheckerHook{
+		t:         t,
+		checkMsgs: []string{"Error getting access token on startup"},
+	})
+
+	_, err := worker.NewClient(worker.ClientConfig{
 		BaseURL:      workerURL,
+		TlsConfig:    nil,
+		ClientId:     "rhsm-api",
+		OfflineToken: offlineToken,
+		OAuthURL:     "http://illegalHost:1234",
+		BasePath:     "/api/image-builder-worker/v1",
+	})
+	require.NoError(t, err)
+
+}
+
+func TestFailedInitialRegisterWorker(t *testing.T) {
+	muteLogrusDuringTest(t)
+
+	_, oauthURL, offlineToken := newTestWorkerServer(t)
+
+	logrus.AddHook(&LogCheckerHook{
+		t: t,
+		checkMsgs: []string{
+			"Unable to register worker",
+			"Error registering worker on startup",
+		}})
+
+	_, err := worker.NewClient(worker.ClientConfig{
+		BaseURL:      "http://illegalHost:1234",
 		TlsConfig:    nil,
 		ClientId:     "rhsm-api",
 		OfflineToken: offlineToken,
 		OAuthURL:     oauthURL,
 		BasePath:     "/api/image-builder-worker/v1",
-		ProxyURL:     proxySrv.URL,
 	})
-
 	require.NoError(t, err)
-	job, err := client.RequestJob([]string{worker.JobTypeOSBuild}, "arch")
-	require.NoError(t, err)
-	r := strings.NewReader("artifact contents")
-	require.NoError(t, job.UploadArtifact("some-artifact", r))
-	c, err := job.Canceled()
-	require.False(t, c)
-	require.NoError(t, err)
-
-	// we expect 6 calls to go through the proxy:
-	// - register worker
-	// - request job (fails, no oauth token)
-	// - oauth call
-	// - request job (succeeds)
-	// - upload artifact
-	// - cancel
-	require.Equal(t, 6, proxy.calls)
 }


### PR DESCRIPTION
Rationale:
When the worker can't reach composer _during runtime_ it just retries.
When it can't reach composer on startup it "crashes" (`logrus.Fatalf()` terminates the worker)

With this patch the worker stays alive and retries.
This should be more reliable and faster than restarting completely.
Also for unit tests and development it's nicer to just retry.

(this is loosely connected to the tests of https://github.com/osbuild/ansible-osbuild-worker/pull/6 )