### PR TITLE
tools/appsre-ansible: fix unregister

### DIFF
--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -171,9 +171,10 @@
       src: /home/ec2-user/rpmbuild/RPMS
       dest: /osbuild-composer/templates/packer/ansible/roles/common/files/rpmbuild/{{ ansible_architecture }}
 
-  - name: Unsubscribe
-    register: result
+  - name: Unregister
     retries: 5
+    delay: 20
+    register: result
     until: result is success
-    community.general.redhat_subscription:
-      state: absent
+    shell: >-
+      subscription-manager unregister


### PR DESCRIPTION
The community redhat_subscription module calls `subscription-manager unsusbscribe`, which doesn't exist. Use shell for now.

---

```
11:01:06 fatal: [54.91.239.48]: FAILED! => {"attempts": 5, "changed": false, "cmd": "/sbin/subscription-manager unsubscribe --all", "msg": "", "rc": 1, "stderr": "", "stderr_lines": [], "stdout": "Usage: subscription-manager MODULE-NAME [MODULE-OPTIONS] [--help]\n\r\nPrimary Modules: \n\n  attach         Attach a specified subscription to the registered system, when system does not use Simple Content Access mode\n  list           List subscription and product information for this system\n  refresh        Pull the latest subscription data from the server\n  register       Register this system to the Customer Portal or another subscription management service\n  release        Configure which operating system release to use\n  remove         Remove all or specific subscriptions from this system\n  status         Show status information for this system's subscriptions and products\n  unregister     Unregister this system from the Customer Portal or another subscription management service\n\nOther Modules:   \n\n  addons         Deprecated, see 'syspurpose'\n  auto-attach    Set if subscriptions are attached on a schedule (default of daily)\n  clean          Remove all local system and subscription data without affecting the server\n  config         List, set, or remove the configuration parameters in use by this system\n  environments   Display the environments available for a user\n  facts          View or update the detected system information\n  identity       Display the identity certificate for this system or request a new one\n  import         Import certificates which were provided outside of the tool\n  orgs           Display the organizations against which a user can register a system\n  plugins        View and configure with 'subscription-manager plugins'\n  redeem         Attempt to redeem a subscription for a preconfigured system\n  repo-override  Manage custom content repository settings\n  repos          List the repositories which this system is entitled to use\n  role           Deprecated, see 'syspurpose'\n  service-level  Deprecated, see 'syspurpose'\n  syspurpose     Convenient module for managing all system purpose settings\n  usage          Deprecated, see 'syspurpose'\n  version        Print version information\n\n", "stdout_lines": ["Usage: subscription-manager MODULE-NAME [MODULE-OPTIONS] [--help]", "", "Primary Modules: ", "", "  attach         Attach a specified subscription to the registered system, when system does not use Simple Content Access mode", "  list           List subscription and product information for this system", "  refresh        Pull the latest subscription data from the server", "  register       Register this system to the Customer Portal or another subscription management service", "  release        Configure which operating system release to use", "  remove         Remove all or specific subscriptions from this system", "  status         Show status information for this system's subscriptions and products", "  unregister     Unregister this system from the Customer Portal or another subscription management service", "", "Other Modules:   ", "", "  addons         Deprecated, see 'syspurpose'", "  auto-attach    Set if subscriptions are attached on a schedule (default of daily)", "  clean          Remove all local system and subscription data without affecting the server", "  config         List, set, or remove the configuration parameters in use by this system", "  environments   Display the environments available for a user", "  facts          View or update the detected system information", "  identity       Display the identity certificate for this system or request a new one", "  import         Import certificates which were provided outside of the tool", "  orgs           Display the organizations against which a user can register a system", "  plugins        View and configure with 'subscription-manager plugins'", "  redeem         Attempt to redeem a subscription for a preconfigured system", "  repo-override  Manage custom content repository settings", "  repos          List the repositories which this system is entitled to use", "  role           Deprecated, see 'syspurpose'", "  service-level  Deprecated, see 'syspurpose'", "  syspurpose     Convenient module for managing all system purpose settings", "  usage          Deprecated, see 'syspurpose'", "  version        Print version information", ""]}
```