### PR TITLE
worker: simplify the `POST` in workerHeartbeat()

### DIFF
--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -228,8 +228,7 @@ func (c *Client) workerHeartbeat() {
 			continue
 		}
 
-		var buf bytes.Buffer
-		resp, err := c.NewRequest("POST", url.String(), map[string]string{"Content-Type": "application/json"}, bytes.NewReader(buf.Bytes()))
+		resp, err := c.NewRequest("POST", url.String(), map[string]string{"Content-Type": "application/json"}, nil)
 		if err != nil {
 			logrus.Errorf("Error updating worker status: %v", err)
 			continue


### PR DESCRIPTION
There is no actual payload when posting the worker status so let's just post `nil` instead of an empty `bytes.Buffer` to make this explicit.

