### PR TITLE
worker: move `api.BasePath` setup to the start of the funcs

### DIFF
--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -75,13 +75,12 @@ type tokenResponse struct {
 }
 
 func NewClient(conf ClientConfig) (*Client, error) {
+	api.BasePath = conf.BasePath
+
 	serverURL, err := url.Parse(conf.BaseURL)
 	if err != nil {
 		return nil, err
 	}
-
-	api.BasePath = conf.BasePath
-
 	serverURL, err = serverURL.Parse(api.BasePath + "/")
 	if err != nil {
 		panic(err)
@@ -131,13 +130,12 @@ func NewClient(conf ClientConfig) (*Client, error) {
 }
 
 func NewClientUnix(conf ClientConfig) *Client {
+	api.BasePath = conf.BasePath
+
 	serverURL, err := url.Parse("http://localhost/")
 	if err != nil {
 		panic(err)
 	}
-
-	api.BasePath = conf.BasePath
-
 	serverURL, err = serverURL.Parse(api.BasePath + "/")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I find it slightly eaiser to read this code when
`api.BasePath = conf.BasePath` is right at the top as it's unrelated to the parsing code below.

Note that the code itself is problematic:
- api.BasePath is global but client is not, this means that multiple client with different configs will result in api.BasePath being potentially wrong
- api.BasePath is set in a non-thread safe manner

Changing is a bigger job but we might consider it (IMHO).

