### PR TITLE
client: extract endpoint() and newServerURL() helper

### DIFF
--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -75,13 +75,12 @@ type tokenResponse struct {
 }
 
 func NewClient(conf ClientConfig) (*Client, error) {
+	api.BasePath = conf.BasePath
+
 	serverURL, err := url.Parse(conf.BaseURL)
 	if err != nil {
 		return nil, err
 	}
-
-	api.BasePath = conf.BasePath
-
 	serverURL, err = serverURL.Parse(api.BasePath + "/")
 	if err != nil {
 		panic(err)
@@ -131,13 +130,12 @@ func NewClient(conf ClientConfig) (*Client, error) {
 }
 
 func NewClientUnix(conf ClientConfig) *Client {
+	api.BasePath = conf.BasePath
+
 	serverURL, err := url.Parse("http://localhost/")
 	if err != nil {
 		panic(err)
 	}
-
-	api.BasePath = conf.BasePath
-
 	serverURL, err = serverURL.Parse(api.BasePath + "/")
 	if err != nil {
 		panic(err)

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -137,3 +137,17 @@ func TestProxy(t *testing.T) {
 	// - cancel
 	require.Equal(t, 6, proxy.calls)
 }
+
+func TestNewServerURL(t *testing.T) {
+	conf := worker.ClientConfig{
+		BaseURL:  "http://localhost:8080/base/",
+		BasePath: "/api/image-builder-worker/v42",
+	}
+	serverURL, err := worker.NewServerURL(conf)
+	require.NoError(t, err)
+	// Note that the "/base" is intentionally discarded by NewServerURL
+	// (the code is written this way and if we would change it it would
+	//  potentially break compatibility)
+	require.Equal(t, "http://localhost:8080/api/image-builder-worker/v42/", serverURL.String())
+
+}

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -149,5 +150,20 @@ func TestNewServerURL(t *testing.T) {
 	// (the code is written this way and if we would change it it would
 	//  potentially break compatibility)
 	require.Equal(t, "http://localhost:8080/api/image-builder-worker/v42/", serverURL.String())
+}
 
+func mustParse(u string) *url.URL {
+	url, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return url
+}
+
+func TestClientEndpointURL(t *testing.T) {
+	client := &worker.Client{}
+	client.SetServerURL(client, mustParse("http://localhost:8080/api/v42"))
+
+	url := client.Endpoint("workers")
+	require.Equal(t, "http://localhost:8080/api/v42/workers", url)
 }

--- a/internal/worker/export_test.go
+++ b/internal/worker/export_test.go
@@ -1,0 +1,17 @@
+package worker
+
+import (
+	"net/url"
+)
+
+var (
+	NewServerURL = newServerURL
+)
+
+func (c *Client) SetServerURL(client *Client, url *url.URL) {
+	c.serverURL = url
+}
+
+func (c *Client) Endpoint(endpoint string) string {
+	return c.endpoint(endpoint)
+}


### PR DESCRIPTION
Small refactor, I am actually not sure it's worth it, so feel free to close as long term we want to move to konflux and a lot of this will probably go away. But maybe it is still useful. 

---

worker: add `endpoint()` helper that cannot fail and use it

Small commit to (hopefully) make the intent of the code more
clear when `serverURL.Parse()` is used. In most cases it is
used to generate an endpoint URL. As this is a realtive path
we do not need `Parse()` but can use `JoinPath()` instead which
has the nice benefit that it cannot error or panic.

----

worker: extract `newServerURL()` helper and add tests

Also explain why serverURL.JoinPath() cannot be used here.
