### PR TITLE
worker: remove `api.BasePath` and replace with MakeHTTPErrorHandler()

### DIFF
--- a/internal/worker/api/api.go
+++ b/internal/worker/api/api.go
@@ -1,6 +1,3 @@
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen -package=api -generate types,server,spec -o api.gen.go openapi.yml
 
 package api
-
-// default basepath, can be overwritten
-var BasePath = "/api/worker/v1"

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -80,9 +80,7 @@ func NewClient(conf ClientConfig) (*Client, error) {
 		return nil, err
 	}
 
-	api.BasePath = conf.BasePath
-
-	serverURL, err = serverURL.Parse(api.BasePath + "/")
+	serverURL, err = serverURL.Parse(conf.BasePath + "/")
 	if err != nil {
 		panic(err)
 	}
@@ -136,9 +134,7 @@ func NewClientUnix(conf ClientConfig) *Client {
 		panic(err)
 	}
 
-	api.BasePath = conf.BasePath
-
-	serverURL, err = serverURL.Parse(api.BasePath + "/")
+	serverURL, err = serverURL.Parse(conf.BasePath + "/")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
[draft as it currently has no tests :( ]

The `api.BasePath` is package global but the way it is used is that multiple clients can (potentially) have different BasePath and the way it is written right now could lead to confusing bugs.

This commit tweaks the `api` package so that `BasePath` does not need to be set. The only place that this is needed is for the `api.APIError()` which can just get the basePath as an argument. With that we also need a helper to construct the api error handler from the static HTTPErrorHandler to a dynamic MakeHTTPErrorHandler() that will return a handler for the given basePath.

This should make https://github.com/osbuild/osbuild-composer/pull/4328 obsolete.

