### PR TITLE
tools/build-rpms: increase size of instances

### DIFF
--- a/tools/build-rpms.py
+++ b/tools/build-rpms.py
@@ -15,11 +15,11 @@ import boto3
 arch_info = {}
 arch_info["x86_64"] = {
     "ImageId": "ami-0f7c7d22de9e097ea",
-    "InstanceType": "c5.large"
+    "InstanceType": "m7a.large"
 }
 arch_info["aarch64"] = {
     "ImageId": "ami-019ece25c0f135889",
-    "InstanceType": "c6g.large"
+    "InstanceType": "m7g.large"
 }
 
 


### PR DESCRIPTION
Mockbuilds are currently timing out after #4287, maybe due to memory constraints.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
