### PR TITLE
osbuild-worker: handle error wrapping from dnfjson package

### DIFF
--- a/cmd/osbuild-worker/jobimpl-depsolve_test.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve_test.go
@@ -26,6 +26,11 @@ func TestWorkerClientErrorFromDnfJson(t *testing.T) {
 	entry, hook := makeMockEntry()
 	clientErr := worker.WorkerClientErrorFrom(dnfJsonErr, entry)
 	assert.Equal(t, `Code: 20, Reason: DNF error occurred: DepsolveError, Details: something is terribly wrong`, clientErr.String())
+
+	wrappedErr := fmt.Errorf("Wrap the error: %w", dnfJsonErr)
+	clientErr = worker.WorkerClientErrorFrom(wrappedErr, entry)
+	assert.Equal(t, `Code: 20, Reason: DNF error occurred: DepsolveError, Details: something is terribly wrong`, clientErr.String())
+
 	assert.Equal(t, 0, len(hook.AllEntries()))
 }
 


### PR DESCRIPTION
osbuild/images#751 wrapped the errors in the images/dnfjson package to provide more details, the depsolve job should take this into account to map the dnfjson error to the correct worker client error.

This caused user input errors errors to be misclassified as internal errors, triggering depsolve job failure alerts.

