### PR TITLE
upload/azure: turn off public access on storage accounts

### DIFF
--- a/internal/upload/azure/azure.go
+++ b/internal/upload/azure/azure.go
@@ -111,7 +111,8 @@ func (ac Client) CreateStorageAccount(ctx context.Context, resourceGroup, name, 
 			tag.Name: &tag.Value,
 		},
 		Properties: &armstorage.AccountPropertiesCreateParameters{
-			MinimumTLSVersion: common.ToPtr(armstorage.MinimumTLSVersionTLS12),
+			AllowBlobPublicAccess: common.ToPtr(false),
+			MinimumTLSVersion:     common.ToPtr(armstorage.MinimumTLSVersionTLS12),
 		},
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
When creating a storage account we're currently allowing public blob access, users might have compliance policies active on their azure accounts which forbid this.



---

Even though the default should be false, we're still getting
```
Storage account Allow Blob Public Access should be disallowed
```

so let's just do it explicitly.