### PR TITLE
test/cases: Use openscap customization + enable oci api test on RHEL-10 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -569,6 +569,7 @@ API:
           - aws
           - azure
           - gcp
+          - oci
         RUNNER:
           - aws/rhel-10.0-nightly-x86_64
         INTERNAL_NETWORK: ["true"]

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -419,11 +419,6 @@ EOF
   ;;
 esac
 
-# TODO: Remove once Openscap works on el-10
-if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} == 10 ]]; then
-  yellowprint "OpenSCAP not supported on ${ID}-${VERSION_ID} now. No openscap profile applied!"
-  OPENSCAP_CUSTOMIZATION_BLOCK=
-fi
 export OPENSCAP_CUSTOMIZATION_BLOCK
 
 TIMEZONE_CUSTOMIZATION_BLOCK=$(cat <<EOF

--- a/test/cases/api/common/common.sh
+++ b/test/cases/api/common/common.sh
@@ -82,12 +82,7 @@ function _instanceCheck() {
   verify_dirs_files_customization "$_ssh"
 
   verify_repository_customization "$_ssh"
-# TODO: Remove once Openscap works on el-10
-  if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} == 10 ]]; then
-    yellowprint "OpenSCAP not supported on ${ID}-${VERSION_ID} now. No verification made!"
-  else
-    verify_openscap_customization "$_ssh"
-  fi
+  verify_openscap_customization "$_ssh"
 
   echo "✔️ Checking timezone customization"
   TZ=$($_ssh timedatectl show  -p Timezone --value)


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
