### PR TITLE
osbuild-worker: fix "crashing" on worker registration issues

### DIFF
--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -123,7 +123,8 @@ func NewClient(conf ClientConfig) (*Client, error) {
 	}
 	err = client.registerWorker()
 	if err != nil {
-		return client, err
+		// workerHeartbeat below will periodically retry to register
+		logrus.Warnf("Error registering worker on startup, %v. Trying again later…", err)
 	}
 	go client.workerHeartbeat()
 	return client, nil


### PR DESCRIPTION
When the osbuild worker cannot register itself with the server on startup the worker will "crash". This is inconsistent with the existing behavior in `workerHeartbeat()` which deals with connectivity or other server issue gracefully and retries periodically.

To unify the behavior this commit changes the behavior and only issues a `logrus.Warnf` instead of the previous `Falalf` when the registration fails.

---

This is an alternative version of https://github.com/osbuild/osbuild-composer/pull/4320 that contains the minimal change to achieve the goal with a test. I feel quite rude to open this PR and I'm sorry for this. I'm mostly doing this as I feel after 51 discussion comments in the other PR it might be easier/more illustrative to offer an alternative version instead of keeping the discussion in the other PR going. 

The key points (to me):
- the change is minimal to achieve the goal
- the test is targeted exactly at the change
- the commit message explains in some (but not too much) details the "what/why/how" for future reference (note that it's the git commit message itself, not the github PR description which is not connected to the git history so won't help when doing e.g. git blame)
 

I hope this helps, I sincerely want to help here, this is not asserting domination or playing one-upmanship or anything like this. I'm sure there are things to improve with this PR too.

P.S. This does not contain the unix socket change, mostly because I did not want to spend more time thinking how to test it (it's probably easy but I wanted to timebox it). Also with unix sockets connectivity issues are more rare so it seemed less important (but I could be wrong here).

[edit: typo fix]