### PR TITLE
tools/build-rpms: increase rpm builder instance disk size

### DIFF
--- a/tools/build-rpms.py
+++ b/tools/build-rpms.py
@@ -106,11 +106,22 @@ def create_ec2_instances(cleanup_actions, args, keypair):
             }
         ]
 
+        img = ec2.describe_images(ImageIds=[arch_info[a]["ImageId"]])
         instance = ec2.create_instances(
             ImageId=arch_info[a]["ImageId"],
             MinCount=1,
             MaxCount=1,
             InstanceType=arch_info[a]["InstanceType"],
+            BlockDeviceMappings=[
+                {
+                    "DeviceName": img['Images'][0]['RootDeviceName'],
+                    "Ebs": {
+                        "VolumeSize": 20,
+                        "DeleteOnTermination": True,
+                        "VolumeType": "gp2",
+                    },
+                },
+            ],
             KeyName=keypair,
             TagSpecifications=tags
         )


### PR DESCRIPTION
The instance created for rpm builds is running out of space on the default 10G disk, let's double it.

