### PR TITLE
tools/build-rpms: fix ec2 client initialisation

### DIFF
--- a/tools/build-rpms.py
+++ b/tools/build-rpms.py
@@ -86,6 +86,7 @@ def create_keypair(cleanup_actions):
 
 def create_ec2_instances(cleanup_actions, args, keypair):
     ec2 = boto3.resource('ec2')
+    ec2cli = boto3.client('ec2')
 
     instances = []
     for a in args.arch:
@@ -106,7 +107,7 @@ def create_ec2_instances(cleanup_actions, args, keypair):
             }
         ]
 
-        img = ec2.describe_images(ImageIds=[arch_info[a]["ImageId"]])
+        img = ec2cli.describe_images(ImageIds=[arch_info[a]["ImageId"]])
         instance = ec2.create_instances(
             ImageId=arch_info[a]["ImageId"],
             MinCount=1,


### PR DESCRIPTION
Fixes:
```
Error: Create EC2 instances  failed: 'ec2.ServiceResource' object has no attribute 'describe_images'
Traceback (most recent call last):
  File "/osbuild-composer/tools/build-rpms.py", line 218, in <module>
    stage_generate_rpms(cleanup_actions, args)
  File "/osbuild-composer/tools/build-rpms.py", line 175, in stage_generate_rpms
    create_ec2_instances, cleanup_actions, args, keyname)
  File "/osbuild-composer/tools/build-rpms.py", line 66, in stage
    ret = fun(*args)
  File "/osbuild-composer/tools/build-rpms.py", line 109, in create_ec2_instances
    img = ec2.describe_images(ImageIds=[arch_info[a]["ImageId"]])
AttributeError: 'ec2.ServiceResource' object has no attribute 'describe_images'
```

---

I didn't realise the difference between boto resources and boto clients. Rather confusing imo.

