### PR TITLE
composer: don't create RepoRegistry using reporegistry.New()

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -77,10 +77,11 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 		return nil, fmt.Errorf("failed to configure distro aliases: %v", err)
 	}
 
-	c.repos, err = reporegistry.New(repositoryConfigs)
+	repoConfigs, err := reporegistry.LoadAllRepositories(repositoryConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("error loading repository definitions: %v", err)
 	}
+	c.repos = reporegistry.NewFromDistrosRepoConfigs(repoConfigs)
 
 	c.solver = dnfjson.NewBaseSolver(path.Join(c.cacheDir, "rpmmd"))
 	c.solver.SetDNFJSONPath(c.config.DNFJson)

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -57,7 +57,14 @@ sudo mkdir -p /etc/osbuild-worker
 # interacting with cloud providers are configured directly in the worker. In addition,
 # no certificates need to be generated, because they are not used anywhere in this
 # scenario.
+#
+# Moreover, there should be no repositories configured in the Service scenario, because
+# these are expected to be provided with the compose request.
 if [[ "$AUTH_METHOD" != "$AUTH_METHOD_NONE" ]]; then
+    # Remove the repositories, because it is not used in the Service scenario
+    sudo rm -rf /etc/osbuild-composer/repositories
+    sudo rm -f /usr/share/osbuild-composer/repositories/*
+
     # Generate all X.509 certificates for the tests
     # The whole generation is done in a $CADIR to better represent how osbuild-ca
     # it.


### PR DESCRIPTION
The `reporegistry.New()` has been enhanced to return an error, in case there were no repositories loaded. This was to fix the situation in many unit tests, which were previously not loading any repositories and silently not running any tests.

This however broke our SaaS deployment, where we actually do not configure any repositories on the filesystem. As a result, osbuild-composer started to fail on it.

Workaround this situation in osbuild-composer by reverting to the old behavior by loading the repo configs separately and then using the loaded repos (which could be empty map) to initialize the RepoRegistry.

Also update the `tools/provision.sh` to delete all repositories in the Service scenario.

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
