### PR TITLE
cloud: fixed typo UnfulfillableCapacity (HMS-4676)

### DIFF
--- a/internal/cloud/awscloud/mocks_test.go
+++ b/internal/cloud/awscloud/mocks_test.go
@@ -293,7 +293,7 @@ func (m *ec2mock) CreateFleet(ctx context.Context, input *ec2.CreateFleetInput, 
 		return &ec2.CreateFleetOutput{
 			Errors: []ec2types.CreateFleetError{
 				{
-					ErrorCode:    aws.String("UnfillableCapacity"),
+					ErrorCode:    aws.String("UnfulfillableCapacity"),
 					ErrorMessage: aws.String("Msg"),
 				},
 			},

--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -547,8 +547,8 @@ func (a *AWS) createFleet(input *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, 
 		return nil, fmt.Errorf("Unable to create spot fleet: %w", err)
 	}
 
-	if len(createFleetOutput.Errors) > 0 && *createFleetOutput.Errors[0].ErrorCode == "UnfillableCapacity" {
-		logrus.Warn("Received UnfillableCapacity from CreateFleet, retrying CreateFleet with OnDemand instance")
+	if len(createFleetOutput.Errors) > 0 && *createFleetOutput.Errors[0].ErrorCode == "UnfulfillableCapacity" {
+		logrus.Warn("Received UnfulfillableCapacity from CreateFleet, retrying CreateFleet with OnDemand instance")
 		input.SpotOptions = nil
 		createFleetOutput, err = a.ec2.CreateFleet(context.Background(), input)
 	}


### PR DESCRIPTION
While I was investigating a customer report I noticed this small typo which could actually cause the fallback not to work at all. The correct terms are linked from AWS Go library:

https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html

Related issue: https://issues.redhat.com/browse/HMS-4676