### PR TITLE
cloud: new AWS metrics for spot instances

### DIFF
--- a/internal/prometheus/aws_metrics.go
+++ b/internal/prometheus/aws_metrics.go
@@ -1,0 +1,94 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	UploadedS3Files = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "uploaded_s3_files",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Total files uploaded to S3",
+	}, []string{"result"})
+
+	RegisterImportSnapshot = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "register_import_snapshot_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of import snapshot registration",
+	})
+
+	CopyImage = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "copy_image_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of copying image",
+	})
+
+	ShareImage = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "share_image_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of sharing image",
+	})
+
+	RemoveImage = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "remove_image_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of removing image",
+	})
+
+	RunSecureImage = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "run_secure_image_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of staring secure image",
+	})
+
+	TerminateSecureImage = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:      "terminate_secure_image_duration_seconds",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Duration of terminating secure image",
+	})
+
+	CreatedFleets = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "created_fleets",
+		Namespace: Namespace,
+		Subsystem: AWSSubsystem,
+		Help:      "Number of created fleets",
+	}, []string{"result", "type"})
+)
+
+func ObserveRegisterImportSnapshot() ObserveFunc {
+	pt := prometheus.NewTimer(RegisterImportSnapshot)
+	return pt.ObserveDuration
+}
+
+func ObserverCopyImage() ObserveFunc {
+	pt := prometheus.NewTimer(CopyImage)
+	return pt.ObserveDuration
+}
+
+func ShareImageObserver() ObserveFunc {
+	pt := prometheus.NewTimer(ShareImage)
+	return pt.ObserveDuration
+}
+
+func RemoveImageObserver() ObserveFunc {
+	pt := prometheus.NewTimer(RemoveImage)
+	return pt.ObserveDuration
+}
+
+func RunSecureImageObserver() ObserveFunc {
+	pt := prometheus.NewTimer(RunSecureImage)
+	return pt.ObserveDuration
+}
+
+func TerminateSecureImageObserver() ObserveFunc {
+	pt := prometheus.NewTimer(TerminateSecureImage)
+	return pt.ObserveDuration
+}

--- a/internal/prometheus/constants.go
+++ b/internal/prometheus/constants.go
@@ -4,4 +4,5 @@ const (
 	Namespace         = "image_builder"
 	ComposerSubsystem = "composer"
 	WorkerSubsystem   = "worker"
+	AWSSubsystem      = "aws"
 )

--- a/internal/prometheus/helpers.go
+++ b/internal/prometheus/helpers.go
@@ -3,7 +3,10 @@ package prometheus
 import (
 	"regexp"
 	"strings"
+	"time"
 )
+
+type ObserveFunc func() time.Duration
 
 func pathLabel(path string) string {
 	r := regexp.MustCompile(":(.*)")


### PR DESCRIPTION
This is a followup for https://github.com/osbuild/osbuild-composer/pull/4385

The goal here is to increase observability of AWS composer integration. Couple of histograms and counters from the most important one is to me the create fleet one which allows us to measure how many of fleet runs were successful and out of these how many of these were actually spot or on-demand.

I am doing this because previously there was a type and it appears that the hosted composer were not able to do a proper on-demand fallback. We can verify the behavior after promotion push or even start actively monitoring this metric on the dashboard.