### PR TITLE
test: disable ostree-remount service checking since /sysroot is ro and /var rw already

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -479,30 +479,6 @@
         dest: "{{ workspace }}/{{ commit_log }}.installed.ostree.log"
       delegate_to: localhost
 
-    # case: check ostree-remount mount log
-    - name: check ostree-remount mount log
-      command: journalctl -u ostree-remount
-      register: result_remount_jounalctl
-
-    # Skipping playbook task in Fedora40, CS9 and RHEL 9 due to bug https://issues.redhat.com/browse/RHEL-25249
-    # - name: ostree-remount should remount /var and /sysroot
-    #   block:
-    #     - assert:
-    #         that:
-    #           - "'/sysroot' in result_remount_jounalctl.stdout"
-    #           - "'/var' in result_remount_jounalctl.stdout"
-    #         fail_msg: "/sysroot or /var are not remounted by ostree-remount"
-    #         success_msg: "/sysroot and /var are remount"
-    #   always:
-    #     - set_fact:
-    #         total_counter: "{{ total_counter | int + 1 }}"
-    #   rescue:
-    #     - name: failed count + 1
-    #       set_fact:
-    #         failed_counter: "{{ failed_counter | int + 1 }}"
-    #   when: (edge_type == "none") and ((ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '<')) or
-    #         ((ansible_facts['distribution'] == 'CentOS') and ansible_facts['distribution_version'] is version('9', '!=')) or (ansible_facts['distribution'] != 'RedHat'))
-
     # case: check dmesg error and failed log
     - name: check dmesg output
       command: dmesg


### PR DESCRIPTION
This pull request includes:

Since /sysroot is being mounted as ro and /var as rw, ostree-remount.service will not remount those mountpoints. The test is no longer necessary. 
Thus, this PR suggests to delete the task as a workaround for the reported Jira [edge-commit CS9 failure: ostree-remount.service fails to remount /sysroot and /var mountpoints](https://issues.redhat.com/browse/RHEL-25249)


- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
