### PR TITLE
tests/regression: Add config for v3 certificates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -246,16 +246,16 @@ Base:
 regression-composer-works-behind-satellite-fallback:
   extends: .regression
   rules:
-    # BLACKLIST: Skipped on subscribed RHEL machines
-    - if: $RUNNER !~ "/^.*(rhel-.*-ga|centos|fedora).*$/" && $RUNNER !~ "/^.*(rhel-9.5|rhel-10.0).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    # WHITELIST: Run on RHEL-nightly only
+    - if: $RUNNER =~ "/^.*(rhel-.*-nightly).*$/" && $CI_PIPELINE_SOURCE != "schedule"
   variables:
     SCRIPT: regression-composer-works-behind-satellite-fallback.sh
 
 regression-composer-works-behind-satellite:
   extends: .regression
   rules: 
-    # BLACKLIST: Skipped on subscribed RHEL machines
-    - if: $RUNNER !~ "/^.*(rhel-.*-ga|centos|fedora).*$/" && $RUNNER !~ "/^.*(rhel-9.5|rhel-10.0).*$/" && $CI_PIPELINE_SOURCE != "schedule"
+    # WHITELIST: Run on RHEL-nightly only
+    - if: $RUNNER =~ "/^.*(rhel-.*-nightly).*$/" && $CI_PIPELINE_SOURCE != "schedule"
   variables:
     SCRIPT: regression-composer-works-behind-satellite.sh
 

--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: composer

--- a/templates/openshift/maintenance.yml
+++ b/templates/openshift/maintenance.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: image-builder-maintenance

--- a/test/cases/regression-composer-works-behind-satellite-fallback.sh
+++ b/test/cases/regression-composer-works-behind-satellite-fallback.sh
@@ -12,17 +12,21 @@ function generate_certificates {
     sudo openssl genrsa -out ca.key
     # Create and self-sign root certificate
     sudo openssl req -new -subj "/C=GB/CN=ca" -addext "subjectAltName = DNS:localhost" -key ca.key -out ca.csr
-    sudo openssl x509 -req -sha256 -days 365 -in ca.csr -signkey ca.key -out ca.crt
+    # Create config for v3 certs
+    sudo tee v3_ca.cnf > /dev/null << EOF
+basicConstraints = CA:TRUE
+EOF
+    sudo openssl x509 -req -sha256 -days 365 -in ca.csr -signkey ca.key -out ca.crt -extfile v3_ca.cnf
     # Key for the server
     sudo openssl genrsa -out server.key
     # Certificate for the server
     sudo openssl req -new -subj "/C=GB/CN=localhost" -sha256 -key server.key -out server.csr
-    sudo openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -sha256
+    sudo openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 365 -sha256 -extfile v3_ca.cnf
     # Key for the client
     sudo openssl genrsa -out client.key
     # Certificate for the client
     sudo openssl req -new -subj "/C=GB/CN=localhost" -sha256 -key client.key -out client.csr
-    sudo openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -sha256
+    sudo openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 365 -sha256 -extfile v3_ca.cnf
 
     # add the certificate authority to the system trust stores
     sudo cp ca.crt "/etc/pki/ca-trust/source/anchors/ca-$(uuidgen).crt"
@@ -46,13 +50,6 @@ case "${ID}" in
         ;;
     "rhel")
         echo "Running on RHEL"
-
-        if [[ "$VERSION_ID" == "9.5" || "$VERSION_ID" == "10.0" ]]; then
-            # fails eventhough we call update-ca-trust, see previous commit
-            echo "This test has been disabled b/c DNF fails with self-signed certificates"
-            exit 1
-        fi
-
         case "${VERSION_ID%.*}" in
             "8" | "9" | "10")
                 echo "Running on RHEL ${VERSION_ID}"


### PR DESCRIPTION
When generating x509 v3 certs we need to explicitely set "CA:TRUE" otherwise they're not trusted to be used.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
