### PR TITLE
internal/worker/server: return an error on depsolve timeout (HMS-2989)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       run: sudo apt-get update
       # gpgme-devel is needed for container upload dependencies
     - name: Install test dependencies
-      run: sudo apt-get install -y libgpgme-dev
+      run: sudo apt-get install -y libgpgme-dev libbtrfs-dev
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ push-check: lint build unit-tests srpm man
 	./tools/check-runners
 	./tools/check-snapshots --errors-only .
 	rpmlint --config rpmlint.config $(CURDIR)/rpmbuild/SRPMS/*
-	./tools/prepare-source.sh
 	@if [ 0 -ne $$(git status --porcelain --untracked-files|wc -l) ]; then \
 	    echo "There should be no changed or untracked files"; \
 	    git status --porcelain --untracked-files; \
@@ -350,6 +349,7 @@ SHELLCHECK_FILES=$(shell find . -name "*.sh" -not -regex "./vendor/.*")
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT_CACHE_DIR) container_composer_golangci_built.info
+	./tools/prepare-source.sh
 	podman run -t --rm -v $(SRCDIR):/app:z -v $(GOLANGCI_LINT_CACHE_DIR):/root/.cache:z -w /app $(GOLANGCI_COMPOSER_IMAGE) golangci-lint run -v
 	echo "$(SHELLCHECK_FILES)" | xargs shellcheck --shell bash -e SC1091 -e SC2002 -e SC2317
 

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -264,7 +264,7 @@ func (s *Server) enqueueCompose(irs []imageRequest, channel string) (uuid.UUID, 
 
 	s.goroutinesGroup.Add(1)
 	go func() {
-		serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, id, ir.manifestSeed)
+		serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
 		defer s.goroutinesGroup.Done()
 	}()
 
@@ -424,7 +424,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 		// copy the image request while passing it into the goroutine to prevent data races
 		s.goroutinesGroup.Add(1)
 		go func(ir imageRequest) {
-			serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, buildID, ir.manifestSeed)
+			serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
 			defer s.goroutinesGroup.Done()
 		}(ir)
 	}
@@ -445,7 +445,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 	return id, nil
 }
 
-func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, osbuildJobID uuid.UUID, seed int64) {
+func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID uuid.UUID, seed int64) {
 	// prepared to become a config variable
 	const depsolveTimeout = 5
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*depsolveTimeout)
@@ -468,12 +468,12 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 		if token == uuid.Nil {
 			if jobResult.JobError != nil {
 				// set all jobs to "failed"
+				// osbuild job will fail as dependency
 				jobs := map[string]uuid.UUID{
 					"depsolve":         depsolveJobID,
 					"containerResolve": containerResolveJobID,
 					"ostreeResolve":    ostreeResolveJobID,
 					"manifest":         manifestJobID,
-					"osbuild":          osbuildJobID,
 				}
 
 				for jobName, jobID := range jobs {

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -519,8 +519,7 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 
 				jobResult.JobError = clienterrors.New(clienterrors.ErrorDepsolveTimeout,
 					"Timeout while waiting for package dependency resolution",
-					"There may be a temporary issue with compute resources. "+
-						"We’re looking into it, please try again later.",
+					"There may be a temporary issue with compute resources.",
 				)
 				break
 			default:

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -469,18 +469,21 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 			if jobResult.JobError != nil {
 				// set all jobs to "failed"
 				// osbuild job will fail as dependency
-				jobs := map[string]uuid.UUID{
-					"depsolve":         depsolveJobID,
-					"containerResolve": containerResolveJobID,
-					"ostreeResolve":    ostreeResolveJobID,
-					"manifest":         manifestJobID,
+				jobs := []struct {
+					Name string
+					ID   uuid.UUID
+				}{
+					{"depsolve", depsolveJobID},
+					{"containerResolve", containerResolveJobID},
+					{"ostreeResolve", ostreeResolveJobID},
+					{"manifest", manifestJobID},
 				}
 
-				for jobName, jobID := range jobs {
-					if jobID != uuid.Nil {
-						err := workers.SetFailed(jobID, jobResult.JobError)
+				for _, job := range jobs {
+					if job.ID != uuid.Nil {
+						err := workers.SetFailed(job.ID, jobResult.JobError)
 						if err != nil {
-							logWithId.Errorf("Error failing %s job: %v", jobName, err)
+							logWithId.Errorf("Error failing %s job: %v", job.Name, err)
 						}
 					}
 				}

--- a/internal/jobqueue/jobqueuetest/jobqueuetest.go
+++ b/internal/jobqueue/jobqueuetest/jobqueuetest.go
@@ -776,18 +776,15 @@ func testFail(t *testing.T, q jobqueue.JobQueue) {
 		),
 	}
 
-	testReason, err := json.Marshal(FailedJobErrorResult)
-	require.NoError(t, err)
-
 	// set a non-existing job to failed
-	err = q.FailJob(uuid.New(), testReason)
+	err := q.FailJob(uuid.New(), FailedJobErrorResult)
 	require.Error(t, err)
 
 	// Cancel a pending job
 	id := pushTestJob(t, q, "coralreef", nil, nil, "testchannel")
 	require.NotEmpty(t, id)
 
-	err = q.FailJob(id, testReason)
+	err = q.FailJob(id, FailedJobErrorResult)
 	require.NoError(t, err)
 
 	//nolint:golint,ineffassign
@@ -798,9 +795,10 @@ func testFail(t *testing.T, q jobqueue.JobQueue) {
 	type JobResult struct {
 		JobError *clienterrors.Error `json:"job_error"`
 	}
+
 	var r1 JobResult
 	err = json.Unmarshal(result, &r1)
-	require.NoError(t, err)
+	require.NoError(t, err, fmt.Sprintf("Error %v when trying to unmarshal %v", err, string(result)))
 
 	require.NotNil(t, r1)
 	require.Equal(t, "Test timeout reason", r1.JobError.Reason)

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -44,6 +44,7 @@ const (
 	ErrorJobPanicked          ClientErrorCode = 37
 	ErrorGeneratingSignedURL  ClientErrorCode = 38
 	ErrorInvalidRepositoryURL ClientErrorCode = 39
+	ErrorDepsolveTimeout      ClientErrorCode = 40
 )
 
 type ClientErrorCode int

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -566,6 +566,20 @@ func (s *Server) Cancel(id uuid.UUID) error {
 	return s.jobs.CancelJob(id)
 }
 
+// SetFailed sets the given job id to "failed" with the given error
+func (s *Server) SetFailed(id uuid.UUID, error *clienterrors.Error) error {
+	FailedJobErrorResult := JobResult{
+		JobError: error,
+	}
+
+	res, err := json.Marshal(FailedJobErrorResult)
+	if err != nil {
+		logrus.Errorf("error marshalling the error: %v", err)
+		return nil
+	}
+	return s.jobs.FailJob(id, res)
+}
+
 // Provides access to artifacts of a job. Returns an io.Reader for the artifact
 // and the artifact's size.
 func (s *Server) JobArtifact(id uuid.UUID, name string) (io.Reader, int64, error) {

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -59,6 +59,9 @@ type JobQueue interface {
 	// Cancel a job. Does nothing if the job has already finished.
 	CancelJob(id uuid.UUID) error
 
+	// Fail a job that didn't even start (e.g. no worker available)
+	FailJob(id uuid.UUID, result interface{}) error
+
 	// If the job has finished, returns the result as raw JSON.
 	//
 	// Returns the current status of the job, in the form of three times:
@@ -114,6 +117,8 @@ var (
 	ErrDequeueTimeout = errors.New("dequeue context timed out or was canceled")
 	ErrActiveJobs     = errors.New("worker has active jobs associated with it")
 	ErrWorkerNotExist = errors.New("worker does not exist")
+	ErrRunning        = errors.New("job is running, but wasn't expected to be")
+	ErrFinished       = errors.New("job is finished, but wasn't expected to be")
 )
 
 type Worker struct {


### PR DESCRIPTION
Fixes the special case that if no worker is available and we generate an internal timeout and cancel the depsolve, including all followup jobs, no error was propagated.

For details, see https://issues.redhat.com/browse/HMS-2989

Now all jobs (in the DB) are set to "failed":
 * All `jobs` entries get a "job_error" in the `result` as well as
 * `started_at` and `failed_at` are set to "now" and
 * `token` is set to a random UUID to comply with the DB schema

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [x] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

This is set to draft for now until:
* I get feedback that this approach is ok
* tests are implemented
* we decided on if we should "create a separate metrics" (see comment in the code)