### PR TITLE
osbuild-worker: use the new ostree resolver API

### DIFF
--- a/cmd/osbuild-koji-tests/main_test.go
+++ b/cmd/osbuild-koji-tests/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 )
@@ -182,7 +182,7 @@ func TestKojiImport(t *testing.T) {
 			Extra: &koji.BuildOutputExtra{
 				ImageOutput: koji.ImageExtraInfo{
 					Arch:     "noarch",
-					BootMode: distro.BOOT_LEGACY.String(),
+					BootMode: platform.BOOT_LEGACY.String(),
 				},
 			},
 		},

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
 	"github.com/sirupsen/logrus"
@@ -101,7 +101,7 @@ func main() {
 			Extra: &koji.BuildOutputExtra{
 				ImageOutput: koji.ImageExtraInfo{
 					Arch:     arch,
-					BootMode: distro.BOOT_NONE.String(), // TODO: put the correct boot mode here
+					BootMode: platform.BOOT_NONE.String(), // TODO: put the correct boot mode here
 				},
 			},
 		},

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -516,14 +516,19 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		}
 	}
 
+	// Both curl and ostree input share the same MTLS config
 	if impl.RepositoryMTLSConfig != nil {
 		if impl.RepositoryMTLSConfig.CA != "" {
 			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CA_CERT=%s", impl.RepositoryMTLSConfig.CA))
+			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_OSTREE_SSL_CA_CERT=%s", impl.RepositoryMTLSConfig.CA))
 		}
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_KEY=%s", impl.RepositoryMTLSConfig.MTLSClientKey))
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT=%s", impl.RepositoryMTLSConfig.MTLSClientCert))
+		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_OSTREE_SSL_CLIENT_KEY=%s", impl.RepositoryMTLSConfig.MTLSClientKey))
+		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_OSTREE_SSL_CLIENT_CERT=%s", impl.RepositoryMTLSConfig.MTLSClientCert))
 		if impl.RepositoryMTLSConfig.Proxy != nil {
 			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_PROXY=%s", impl.RepositoryMTLSConfig.Proxy.String()))
+			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_OSTREE_PROXY=%s", impl.RepositoryMTLSConfig.Proxy.String()))
 		}
 	}
 

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	slogger "github.com/osbuild/osbuild-composer/pkg/splunk_logger"
 	"net/url"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	slogger "github.com/osbuild/osbuild-composer/pkg/splunk_logger"
 
 	"github.com/BurntSushi/toml"
 	"github.com/sirupsen/logrus"
@@ -508,8 +509,10 @@ func main() {
 		worker.JobTypeContainerResolve: &ContainerResolveJobImpl{
 			AuthFilePath: containersAuthFilePath,
 		},
-		worker.JobTypeOSTreeResolve: &OSTreeResolveJobImpl{},
-		worker.JobTypeFileResolve:   &FileResolveJobImpl{},
+		worker.JobTypeOSTreeResolve: &OSTreeResolveJobImpl{
+			RepositoryMTLSConfig: repositoryMTLSConfig,
+		},
+		worker.JobTypeFileResolve: &FileResolveJobImpl{},
 		worker.JobTypeAWSEC2Copy: &AWSEC2CopyJobImpl{
 			AWSCreds: awsCredentials,
 		},

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.95.0
+	github.com/osbuild/images v0.96.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.438 h1:tsLCCUzbLCTL4RZG02y9RuopmGCXp
 github.com/openshift-online/ocm-sdk-go v0.1.438/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.95.0 h1:WWxYEQKD9wFGs/zkWF4wd3IDwNColZwzKsQh/+dwvUw=
-github.com/osbuild/images v0.95.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.96.0 h1:ZieK4i5pyKTdLaA/EwxeNEQsWBLEkX3FsZVyIaYCJKI=
+github.com/osbuild/images v0.96.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/internal/cloudapi/v2/imagerequest.go
+++ b/internal/cloudapi/v2/imagerequest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/cloud/gcp"
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -56,11 +57,11 @@ func newAWSTarget(options UploadOptions, imageType distro.ImageType) (*target.Ta
 
 	var amiBootMode *string
 	switch imageType.BootMode() {
-	case distro.BOOT_HYBRID:
+	case platform.BOOT_HYBRID:
 		amiBootMode = common.ToPtr(string(ec2types.BootModeValuesUefiPreferred))
-	case distro.BOOT_UEFI:
+	case platform.BOOT_UEFI:
 		amiBootMode = common.ToPtr(string(ec2types.BootModeValuesUefi))
-	case distro.BOOT_LEGACY:
+	case platform.BOOT_LEGACY:
 		amiBootMode = common.ToPtr(string(ec2types.BootModeValuesLegacyBios))
 	}
 

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -228,7 +228,12 @@ func (s *Server) enqueueCompose(irs []imageRequest, channel string) (uuid.UUID, 
 		workerResolveSpecs := make([]worker.OSTreeResolveSpec, len(sources))
 		for idx, source := range sources {
 			// ostree.SourceSpec is directly convertible to worker.OSTreeResolveSpec
-			workerResolveSpecs[idx] = worker.OSTreeResolveSpec(source)
+			workerResolveSpecs[idx] = worker.OSTreeResolveSpec{
+				URL:  source.URL,
+				Ref:  source.Ref,
+				RHSM: source.RHSM,
+			}
+
 		}
 		jobID, err := s.workers.EnqueueOSTreeResolveJob(&worker.OSTreeResolveJob{Specs: workerResolveSpecs}, channel)
 		if err != nil {
@@ -356,7 +361,11 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 			workerResolveSpecs := make([]worker.OSTreeResolveSpec, len(sources))
 			for idx, source := range sources {
 				// ostree.SourceSpec is directly convertible to worker.OSTreeResolveSpec
-				workerResolveSpecs[idx] = worker.OSTreeResolveSpec(source)
+				workerResolveSpecs[idx] = worker.OSTreeResolveSpec{
+					URL:  source.URL,
+					Ref:  source.Ref,
+					RHSM: source.RHSM,
+				}
 			}
 			jobID, err := s.workers.EnqueueOSTreeResolveJob(&worker.OSTreeResolveJob{Specs: workerResolveSpecs}, channel)
 			if err != nil {

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2393,6 +2393,7 @@ func (api *API) resolveOSTreeCommits(sourceSpecs map[string][]ostree.SourceSpec,
 					Checksum: checksum,
 				}
 			} else {
+				// MTLS not supported on-prem
 				commit, err := ostree.Resolve(source)
 				if err != nil {
 					return nil, err

--- a/internal/weldr/upload.go
+++ b/internal/weldr/upload.go
@@ -10,6 +10,7 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/osbuild-composer/internal/cloud/gcp"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/sirupsen/logrus"
@@ -283,11 +284,11 @@ func uploadRequestToTarget(u uploadRequest, imageType distro.ImageType) *target.
 
 		var amiBootMode *string
 		switch imageType.BootMode() {
-		case distro.BOOT_HYBRID:
+		case platform.BOOT_HYBRID:
 			amiBootMode = common.ToPtr(string(ec2types.BootModeValuesUefiPreferred))
-		case distro.BOOT_UEFI:
+		case platform.BOOT_UEFI:
 			amiBootMode = common.ToPtr(string(ec2types.BootModeValuesUefi))
-		case distro.BOOT_LEGACY:
+		case platform.BOOT_LEGACY:
 			amiBootMode = common.ToPtr(string(ec2types.BootModeValuesLegacyBios))
 		}
 

--- a/vendor/github.com/osbuild/images/pkg/disk/partition_table.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/partition_table.go
@@ -715,7 +715,7 @@ func (pt *PartitionTable) ensureLVM() error {
 
 		// create root logical volume on the new volume group with the same
 		// size and filesystem as the previous root partition
-		_, err := vg.CreateLogicalVolume("root", part.Size, filesystem)
+		_, err := vg.CreateLogicalVolume("rootlv", part.Size, filesystem)
 		if err != nil {
 			panic(fmt.Sprintf("Could not create LV: %v", err))
 		}

--- a/vendor/github.com/osbuild/images/pkg/distro/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/distro.go
@@ -6,35 +6,15 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rhsm/facts"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-type BootMode uint64
-
 const (
-	BOOT_NONE BootMode = iota
-	BOOT_LEGACY
-	BOOT_UEFI
-	BOOT_HYBRID
 	UnsupportedCustomizationError = "unsupported blueprint customizations found for image type %q: (allowed: %s)"
 	NoCustomizationsAllowedError  = "image type %q does not support customizations"
 )
-
-func (m BootMode) String() string {
-	switch m {
-	case BOOT_NONE:
-		return "none"
-	case BOOT_LEGACY:
-		return "legacy"
-	case BOOT_UEFI:
-		return "uefi"
-	case BOOT_HYBRID:
-		return "hybrid"
-	default:
-		panic("invalid boot mode")
-	}
-}
 
 // A Distro represents composer's notion of what a given distribution is.
 type Distro interface {
@@ -121,7 +101,7 @@ type ImageType interface {
 	PartitionType() string
 
 	// Returns the corresponding boot mode ("legacy", "uefi", "hybrid") or "none"
-	BootMode() BootMode
+	BootMode() platform.BootMode
 
 	// Returns the names of the pipelines that set up the build environment (buildroot).
 	BuildPipelines() []string

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/imagetype.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/imagetype.go
@@ -126,15 +126,15 @@ func (t *imageType) Exports() []string {
 	return []string{"assembler"}
 }
 
-func (t *imageType) BootMode() distro.BootMode {
+func (t *imageType) BootMode() platform.BootMode {
 	if t.platform.GetUEFIVendor() != "" && t.platform.GetBIOSPlatform() != "" {
-		return distro.BOOT_HYBRID
+		return platform.BOOT_HYBRID
 	} else if t.platform.GetUEFIVendor() != "" {
-		return distro.BOOT_UEFI
+		return platform.BOOT_UEFI
 	} else if t.platform.GetBIOSPlatform() != "" || t.platform.GetZiplSupport() {
-		return distro.BOOT_LEGACY
+		return platform.BOOT_LEGACY
 	}
-	return distro.BOOT_NONE
+	return platform.BOOT_NONE
 }
 
 func (t *imageType) getPartitionTable(

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/imagetype.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/imagetype.go
@@ -168,15 +168,15 @@ func (t *ImageType) Exports() []string {
 	return []string{"assembler"}
 }
 
-func (t *ImageType) BootMode() distro.BootMode {
+func (t *ImageType) BootMode() platform.BootMode {
 	if t.platform.GetUEFIVendor() != "" && t.platform.GetBIOSPlatform() != "" {
-		return distro.BOOT_HYBRID
+		return platform.BOOT_HYBRID
 	} else if t.platform.GetUEFIVendor() != "" {
-		return distro.BOOT_UEFI
+		return platform.BOOT_UEFI
 	} else if t.platform.GetBIOSPlatform() != "" || t.platform.GetZiplSupport() {
-		return distro.BOOT_LEGACY
+		return platform.BOOT_LEGACY
 	}
-	return distro.BOOT_NONE
+	return platform.BOOT_NONE
 }
 
 func (t *ImageType) GetPartitionTable(

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/azure.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/azure.go
@@ -529,7 +529,6 @@ var defaultAzureImageConfig = &distro.ImageConfig{
 		"nm-cloud-setup.service",
 		"nm-cloud-setup.timer",
 		"sshd",
-		"systemd-resolved",
 		"waagent",
 	},
 	SshdConfig: &osbuild.SshdConfigStageOptions{

--- a/vendor/github.com/osbuild/images/pkg/distro/test_distro/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/test_distro/distro.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
+	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/policies"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -210,8 +211,8 @@ func (t *TestImageType) PartitionType() string {
 	return ""
 }
 
-func (t *TestImageType) BootMode() distro.BootMode {
-	return distro.BOOT_HYBRID
+func (t *TestImageType) BootMode() platform.BootMode {
+	return platform.BOOT_HYBRID
 }
 
 func (t *TestImageType) BuildPipelines() []string {

--- a/vendor/github.com/osbuild/images/pkg/image/bootc_disk.go
+++ b/vendor/github.com/osbuild/images/pkg/image/bootc_disk.go
@@ -3,9 +3,7 @@ package image
 import (
 	"fmt"
 	"math/rand"
-	"regexp"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
@@ -92,15 +90,7 @@ func (img *BootcDiskImage) InstantiateManifestFromContainers(m *manifest.Manifes
 		fmt.Sprintf("%s.vhd", fileBasename),
 	}
 
-	// XXX: copied from https://github.com/osbuild/images/blob/v0.85.0/pkg/image/disk.go#L102
-	gcePipeline := manifest.NewTar(buildPipeline, rawImage, "gce")
-	gcePipeline.Format = osbuild.TarArchiveFormatOldgnu
-	gcePipeline.RootNode = osbuild.TarRootNodeOmit
-	// these are required to successfully import the image to GCP
-	gcePipeline.ACLs = common.ToPtr(false)
-	gcePipeline.SELinux = common.ToPtr(false)
-	gcePipeline.Xattrs = common.ToPtr(false)
-	gcePipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(rawImage.Filename()))
+	gcePipeline := newGCETarPipelineForImg(buildPipeline, rawImage, "gce")
 	gcePipeline.SetFilename("image.tar.gz")
 
 	return nil

--- a/vendor/github.com/osbuild/images/pkg/image/disk.go
+++ b/vendor/github.com/osbuild/images/pkg/image/disk.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/internal/environment"
 	"github.com/osbuild/images/internal/workload"
 	"github.com/osbuild/images/pkg/artifact"
@@ -103,13 +102,7 @@ func (img *DiskImage) InstantiateManifest(m *manifest.Manifest,
 		// NOTE(akoutsou): temporary workaround; filename required for GCP
 		// TODO: define internal raw filename on image type
 		rawImagePipeline.SetFilename("disk.raw")
-		tarPipeline := manifest.NewTar(buildPipeline, rawImagePipeline, "archive")
-		tarPipeline.Format = osbuild.TarArchiveFormatOldgnu
-		tarPipeline.RootNode = osbuild.TarRootNodeOmit
-		// these are required to successfully import the image to GCP
-		tarPipeline.ACLs = common.ToPtr(false)
-		tarPipeline.SELinux = common.ToPtr(false)
-		tarPipeline.Xattrs = common.ToPtr(false)
+		tarPipeline := newGCETarPipelineForImg(buildPipeline, rawImagePipeline, "archive")
 		tarPipeline.SetFilename(img.Filename) // filename extension will determine compression
 		imagePipeline = tarPipeline
 	default:

--- a/vendor/github.com/osbuild/images/pkg/image/gce.go
+++ b/vendor/github.com/osbuild/images/pkg/image/gce.go
@@ -1,0 +1,24 @@
+package image
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/images/pkg/osbuild"
+)
+
+func newGCETarPipelineForImg(buildPipeline manifest.Build, inputPipeline manifest.FilePipeline, pipelinename string) *manifest.Tar {
+	tarPipeline := manifest.NewTar(buildPipeline, inputPipeline, pipelinename)
+	tarPipeline.Format = osbuild.TarArchiveFormatOldgnu
+	tarPipeline.RootNode = osbuild.TarRootNodeOmit
+	// these are required to successfully import the image to GCP
+	tarPipeline.ACLs = common.ToPtr(false)
+	tarPipeline.SELinux = common.ToPtr(false)
+	tarPipeline.Xattrs = common.ToPtr(false)
+	if inputPipeline.Filename() != "disk.raw" {
+		tarPipeline.Transform = fmt.Sprintf(`s/%s/disk.raw/`, regexp.QuoteMeta(inputPipeline.Filename()))
+	}
+	return tarPipeline
+}

--- a/vendor/github.com/osbuild/images/pkg/manifest/build.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/build.go
@@ -236,7 +236,9 @@ func (p *BuildrootFromContainer) serialize() osbuild.Pipeline {
 	pipeline.Runner = p.runner.String()
 
 	image := osbuild.NewContainersInputForSingleSource(p.containerSpecs[0])
-	stage, err := osbuild.NewContainerDeployStage(image, &osbuild.ContainerDeployOptions{})
+	// Make skopeo copy to remove the signatures of signed containers by default to workaround
+	// build failures until https://github.com/containers/image/issues/2599 is implemented
+	stage, err := osbuild.NewContainerDeployStage(image, &osbuild.ContainerDeployOptions{RemoveSignatures: true})
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/container_deploy_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/container_deploy_stage.go
@@ -9,7 +9,8 @@ type ContainerDeployInputs struct {
 func (ContainerDeployInputs) isStageInputs() {}
 
 type ContainerDeployOptions struct {
-	Exclude []string `json:"exclude,omitempty"`
+	Exclude          []string `json:"exclude,omitempty"`
+	RemoveSignatures bool     `json:"remove-signatures,omitempty"`
 }
 
 func (ContainerDeployOptions) isStageOptions() {}

--- a/vendor/github.com/osbuild/images/pkg/platform/bootmode.go
+++ b/vendor/github.com/osbuild/images/pkg/platform/bootmode.go
@@ -1,0 +1,25 @@
+package platform
+
+type BootMode uint64
+
+const (
+	BOOT_NONE BootMode = iota
+	BOOT_LEGACY
+	BOOT_UEFI
+	BOOT_HYBRID
+)
+
+func (m BootMode) String() string {
+	switch m {
+	case BOOT_NONE:
+		return "none"
+	case BOOT_LEGACY:
+		return "legacy"
+	case BOOT_UEFI:
+		return "uefi"
+	case BOOT_HYBRID:
+		return "hybrid"
+	default:
+		panic("invalid boot mode")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1022,7 +1022,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.95.0
+# github.com/osbuild/images v0.96.0
 ## explicit; go 1.21.0
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
For Edge Pulp migration we need the very same thing as repositories (curl) but for ostree input.