### PR TITLE
cloud/awscloud: retry CreateFleet regardless of the error code

### DIFF
--- a/internal/cloud/awscloud/secure-instance_test.go
+++ b/internal/cloud/awscloud/secure-instance_test.go
@@ -142,7 +142,7 @@ func TestSICreateFleetFailures(t *testing.T) {
 	aws := awscloud.NewForTest(m, &ec2imdsmock{t, "instance-id", "region1"}, nil, nil, nil)
 	require.NotNil(t, aws)
 
-	// unfillable capacity should call create fleet thrice
+	// create fleet error should call create fleet thrice
 	m.failFn["CreateFleet"] = nil
 	si, err := aws.RunSecureInstance("iam-profile", "key-name", "cw-group", "hostname")
 	require.Error(t, err)


### PR DESCRIPTION
The errors returned by create fleet are not entirely clear. It seems it also returns `InsufficientInstanceCapacity` in addition to `UnfulfillableCapacity`. Let's just retry three times regardless of the create fleet error, that way there's no need to chase error codes which aren't clearly defined.
