### PR TITLE
packer: don't deregister old AMIs (COMPOSER-2376)

### DIFF
--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -4,10 +4,6 @@ source "amazon-ebs" "image_builder" {
   secret_key = var.aws_secret_key
   region = var.region
 
-  # Remove previous image before making the new one.
-  force_deregister = true
-  force_delete_snapshot = true
-
   # Apply tags to the instance that is building our image.
   run_tags = {
     AppCode = "IMGB-001"


### PR DESCRIPTION
Imagine this scenario: the packer job is ran, an AMI gets created.
We configure our deployment to use this AMI. Then, someone retries the
packer job. Since we have force_deregister=true, this will not only
create a new AMI, but also remove the old one (because it has the same
name). Thus, our deployment will get broken, because the source AMI
no longer exists. This means that the ASG cannot replace any broken
instances, and the secure instance feature gets absolutely broken
because it cannot spawn new secure instances (they "inherit" the AMI
ID from their parents).

Let's remove force_deregister=true, so the AMI never gets replaced.
This might cause some pipelines to start failing because they are
rerunning the packer job for same commit (the GA pipeline currently).
Let's fix those then, rerunning the packer job is just confusing.

If this causes some unexpected issues, we can always resort to using
unique AMI names (by appending a timestamp to their name), but having
multiple AMIs with different names, but same tags will cause our
terraform configuration to be reapplied everytime there's a rerun,
which is also not great.