### PR TITLE
Remove leftover secure instances in service maintenance

### DIFF
--- a/cmd/osbuild-service-maintenance/aws_test.go
+++ b/cmd/osbuild-service-maintenance/aws_test.go
@@ -1,0 +1,52 @@
+package main_test
+
+import (
+	"testing"
+	"time"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/require"
+
+	main "github.com/osbuild/osbuild-composer/cmd/osbuild-service-maintenance"
+	"github.com/osbuild/osbuild-composer/internal/common"
+)
+
+func TestFilterReservations(t *testing.T) {
+	reservations := []ec2types.Reservation{
+		{
+			Instances: []ec2types.Instance{
+				{
+					LaunchTime: common.ToPtr(time.Now().Add(-time.Hour * 24)),
+					InstanceId: common.ToPtr("not filtered"),
+				},
+			},
+		},
+		{
+			Instances: []ec2types.Instance{
+				{
+					LaunchTime: common.ToPtr(time.Now().Add(-time.Minute * 121)),
+					InstanceId: common.ToPtr("not filtered"),
+				},
+			},
+		},
+		{
+			Instances: []ec2types.Instance{
+				{
+					LaunchTime: common.ToPtr(time.Now().Add(-time.Minute * 119)),
+					InstanceId: common.ToPtr("filtered"),
+				},
+			},
+		},
+		{
+			Instances: []ec2types.Instance{
+				{
+					LaunchTime: common.ToPtr(time.Now()),
+					InstanceId: common.ToPtr("filtered"),
+				},
+			},
+		},
+	}
+
+	instanceIDs := main.FilterReservations(reservations)
+	require.Equal(t, []string{"not filtered", "not filtered"}, instanceIDs)
+}

--- a/cmd/osbuild-service-maintenance/export_test.go
+++ b/cmd/osbuild-service-maintenance/export_test.go
@@ -1,0 +1,3 @@
+package main
+
+var FilterReservations = filterReservations

--- a/internal/cloud/awscloud/awscloud_test.go
+++ b/internal/cloud/awscloud/awscloud_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/cloud/awscloud"
@@ -76,27 +75,6 @@ func TestEC2CopyImage(t *testing.T) {
 	require.Equal(t, 1, m.calledFn["CopyImage"])
 	// 1 snapshot, 1 image
 	require.Equal(t, 2, m.calledFn["CreateTags"])
-}
-
-func TestEC2RemoveSnapshotAndDeregisterImage(t *testing.T) {
-	m := newEc2Mock(t)
-	aws := awscloud.NewForTest(m, nil, &s3mock{t, "bucket", "object-key"}, nil, nil)
-	require.NotNil(t, aws)
-
-	err := aws.RemoveSnapshotAndDeregisterImage(&ec2types.Image{
-		ImageId: &m.imageId,
-		State:   ec2types.ImageStateAvailable,
-		BlockDeviceMappings: []ec2types.BlockDeviceMapping{
-			{
-				Ebs: &ec2types.EbsBlockDevice{
-					SnapshotId: &m.snapshotId,
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	require.Equal(t, 1, m.calledFn["DeleteSnapshot"])
-	require.Equal(t, 1, m.calledFn["DeregisterImage"])
 }
 
 func TestEC2Regions(t *testing.T) {

--- a/internal/cloud/awscloud/maintenance.go
+++ b/internal/cloud/awscloud/maintenance.go
@@ -1,0 +1,64 @@
+package awscloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/sirupsen/logrus"
+)
+
+// For service maintenance images are discovered by the "Name:composer-api-*" tag filter. Currently
+// all image names in the service are generated, so they're guaranteed to be unique as well. If
+// users are ever allowed to name their images, an extra tag should be added.
+func (a *AWS) DescribeImagesByTag(tagKey, tagValue string) ([]ec2types.Image, error) {
+	imgs, err := a.ec2.DescribeImages(
+		context.Background(),
+		&ec2.DescribeImagesInput{
+			Filters: []ec2types.Filter{
+				{
+					Name:   aws.String(fmt.Sprintf("tag:%s", tagKey)),
+					Values: []string{tagValue},
+				},
+			},
+		},
+	)
+	return imgs.Images, err
+}
+
+func (a *AWS) RemoveSnapshotAndDeregisterImage(image *ec2types.Image) error {
+	if image == nil {
+		return fmt.Errorf("image is nil")
+	}
+
+	var snapshots []*string
+	for _, bdm := range image.BlockDeviceMappings {
+		snapshots = append(snapshots, bdm.Ebs.SnapshotId)
+	}
+
+	_, err := a.ec2.DeregisterImage(
+		context.Background(),
+		&ec2.DeregisterImageInput{
+			ImageId: image.ImageId,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range snapshots {
+		_, err = a.ec2.DeleteSnapshot(
+			context.Background(),
+			&ec2.DeleteSnapshotInput{
+				SnapshotId: s,
+			},
+		)
+		if err != nil {
+			// TODO return err?
+			logrus.Warn("Unable to remove snapshot", s)
+		}
+	}
+	return err
+}

--- a/internal/cloud/awscloud/maintenance.go
+++ b/internal/cloud/awscloud/maintenance.go
@@ -62,3 +62,28 @@ func (a *AWS) RemoveSnapshotAndDeregisterImage(image *ec2types.Image) error {
 	}
 	return err
 }
+
+func (a *AWS) DescribeInstancesByTag(tagKey, tagValue string) ([]ec2types.Reservation, error) {
+	res, err := a.ec2.DescribeInstances(
+		context.Background(),
+		&ec2.DescribeInstancesInput{
+			Filters: []ec2types.Filter{
+				{
+					Name:   aws.String(fmt.Sprintf("tag:%s", tagKey)),
+					Values: []string{tagValue},
+				},
+			},
+		},
+	)
+	return res.Reservations, err
+}
+
+func (a *AWS) TerminateInstances(instanceIDs []string) error {
+	_, err := a.ec2.TerminateInstances(
+		context.Background(),
+		&ec2.TerminateInstancesInput{
+			InstanceIds: instanceIDs,
+		},
+	)
+	return err
+}

--- a/internal/cloud/awscloud/maintenance_test.go
+++ b/internal/cloud/awscloud/maintenance_test.go
@@ -1,0 +1,31 @@
+package awscloud_test
+
+import (
+	"testing"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/osbuild-composer/internal/cloud/awscloud"
+)
+
+func TestEC2RemoveSnapshotAndDeregisterImage(t *testing.T) {
+	m := newEc2Mock(t)
+	aws := awscloud.NewForTest(m, nil, &s3mock{t, "bucket", "object-key"}, nil, nil)
+	require.NotNil(t, aws)
+
+	err := aws.RemoveSnapshotAndDeregisterImage(&ec2types.Image{
+		ImageId: &m.imageId,
+		State:   ec2types.ImageStateAvailable,
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{
+			{
+				Ebs: &ec2types.EbsBlockDevice{
+					SnapshotId: &m.snapshotId,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, m.calledFn["DeleteSnapshot"])
+	require.Equal(t, 1, m.calledFn["DeregisterImage"])
+}


### PR DESCRIPTION
Now and then there are leftover secure instances, probably when worker instances get terminated during builds, this is possible in ASGs. 2 hours as a cutoff should be enough, since the build times out after 60 minutes, and fetching the output archive after 30 minutes, so that leaves 30 minutes for booting and connection.
