### PR TITLE
Enable the anaconda modules customization

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -355,6 +355,12 @@ func Convert(bp Blueprint) iblueprint.Blueprint {
 					Contents: installer.Kickstart.Contents,
 				}
 			}
+			if installer.Modules != nil {
+				iinst.Modules = &iblueprint.AnacondaModules{
+					Enable:  installer.Modules.Enable,
+					Disable: installer.Modules.Disable,
+				}
+			}
 			customizations.Installer = &iinst
 		}
 		if rpm := c.RPM; rpm != nil && rpm.ImportKeys != nil {

--- a/internal/blueprint/blueprint_convert_test.go
+++ b/internal/blueprint/blueprint_convert_test.go
@@ -173,6 +173,9 @@ func TestConvert(t *testing.T) {
 					Installer: &InstallerCustomization{
 						Unattended:   true,
 						SudoNopasswd: []string{"%group", "user"},
+						Kickstart: &Kickstart{
+							Contents: "# test kickstart addition created by osbuild-composer",
+						},
 						Modules: &AnacondaModules{
 							Enable: []string{
 								"org.fedoraproject.Anaconda.Modules.Localization",
@@ -360,6 +363,9 @@ func TestConvert(t *testing.T) {
 					Installer: &iblueprint.InstallerCustomization{
 						Unattended:   true,
 						SudoNopasswd: []string{"%group", "user"},
+						Kickstart: &iblueprint.Kickstart{
+							Contents: "# test kickstart addition created by osbuild-composer",
+						},
 						Modules: &iblueprint.AnacondaModules{
 							Enable: []string{
 								"org.fedoraproject.Anaconda.Modules.Localization",

--- a/internal/blueprint/blueprint_convert_test.go
+++ b/internal/blueprint/blueprint_convert_test.go
@@ -173,6 +173,15 @@ func TestConvert(t *testing.T) {
 					Installer: &InstallerCustomization{
 						Unattended:   true,
 						SudoNopasswd: []string{"%group", "user"},
+						Modules: &AnacondaModules{
+							Enable: []string{
+								"org.fedoraproject.Anaconda.Modules.Localization",
+								"org.fedoraproject.Anaconda.Modules.Users",
+							},
+							Disable: []string{
+								"org.fedoraproject.Anaconda.Modules.Network",
+							},
+						},
 					},
 					RPM: &RPMCustomization{
 						ImportKeys: &RPMImportKeys{
@@ -351,6 +360,15 @@ func TestConvert(t *testing.T) {
 					Installer: &iblueprint.InstallerCustomization{
 						Unattended:   true,
 						SudoNopasswd: []string{"%group", "user"},
+						Modules: &iblueprint.AnacondaModules{
+							Enable: []string{
+								"org.fedoraproject.Anaconda.Modules.Localization",
+								"org.fedoraproject.Anaconda.Modules.Users",
+							},
+							Disable: []string{
+								"org.fedoraproject.Anaconda.Modules.Network",
+							},
+						},
 					},
 					RPM: &iblueprint.RPMCustomization{
 						ImportKeys: &iblueprint.RPMImportKeys{

--- a/internal/blueprint/installer_customizatios.go
+++ b/internal/blueprint/installer_customizatios.go
@@ -1,11 +1,17 @@
 package blueprint
 
 type InstallerCustomization struct {
-	Unattended   bool       `json:"unattended,omitempty" toml:"unattended,omitempty"`
-	SudoNopasswd []string   `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
-	Kickstart    *Kickstart `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
+	Unattended   bool             `json:"unattended,omitempty" toml:"unattended,omitempty"`
+	SudoNopasswd []string         `json:"sudo-nopasswd,omitempty" toml:"sudo-nopasswd,omitempty"`
+	Kickstart    *Kickstart       `json:"kickstart,omitempty" toml:"kickstart,omitempty"`
+	Modules      *AnacondaModules `json:"modules,omitempty" toml:"modules,omitempty"`
 }
 
 type Kickstart struct {
 	Contents string `json:"contents" toml:"contents"`
+}
+
+type AnacondaModules struct {
+	Enable  []string `json:"enable,omitempty" toml:"enable,omitempty"`
+	Disable []string `json:"disable,omitempty" toml:"disable,omitempty"`
 }


### PR DESCRIPTION
**blueprint: enable the anaconda modules customization**

This has been available since v0.74.0 of osbuild/images but was never
connected to the frontend blueprint.

See https://github.com/osbuild/images/pull/799

---

**blueprint: add kickstart contents to conversion test**

The option was added in f5c6cdd9cfc6d38a375b2f38d868d520399b668d but a
value was never added to the conversion test.

---

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [x] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
