### PR TITLE
worker: fix OSBUILD_SOURCES_CURL_SSL_CA_CERT variable

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -518,7 +518,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 
 	if impl.RepositoryMTLSConfig != nil {
 		if impl.RepositoryMTLSConfig.CA != "" {
-			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT=%s", impl.RepositoryMTLSConfig.CA))
+			extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CA_CERT=%s", impl.RepositoryMTLSConfig.CA))
 		}
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_KEY=%s", impl.RepositoryMTLSConfig.MTLSClientKey))
 		extraEnv = append(extraEnv, fmt.Sprintf("OSBUILD_SOURCES_CURL_SSL_CLIENT_CERT=%s", impl.RepositoryMTLSConfig.MTLSClientCert))


### PR DESCRIPTION
This looks like a copy and paste error.

The variable name was not correct:

https://github.com/osbuild/osbuild/blob/4b4b5cea950910ed9e1bc9d2fc1c618e0596b2b7/sources/org.osbuild.curl#L14