### PR TITLE
cloud/awscloud: rework create fleet retry logic

### DIFF
--- a/internal/cloud/awscloud/export_test.go
+++ b/internal/cloud/awscloud/export_test.go
@@ -1,3 +1,4 @@
 package awscloud
 
 var NewForTest = newForTest
+var DoCreateFleetRetry = doCreateFleetRetry

--- a/internal/cloud/awscloud/secure-instance_test.go
+++ b/internal/cloud/awscloud/secure-instance_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osbuild/osbuild-composer/internal/cloud/awscloud"
@@ -163,4 +166,65 @@ func TestSICreateFleetFailures(t *testing.T) {
 	require.Equal(t, 2, m.calledFn["CreateLaunchTemplate"])
 	require.Equal(t, 4, m.calledFn["DeleteSecurityGroup"])
 	require.Equal(t, 4, m.calledFn["DeleteLaunchTemplate"])
+}
+
+func TestDoCreateFleetRetry(t *testing.T) {
+	cfOutput := &ec2.CreateFleetOutput{
+		Errors: []ec2types.CreateFleetError{
+			{
+				ErrorCode:    aws.String("UnfulfillableCapacity"),
+				ErrorMessage: aws.String("Msg"),
+			},
+		},
+	}
+	retry, fmtErrs := awscloud.DoCreateFleetRetry(cfOutput)
+	require.True(t, retry)
+	require.Equal(t, []string{"UnfulfillableCapacity: Msg"}, fmtErrs)
+
+	cfOutput = &ec2.CreateFleetOutput{
+		Errors: []ec2types.CreateFleetError{
+			{
+				ErrorCode:    aws.String("Bogus"),
+				ErrorMessage: aws.String("Msg"),
+			},
+			{
+				ErrorCode:    aws.String("InsufficientInstanceCapacity"),
+				ErrorMessage: aws.String("Msg"),
+			},
+		},
+	}
+	retry, fmtErrs = awscloud.DoCreateFleetRetry(cfOutput)
+	require.True(t, retry)
+	require.Equal(t, []string{"Bogus: Msg", "InsufficientInstanceCapacity: Msg"}, fmtErrs)
+
+	cfOutput = &ec2.CreateFleetOutput{
+		Errors: []ec2types.CreateFleetError{
+			{
+				ErrorCode:    aws.String("Bogus"),
+				ErrorMessage: aws.String("Msg"),
+			},
+		},
+	}
+	retry, fmtErrs = awscloud.DoCreateFleetRetry(cfOutput)
+	require.False(t, retry)
+	require.Equal(t, []string{"Bogus: Msg"}, fmtErrs)
+
+	cfOutput = &ec2.CreateFleetOutput{
+		Errors: []ec2types.CreateFleetError{
+			{
+				ErrorCode:    aws.String("InsufficientInstanceCapacity"),
+				ErrorMessage: aws.String("Msg"),
+			},
+		},
+		Instances: []ec2types.CreateFleetInstance{
+			{
+				InstanceIds: []string{
+					"instance-id",
+				},
+			},
+		},
+	}
+	retry, fmtErrs = awscloud.DoCreateFleetRetry(cfOutput)
+	require.False(t, retry)
+	require.Equal(t, []string{"InsufficientInstanceCapacity: Msg", "Already launched instance ([instance-id]), aborting create fleet"}, fmtErrs)
 }


### PR DESCRIPTION
The current path sometimes launches two instances, which is problematic because the rest of the secure instance code expects exactly one instance. A security group could be attached to both instances and would block the worker from launching any more SIs as it tries to delete the old security group first, which is still held by one of the surplus SIs which didn't get terminated.

Only retry if:
- there are "UnfulfillableCapacity" or "InsufficientInstanceCapacity" error codes;
- there wasn't an instance launched anyway.

If either of these checks fail, do not try to launch another one, and just fail the job.
