### PR TITLE
Implement running db tests locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,14 +79,9 @@ jobs:
         PGHOST: localhost
         PGPORT: 5432
       run: |
-        WORKDIR=$(readlink -f pkg/jobqueue/dbjobqueue/schemas)
-        pushd $(mktemp -d)
-        go mod init temp
-        go install github.com/jackc/tern@latest
-        $(go env GOPATH)/bin/tern migrate -m "$WORKDIR"
-        popd
-    - run: go test -tags=integration ./cmd/osbuild-composer-dbjobqueue-tests
-    - run: go test -tags=integration ./cmd/osbuild-service-maintenance
+        ./tools/dbtest-prepare-env.sh
+        ./tools/dbtest-run-migrations.sh
+    - run: ./tools/dbtest-entrypoint.sh
 
   python-lint:
     name: "🐍 Lint python scripts"

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ build: $(BUILDDIR)/bin/
 	go build -o $<osbuild-service-maintenance ./cmd/osbuild-service-maintenance
 	go build -o $<osbuild-jobsite-manager ./cmd/osbuild-jobsite-manager
 	go build -o $<osbuild-jobsite-builder ./cmd/osbuild-jobsite-builder
+	# also build the test binaries
 	go test -c -tags=integration -o $<osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go
 	go test -c -tags=integration -o $<osbuild-weldr-tests ./internal/client/
 	go test -c -tags=integration -o $<osbuild-dnf-json-tests ./cmd/osbuild-dnf-json-tests/main_test.go

--- a/Makefile
+++ b/Makefile
@@ -344,9 +344,14 @@ container_composer_golangci_built.info: Makefile Containerfile_golangci_lint too
 	echo "Image last built on" > $@
 	date >> $@
 
+# trying to catch our use cases of the github action implementation
+# https://github.com/ludeeus/action-shellcheck/blob/master/action.yaml#L164
+SHELLCHECK_FILES=$(shell find . -name "*.sh" -not -regex "./vendor/.*")
+
 .PHONY: lint
 lint: $(GOLANGCI_LINT_CACHE_DIR) container_composer_golangci_built.info
 	podman run -t --rm -v $(SRCDIR):/app:z -v $(GOLANGCI_LINT_CACHE_DIR):/root/.cache:z -w /app $(GOLANGCI_COMPOSER_IMAGE) golangci-lint run -v
+	echo "$(SHELLCHECK_FILES)" | xargs shellcheck --shell bash -e SC1091 -e SC2002 -e SC2317
 
 # The OpenShift CLI - maybe get it from https://access.redhat.com/downloads/content/290
 OC_EXECUTABLE ?= oc

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ help:
 	@echo "    clean:              Remove all built binaries"
 	@echo "    man:                Generate all man-pages"
 	@echo "    unit-tests:         Run unit tests"
+	@echo "    db-tests:           Run postgres DB tests"
 	@echo "    push-check:         Replicates the github workflow checks as close as possible"
 	@echo "                        (do this before pushing!)"
 	@echo "    lint:               Runs linters as close as github workflow as possible"

--- a/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
+++ b/cmd/osbuild-composer-dbjobqueue-tests/main_test.go
@@ -14,12 +14,10 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/jobqueue/jobqueuetest"
 )
 
-const url = "postgres://postgres:foobar@localhost:5432/osbuildcomposer"
-
 func TestJobQueueInterface(t *testing.T) {
 	makeJobQueue := func() (jobqueue.JobQueue, func(), error) {
 		// clear db before each run
-		conn, err := pgx.Connect(context.Background(), url)
+		conn, err := pgx.Connect(context.Background(), jobqueuetest.TestDbURL())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -35,7 +33,7 @@ func TestJobQueueInterface(t *testing.T) {
 			return nil, nil, err
 		}
 
-		q, err := dbjobqueue.New(url)
+		q, err := dbjobqueue.New(jobqueuetest.TestDbURL())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cmd/osbuild-service-maintenance/db_test.go
+++ b/cmd/osbuild-service-maintenance/db_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"github.com/osbuild/osbuild-composer/internal/jobqueue/jobqueuetest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,13 +14,11 @@ import (
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue/dbjobqueue"
 )
 
-const url = "postgres://postgres:foobar@localhost:5432/osbuildcomposer"
-
 func TestDBJobQueueMaintenance(t *testing.T) {
-	dbMaintenance, err := newDB(url)
+	dbMaintenance, err := newDB(jobqueuetest.TestDbURL())
 	require.NoError(t, err)
 	defer dbMaintenance.Close()
-	q, err := dbjobqueue.New(url)
+	q, err := dbjobqueue.New(jobqueuetest.TestDbURL())
 	require.NoError(t, err)
 	defer q.Close()
 

--- a/internal/jobqueue/jobqueuetest/jobqueuetest.go
+++ b/internal/jobqueue/jobqueuetest/jobqueuetest.go
@@ -87,7 +87,7 @@ func testErrors(t *testing.T, q jobqueue.JobQueue) {
 	require.Equal(t, uuid.Nil, id)
 
 	// invalid dependency
-	id, err = q.Enqueue("test", "arg0", []uuid.UUID{uuid.New()}, "")
+	id, err = q.Enqueue("test", "{}", []uuid.UUID{uuid.New()}, "")
 	require.Error(t, err)
 	require.Equal(t, uuid.Nil, id)
 

--- a/internal/jobqueue/jobqueuetest/jobqueuetest.go
+++ b/internal/jobqueue/jobqueuetest/jobqueuetest.go
@@ -6,6 +6,8 @@ package jobqueuetest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +20,14 @@ import (
 type MakeJobQueue func() (q jobqueue.JobQueue, stop func(), err error)
 
 type testResult struct {
+}
+
+func TestDbURL() string {
+	host := os.Getenv("COMPOSER_TEST_DB_HOST")
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("postgres://postgres:foobar@%s:5432/osbuildcomposer", host)
 }
 
 func TestJobQueue(t *testing.T, makeJobQueue MakeJobQueue) {

--- a/tools/dbtest-entrypoint.sh
+++ b/tools/dbtest-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+go version
+go test -tags=integration ./cmd/osbuild-composer-dbjobqueue-tests
+go test -tags=integration ./cmd/osbuild-service-maintenance

--- a/tools/dbtest-prepare-env.sh
+++ b/tools/dbtest-prepare-env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+pushd $(mktemp -d)
+go mod init temp
+go install github.com/jackc/tern@latest
+popd

--- a/tools/dbtest-prepare-env.sh
+++ b/tools/dbtest-prepare-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-pushd $(mktemp -d)
+pushd "$(mktemp -d)" || exit 1
 go mod init temp
 go install github.com/jackc/tern@latest
-popd
+popd || exit

--- a/tools/dbtest-run-migrations.sh
+++ b/tools/dbtest-run-migrations.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+WORKDIR=$(readlink -f pkg/jobqueue/dbjobqueue/schemas)
+$(go env GOPATH)/bin/tern migrate -m "$WORKDIR"

--- a/tools/dbtest-run-migrations.sh
+++ b/tools/dbtest-run-migrations.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 WORKDIR=$(readlink -f pkg/jobqueue/dbjobqueue/schemas)
-$(go env GOPATH)/bin/tern migrate -m "$WORKDIR"
+"$(go env GOPATH)"/bin/tern migrate -m "$WORKDIR"


### PR DESCRIPTION
This PR implements `make db-tests` and extends `make clean`

The tests which are run locally until now used the `fsjobqueue` and the postgres DB tests were only run in github.

For now this just implements running the tests. More improvements to the tests them selves will be handled in subsequent PRs.
