### PR TITLE
schutzbot: shorten the slack notification

### DIFF
--- a/schutzbot/slack_notification.sh
+++ b/schutzbot/slack_notification.sh
@@ -8,15 +8,15 @@ if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
 fi
 
 if [ "$3" == "ga" ]; then
-    MESSAGE="\"GA composes pipeline execution finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL \""
+    MESSAGE="\"<$CI_PIPELINE_URL|GA composes pipeline>: *$1* $2, cc <@U01CUGX9L68>, <@U01Q07AHZ9C>, <@U04PYMDRV5H>\""
 else
     COMPOSE_ID=$(cat COMPOSE_ID)
     COMPOSER_NVR=$(cat COMPOSER_NVR)
-    MESSAGE="\"Nightly pipeline execution on *$COMPOSE_ID* with *$COMPOSER_NVR* finished with status *$1* $2 \n QE: @atodorov, @jrusz, @tkosciel\n Link to results: $CI_PIPELINE_URL\n For edge testing status please see https://url.corp.redhat.com/edge-pipelines \""
+    MESSAGE="\"<$CI_PIPELINE_URL|Nightly pipeline> ($COMPOSE_ID: $COMPOSER_NVR): *$1* $2, cc <@U01CUGX9L68>, <@U01Q07AHZ9C>, <@U04PYMDRV5H>\""
 fi
 
 curl \
     -X POST \
     -H 'Content-type: application/json' \
-    --data '{"text": "test", "blocks": [ { "type": "section", "text": {"type": "mrkdwn", "text":'"$MESSAGE"'}}]}' \
+    --data '{"text": '"$MESSAGE"'}' \
     "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
We are on a quest to reduce clutter on our Slack channels. Thus,
I decided to simplify the daily CI notifications:
  - the link to the edge pipelines got removed, it's now in bookmarks
  - several words were removed to make the message shorter
  - the link to the pipeline is now a hyperlink
  - the whole message should be a one liner
  - less text is now bold

I've also simplified the format in which we send the message. I think
that the block format used before makes redundant line-breaks.
Unfortunately, the mentions need to be done using user IDs instead
of user names. If you ever need to find them, go to the user's profile,
click on the three dots and select "Copy member ID".

Before:
![image](https://github.com/user-attachments/assets/404cd088-7f22-44aa-9ca8-b527cdabf637)

After:
![image](https://github.com/user-attachments/assets/6c5097b2-4b6c-4ac0-bc37-1d730ec1c33d)

(I've also removed the bold style from the COMPOSE_ID and the NVR, this is not shown in the screenshot.)