### PR TITLE
cloud/awscloud: fix nil pointer dereference in maintenance fns

### DIFF
--- a/internal/cloud/awscloud/maintenance.go
+++ b/internal/cloud/awscloud/maintenance.go
@@ -25,7 +25,10 @@ func (a *AWS) DescribeImagesByTag(tagKey, tagValue string) ([]ec2types.Image, er
 			},
 		},
 	)
-	return imgs.Images, err
+	if err != nil {
+		return nil, err
+	}
+	return imgs.Images, nil
 }
 
 func (a *AWS) RemoveSnapshotAndDeregisterImage(image *ec2types.Image) error {


### PR DESCRIPTION
The maintenance pod is crashing when describing the images by tag, most likely something else is failing.

