### PR TITLE
spec: update version to 101.2

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -12,7 +12,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        101
+Version:        101.2
 
 %gometa
 


### PR DESCRIPTION
I just created a release for the backport tagged v101.1: https://github.com/osbuild/osbuild-composer/releases/tag/v101.1
and made a copr build successfully for the affected user, but quickly realised I hadn't updated the version in the spec file.