### PR TITLE
cloud/awscloud: fix retrying to create secure instances

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -552,6 +552,7 @@ func (a *AWS) createFleet(input *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, 
 	if len(fleetErrs) > 0 && retry {
 		logrus.Warnf("Received errors (%s) from CreateFleet, retrying CreateFleet with OnDemand instance", strings.Join(fleetErrs, "; "))
 		input.SpotOptions = nil
+		input.TargetCapacitySpecification.DefaultTargetCapacityType = ec2types.DefaultTargetCapacityTypeOnDemand
 		createFleetOutput, err = a.ec2.CreateFleet(context.Background(), input)
 		if err != nil {
 			return nil, fmt.Errorf("Unable to create on demand fleet: %w", err)


### PR DESCRIPTION
Set the correct target capacity specification type, just setting the spot options to nil doesn't result in an on demand instance.

