### PR TITLE
templates/packer: allow setting executor type in worker config

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
@@ -6,6 +6,7 @@ source /tmp/cloud_init_vars
 echo "Writing osbuild_executor config to worker configuration."
 OSBUILD_EXECUTOR_IAM_PROFILE=${OSBUILD_EXECUTOR_IAM_PROFILE:-osbuild-executor}
 OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-}
+OSBUILD_EXECUTOR_TYPE=${OSBUILD_EXECUTOR_TYPE:-aws.ec2}
 
 CLOUDWATCH_GROUP_CONFIG=""
 if [ -n "${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}" ]; then
@@ -14,7 +15,7 @@ fi
 
 sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 [osbuild_executor]
-type = "aws.ec2"
+type = "${OSBUILD_EXECUTOR_TYPE}"
 iam_profile = "${OSBUILD_EXECUTOR_IAM_PROFILE}"
 ${CLOUDWATCH_GROUP_CONFIG}
 EOF


### PR DESCRIPTION
Currently the worker images always have to use aws.ec2, this way we can use the host executor for fedora.

