### PR TITLE
Makefile: clean golangci-lint cache on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ clean:
 	rm -rf $(CURDIR)/rpmbuild
 	rm -rf container_composer_golangci_built.info
 	rm -rf $(BUILDDIR)/$(PROCESSED_TEMPLATE_DIR)
+	rm -rf $(GOLANGCI_LINT_CACHE_DIR)
 
 .PHONY: push-check
 push-check: lint build unit-tests srpm man


### PR DESCRIPTION
This is a followup of #4435.

To speedup `make lint` we use a local cache.
It seems that there is no sane way to check and just update the cache, so we'll just provide an option to wipe it.

Using the cache does reduce the time of `make lint` from 1 minute 15sec to 1 sec on my PC. So for consecutive runs, the cache still makes sense.

Thanks @mvo5 for the tests in #4435 