### PR TITLE
cloud/awscloud: don't specify max spot price

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -419,7 +419,6 @@ func (a *AWS) createOrReplaceLT(hostInstanceID, imageID, sgID, iamProfile, keyNa
 				NetworkInterfaceCount: &ec2types.NetworkInterfaceCountRequest{
 					Min: aws.Int32(1),
 				},
-				SpotMaxPricePercentageOverLowestPrice: aws.Int32(200),
 				VCpuCount: &ec2types.VCpuCountRangeRequest{
 					Min: aws.Int32(2),
 				},


### PR DESCRIPTION
The current spot price could be limiting the available instance pool significantly. ARM instances specifically are experiencing a lot of capacity errors.

