### PR TITLE
go.mod: update osbuild/images to v0.95.0

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -148,6 +148,10 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 }
 
 func (c *Composer) InitWeldr(weldrListener net.Listener, distrosImageTypeDenylist map[string][]string) (err error) {
+	// Weldr requires repository definitions, so error out if none were loaded
+	if c.repos == nil {
+		return fmt.Errorf("weldr API requires repository definitions but none were loaded")
+	}
 	c.weldr, err = weldr.New(c.repos, c.stateDir, c.solver, c.distros, c.logger, c.workers, distrosImageTypeDenylist)
 	if err != nil {
 		return err

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -12,18 +12,19 @@ import (
 )
 
 type ComposerConfigFile struct {
-	Koji              KojiAPIConfig     `toml:"koji"`
-	Worker            WorkerAPIConfig   `toml:"worker"`
-	WeldrAPI          WeldrAPIConfig    `toml:"weldr_api"`
-	DistroAliases     map[string]string `toml:"distro_aliases" env:"DISTRO_ALIASES"`
-	LogLevel          string            `toml:"log_level"`
-	LogFormat         string            `toml:"log_format"`
-	DNFJson           string            `toml:"dnf-json"`
-	SplunkHost        string            `env:"SPLUNK_HEC_HOST"`
-	SplunkPort        string            `env:"SPLUNK_HEC_PORT"`
-	SplunkToken       string            `env:"SPLUNK_HEC_TOKEN"`
-	GlitchTipDSN      string            `env:"GLITCHTIP_DSN"`
-	DeploymentChannel string            `env:"CHANNEL"`
+	Koji               KojiAPIConfig     `toml:"koji"`
+	Worker             WorkerAPIConfig   `toml:"worker"`
+	WeldrAPI           WeldrAPIConfig    `toml:"weldr_api"`
+	DistroAliases      map[string]string `toml:"distro_aliases" env:"DISTRO_ALIASES"`
+	LogLevel           string            `toml:"log_level"`
+	LogFormat          string            `toml:"log_format"`
+	DNFJson            string            `toml:"dnf-json"`
+	IgnoreMissingRepos bool              `toml:"ignore_missing_repos"`
+	SplunkHost         string            `env:"SPLUNK_HEC_HOST"`
+	SplunkPort         string            `env:"SPLUNK_HEC_PORT"`
+	SplunkToken        string            `env:"SPLUNK_HEC_TOKEN"`
+	GlitchTipDSN       string            `env:"GLITCHTIP_DSN"`
+	DeploymentChannel  string            `env:"CHANNEL"`
 }
 
 type KojiAPIConfig struct {
@@ -129,9 +130,10 @@ func GetDefaultConfig() *ComposerConfigFile {
 			"rhel-9":  "rhel-9.5",
 			"rhel-10": "rhel-10.0",
 		},
-		LogLevel:  "info",
-		LogFormat: "journal",
-		DNFJson:   "/usr/libexec/osbuild-depsolve-dnf",
+		LogLevel:           "info",
+		LogFormat:          "journal",
+		DNFJson:            "/usr/libexec/osbuild-depsolve-dnf",
+		IgnoreMissingRepos: false,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.94.0
+	github.com/osbuild/images v0.95.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.438 h1:tsLCCUzbLCTL4RZG02y9RuopmGCXp
 github.com/openshift-online/ocm-sdk-go v0.1.438/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.94.0 h1:bdvVW+qIAwfyoYdMH5f4ZVJBVxEVWPyqpDXNhrwN2MI=
-github.com/osbuild/images v0.94.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.95.0 h1:WWxYEQKD9wFGs/zkWF4wd3IDwNColZwzKsQh/+dwvUw=
+github.com/osbuild/images v0.95.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -249,6 +249,7 @@ objects:
       - claim: account_id
         pattern: ^(${ACL_ACCOUNT_ID_TENANTS})$
     osbuild-composer.toml: |
+      ignore_missing_repos = true
       log_level = "info"
       log_format = "json"
       [koji]

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -136,6 +136,7 @@ PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PG
 popd
 
 cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+ignore_missing_repos = true
 log_level = "debug"
 [koji]
 allowed_domains = [ "localhost", "client.osbuild.org" ]
@@ -778,6 +779,7 @@ verifyPackageList
 #
 greenprint  "Verifying oauth2"
 cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+ignore_missing_repos = true
 [koji]
 enable_tls = false
 enable_mtls = false

--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -102,6 +102,7 @@ sudo "${CONTAINER_RUNTIME}" pull --creds "${V2_QUAY_USERNAME}":"${V2_QUAY_PASSWO
      "quay.io/osbuild/osbuild-composer-ubi-pr:${CI_COMMIT_SHA}"
 
 cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+ignore_missing_repos = true
 log_level = "debug"
 [koji]
 allowed_domains = [ "localhost", "client.osbuild.org" ]

--- a/test/data/composer/osbuild-composer-jwt.toml
+++ b/test/data/composer/osbuild-composer-jwt.toml
@@ -1,3 +1,5 @@
+ignore_missing_repos = true
+
 [koji]
 enable_tls = false
 enable_mtls = false

--- a/test/data/composer/osbuild-composer-tls.toml
+++ b/test/data/composer/osbuild-composer-tls.toml
@@ -1,3 +1,5 @@
+ignore_missing_repos = true
+
 [koji]
 allowed_domains = [ "localhost", "client.osbuild.org" ]
 ca = "/etc/osbuild-composer/ca-crt.pem"

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -62,6 +62,7 @@ sudo mkdir -p /etc/osbuild-worker
 # these are expected to be provided with the compose request.
 if [[ "$AUTH_METHOD" != "$AUTH_METHOD_NONE" ]]; then
     # Remove the repositories, because it is not used in the Service scenario
+    # This requires that ignore_missing_repos is enabled in the osbuild-composer configuration
     sudo rm -rf /etc/osbuild-composer/repositories
     sudo rm -f /usr/share/osbuild-composer/repositories/*
 

--- a/vendor/github.com/osbuild/images/pkg/reporegistry/error.go
+++ b/vendor/github.com/osbuild/images/pkg/reporegistry/error.go
@@ -1,0 +1,13 @@
+package reporegistry
+
+import "fmt"
+
+// NoReposLoadedError is an error type that is returned when no repositories
+// are loaded from the given paths.
+type NoReposLoadedError struct {
+	Paths []string
+}
+
+func (e *NoReposLoadedError) Error() string {
+	return fmt.Sprintf("no repositories found in the given paths: %v", e.Paths)
+}

--- a/vendor/github.com/osbuild/images/pkg/reporegistry/reporegistry.go
+++ b/vendor/github.com/osbuild/images/pkg/reporegistry/reporegistry.go
@@ -23,9 +23,6 @@ func New(repoConfigPaths []string) (*RepoRegistry, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(repositories) == 0 {
-		return nil, fmt.Errorf("no repositories found in the given paths: %v", repoConfigPaths)
-	}
 
 	return &RepoRegistry{repositories}, nil
 }

--- a/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
+++ b/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
@@ -1,7 +1,6 @@
 package reporegistry
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -66,6 +65,10 @@ func LoadAllRepositories(confPaths []string) (rpmmd.DistrosRepoConfigs, error) {
 		}
 	}
 
+	if len(distrosRepoConfigs) == 0 {
+		return nil, &NoReposLoadedError{confPaths}
+	}
+
 	return distrosRepoConfigs, nil
 }
 
@@ -93,7 +96,7 @@ func LoadRepositories(confPaths []string, distro string) (map[string][]rpmmd.Rep
 	}
 
 	if repoConfigs == nil {
-		return nil, fmt.Errorf("LoadRepositories failed: none of the provided paths contain distro configuration")
+		return nil, &NoReposLoadedError{confPaths}
 	}
 
 	return repoConfigs, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1022,7 +1022,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.94.0
+# github.com/osbuild/images v0.95.0
 ## explicit; go 1.21.0
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
This is a small update that only includes one PR from osbuild/images: https://github.com/osbuild/images/pull/946

The second and third commits change the behaviour of osbuild-composer's startup when no repositories are configured.

Weldr (running on-prem) requires local repository configurations, while the API (SaaS) doesn't.  However, at the time during startup when reporegistry.LoadAllRepositories() is called, it is still not known whether the Weldr API will be initialised.

Since lack of repository configurations is no longer a stop condition for osbuild-composer's startup, the Weldr API will now return with an error when no repositories are configured during its initialisation.
