### PR TITLE
composer: simplify loading the repositories

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -77,11 +77,10 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 		return nil, fmt.Errorf("failed to configure distro aliases: %v", err)
 	}
 
-	repoConfigs, err := reporegistry.LoadAllRepositories(repositoryConfigs)
+	c.repos, err = reporegistry.New(repositoryConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("error loading repository definitions: %v", err)
 	}
-	c.repos = reporegistry.NewFromDistrosRepoConfigs(repoConfigs)
 
 	c.solver = dnfjson.NewBaseSolver(path.Join(c.cacheDir, "rpmmd"))
 	c.solver.SetDNFJSONPath(c.config.DNFJson)


### PR DESCRIPTION
Move to use `reporegistry.New(repositoryConfigs)` which will do the equivivalent of the existing code and is shorter.

With this merged we can unexport `LoadAllRepositories()` and remove `NewFromDistrosRepoConfigs` from the "images" library as this is the only place using them.
