### PR TITLE
bib/composer integration: add manifest job for osbuild processing (HMS-4843)

### DIFF
--- a/cmd/osbuild-worker/jobimpl-bootc-manifest.go
+++ b/cmd/osbuild-worker/jobimpl-bootc-manifest.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
+)
+
+type BootcManifestJobImpl struct{}
+
+type ErrorInvalidImageType string
+
+func (e ErrorInvalidImageType) Error() string { return string(e) }
+
+type ErrorCommandExecution string
+
+func (e ErrorCommandExecution) Error() string { return string(e) }
+
+type ErrorInvalidArguments string
+
+func (e ErrorInvalidArguments) Error() string { return string(e) }
+
+type ErrorUnknown string
+
+func (e ErrorUnknown) Error() string { return string(e) }
+
+func setResponseError(err error, result *worker.BootcManifestJobResult) {
+	switch e := err.(type) {
+	case ErrorInvalidImageType:
+		result.JobError = clienterrors.New(
+			clienterrors.ErrorInvalidImageType,
+			"Unsupported image type",
+			e.Error(),
+		)
+	case ErrorCommandExecution:
+		result.JobError = clienterrors.New(
+			clienterrors.ErrorBootcManifestExec,
+			"Error running bootc-image-builder command",
+			e.Error(),
+		)
+	default:
+		result.JobError = clienterrors.New(
+			clienterrors.ErrorInvalidManifestArgs,
+			"Invalid bootc parameters or parameter combination",
+			err.Error(),
+		)
+	}
+}
+
+func buildManifestCommand(args *worker.BootcManifestJob) *exec.Cmd {
+	baseArgs := []string{
+		"sudo", "podman", "run",
+		"--privileged",
+		"--rm",
+		"--pull=missing",
+		"--storage-driver=vfs",
+		"--cgroup-manager=cgroupfs",
+		"--runtime=runc",
+		"--security-opt=label=type:unconfined_t",
+		"quay.io/centos-bootc/bootc-image-builder:latest",
+		"manifest",
+		args.ImageRef,
+	}
+
+	// Append optional arguments
+	if args.ImageType != "" {
+		baseArgs = append(baseArgs, "--type", args.ImageType)
+	}
+	if args.Arch != "" {
+		baseArgs = append(baseArgs, "--target-arch", args.Arch)
+	}
+	if !args.TLSVerify {
+		baseArgs = append(baseArgs, "--tls-verify=false")
+	}
+
+	return exec.Command(baseArgs[0], baseArgs[1:]...)
+}
+
+func (impl *BootcManifestJobImpl) Run(job worker.Job) error {
+	logrus.Info("Running bootc-image-builder job")
+	logWithId := logrus.WithField("jobId", job.Id())
+	// Parse the job arguments
+	var args worker.BootcManifestJob
+	err := job.Args(&args)
+	if err != nil {
+		return err
+	}
+	jobResult := worker.BootcManifestJobResult{}
+
+	cmd := buildManifestCommand(&args)
+	logWithId.Infof("Running bib manifest: %s", cmd.String())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logWithId.Errorf("Error running bootc-image-builder: %v, Output: %s", err, string(output))
+		setResponseError(ErrorCommandExecution(err.Error()), &jobResult)
+		return job.Update(&jobResult)
+	}
+
+	outputStr := string(output)
+	re := regexp.MustCompile(`\{.*\}`)
+	jsonData := re.FindString(outputStr)
+
+	var manifestData manifest.OSBuildManifest
+	err = json.Unmarshal([]byte(jsonData), &manifestData)
+	if err != nil {
+		logWithId.Errorf("Error unmarshalling manifest data: %v", err)
+		setResponseError(ErrorCommandExecution(err.Error()), &jobResult)
+	}
+
+	jobResult.Manifest = manifestData
+	jobResult.JobResult = worker.JobResult{}
+	err = job.Update(&jobResult)
+	if err != nil {
+		setResponseError(ErrorUnknown(fmt.Sprintf("Error reporting job result: %v", err)), &jobResult)
+		return job.Update(&jobResult)
+	}
+
+	return nil
+}

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -44,6 +44,9 @@ const (
 	ErrorJobPanicked          ClientErrorCode = 37
 	ErrorGeneratingSignedURL  ClientErrorCode = 38
 	ErrorInvalidRepositoryURL ClientErrorCode = 39
+	ErrorBootcManifestExec    ClientErrorCode = 40
+	ErrorInvalidImageType     ClientErrorCode = 41
+	ErrorInvalidManifestArgs  ClientErrorCode = 42
 )
 
 type ClientErrorCode int

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -305,6 +305,19 @@ type OSTreeResolveSpec struct {
 	RHSM bool   `json:"rhsm"`
 }
 
+type BootcManifestJob struct {
+	ImageType string `json:"image_type"`
+	Arch      string `json:"arch"`
+	ImageRef  string `json:"image_ref"`
+	TLSVerify bool   `json:"tls_verify,omitempty"`
+}
+
+type BootcManifestJobResult struct {
+	Manifest manifest.OSBuildManifest `json:"data,omitempty"`
+	Error    string                   `json:"error"`
+	JobResult
+}
+
 type OSTreeResolveJob struct {
 	Specs []OSTreeResolveSpec `json:"ostree_resolve_specs"`
 }


### PR DESCRIPTION
With this change:
- bib is used to generate a manifest without initiating a full build.
- Composer’s osbuild job can now process the manifest independently.

This setup improves modularity and prepares for future enhancements in the osbuild processing pipeline.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

