### PR TITLE
feat(api): Add /experimental/compose endpoint for bootc integration

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -143,6 +143,26 @@ type imageRequest struct {
 	manifestSeed int64
 }
 
+func (h *apiHandlers) PostBootcCompose(ctx echo.Context) error {
+	var request ComposeBootcRequest
+	err := ctx.Bind(&request)
+	if err != nil {
+		return err
+	}
+
+	// TODO: add enqueueBootcCompose in server and call it here
+
+	return ctx.JSON(http.StatusCreated, &ComposeId{
+		ObjectReference: ObjectReference{
+			Href: "/api/image-builder-composer/v2/experimental/compose",
+			Id:   "not-implemented",
+			Kind: "ComposeId",
+		},
+		Id: "",
+	})
+
+}
+
 func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 	var request ComposeRequest
 	err := ctx.Bind(&request)

--- a/internal/cloudapi/v2/openapi.v2.yml
+++ b/internal/cloudapi/v2/openapi.v2.yml
@@ -346,6 +346,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /experimental/compose:
+    post:
+      operationId: postBootcCompose
+      summary: Create compose with bootc image
+      description: Create a new compose with bootc image, potentially consisting of several images and upload each to their destinations.
+      security:
+        - Bearer: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComposeBootcRequest'
+      responses:
+        '201':
+          description: Compose has started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeId'
+        '400':
+          description: Invalid compose request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /compose:
     post:
       operationId: postCompose
@@ -831,43 +881,65 @@ components:
         signature:
           type: string
 
-    ComposeRequest:
+    BaseComposeRequest:
+      type: object
       additionalProperties: false
-      required:
-        - distribution
-      not: {required: ['customizations', 'blueprint']}
       properties:
         distribution:
           type: string
           example: 'rhel-8'
-        image_request:
-          $ref: '#/components/schemas/ImageRequest'
-        image_requests:
-          type: array
-          items:
-            $ref: '#/components/schemas/ImageRequest'
         customizations:
           $ref: '#/components/schemas/Customizations'
-        koji:
-          $ref: '#/components/schemas/Koji'
-        blueprint:
-          $ref: '#/components/schemas/Blueprint'
-    ImageRequest:
+
+    ComposeBootcRequest:
+      allOf:
+        - $ref: '#/components/schemas/BaseComposeRequest'
+        - type: object
+          required:
+            - distribution
+            - image_ref
+          not: {required: ['customizations', 'blueprint']}
+          properties:
+            image_request:
+              $ref: '#/components/schemas/ImageRequestBase'
+            image_requests:
+              type: array
+              items:
+                $ref: '#/components/schemas/ImageRequestBase'
+            image_ref:
+              type: string
+              example: 'quay.io/myaccount/bootc:latest'
+
+    ComposeRequest:
+      allOf:
+        - $ref: '#/components/schemas/BaseComposeRequest'
+        - type: object
+          required:
+            - distribution
+          not: {required: ['customizations', 'blueprint']}
+          properties:
+            image_request:
+              $ref: '#/components/schemas/ImageRequest'
+            image_requests:
+              type: array
+              items:
+                $ref: '#/components/schemas/ImageRequest'
+            koji:
+              $ref: '#/components/schemas/Koji'
+            blueprint:
+              $ref: '#/components/schemas/Blueprint'
+    
+    ImageRequestBase:
       additionalProperties: false
       required:
         - architecture
         - image_type
-        - repositories
       properties:
         architecture:
           type: string
           example: 'x86_64'
         image_type:
           $ref: '#/components/schemas/ImageTypes'
-        repositories:
-          type: array
-          items:
-            $ref: '#/components/schemas/Repository'
         ostree:
           $ref: '#/components/schemas/OSTree'
         upload_targets:
@@ -892,6 +964,18 @@ components:
           description: |
             Size of image, in bytes. When set to 0 the image size is a minimum
             defined by the image type.
+    ImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/ImageRequestBase'
+        - type: object
+          properties:
+            repositories:
+              type: array
+              items:
+                $ref: '#/components/schemas/Repository'
+          required:
+            - repositories
+   
     ImageTypes:
       type: string
       enum:


### PR DESCRIPTION
Introduce a new /experimental/compose endpoint to separate the bootc compose logic from the regular compose requests. This aims to simplify the integration process and keep the existing compose endpoint clean during the bootc development phase.

Key differences in the bootc payload:
- Requires an image reference from a registry.
- The `repositories` in `ImageRequest` is not needed.
- Retains the same `customizations` schema, due to  necessary properties like `filesystem`.

This separation allows for gradual progress and enables faster experimentation with bootc-based compose


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

