### PR TITLE
worker: check MTLS config for ostree

### DIFF
--- a/cmd/osbuild-worker/jobimpl-ostree-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-ostree-resolve.go
@@ -17,6 +17,10 @@ type OSTreeResolveJobImpl struct {
 }
 
 func (job *OSTreeResolveJobImpl) CompareBaseURL(baseURLStr string) (bool, error) {
+	if job.RepositoryMTLSConfig == nil || job.RepositoryMTLSConfig.BaseURL == nil {
+		return false, nil
+	}
+
 	baseURL, err := url.Parse(baseURLStr)
 	if err != nil {
 		return false, err
@@ -91,6 +95,12 @@ func (impl *OSTreeResolveJobImpl) Run(job worker.Job) error {
 				err.Error(),
 			)
 			break
+		} else {
+			mURL := ""
+			if impl.RepositoryMTLSConfig != nil && impl.RepositoryMTLSConfig.BaseURL != nil {
+				mURL = impl.RepositoryMTLSConfig.BaseURL.String()
+			}
+			logWithId.Warnf("Repository URL '%s' does not match '%s', MTLS: %t", s.URL, mURL, impl.RepositoryMTLSConfig != nil)
 		}
 		commitSpec, err := ostree.Resolve(reqParams)
 		if err != nil {


### PR DESCRIPTION
My MTLS patch was not correctly checking MTLS config - it is currently missing and all builds are failing.

https://issues.redhat.com/browse/HMS-4975
