### PR TITLE
worker: check MTLS proxy for nil

### DIFF
--- a/cmd/osbuild-worker/jobimpl-ostree-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-ostree-resolve.go
@@ -81,7 +81,9 @@ func (impl *OSTreeResolveJobImpl) Run(job worker.Job) error {
 		reqParams.URL = s.URL
 		reqParams.Ref = s.Ref
 		if match, err := impl.CompareBaseURL(s.URL); match && err == nil {
-			reqParams.Proxy = impl.RepositoryMTLSConfig.Proxy.String()
+			if impl.RepositoryMTLSConfig.Proxy != nil {
+				reqParams.Proxy = impl.RepositoryMTLSConfig.Proxy.String()
+			}
 			reqParams.MTLS = &ostree.MTLS{
 				CA:         impl.RepositoryMTLSConfig.CA,
 				ClientCert: impl.RepositoryMTLSConfig.MTLSClientCert,


### PR DESCRIPTION
Ostree builds are ending up with "connection refused"

```
"details": "error sending request to ostree repository \"https://mtls.xxxxx.redhat.com/api/pulp-content/edge-integration-test-2/lzap-rhel9/refs/heads/rhel/9/x86_64/edge\": Get \"https://mtls.xxxxx.redhat.com/api/pulp-content/edge-integration-test-2/lzap-rhel9/refs/heads/rhel/9/x86_64/edge\": proxyconnect tcp: dial tcp :0: connect: connection refused"
```

this patch ensures the proxy configuration parses fine, it should be set to `squid.xxxxxxx.redhat.com:3128` which parses fine via `url.Parse` so not sure why it does not work.

Well at least I found this, but need to dig deeper.