### PR TITLE
awscloud/secure-instance: enrich logging with secure instance id

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -203,6 +203,12 @@ func (a *AWS) RunSecureInstance(iamProfile, keyName, cloudWatchGroup, hostname s
 	}
 	secureInstance.Instance = &descrInstOutput.Reservations[0].Instances[0]
 
+	logrus.Infof(
+		"Secure instance created: https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#InstanceDetails:instanceId=%s",
+		identity.Region,
+		identity.Region,
+		secureInstance.InstanceID)
+
 	return secureInstance, nil
 }
 


### PR DESCRIPTION
We'll log as direct URL to the console for easier tracing

@croissanne would this work (especially `identity.Region`) and do you think this is useful or too much 😁