### PR TITLE
awscloud/secure-instance: fix cleaning up fleets with creation errors

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -639,6 +639,7 @@ func doCreateFleetRetry(cfOutput *ec2.CreateFleetOutput) (bool, []string) {
 	msg := []string{}
 	retry := false
 	for _, err := range cfOutput.Errors {
+		logrus.Infof("Checking to retry fleet create on error %s (msg: %s)", *err.ErrorCode, *err.ErrorMessage)
 		if slices.Contains(retryCodes, *err.ErrorCode) {
 			retry = true
 		}


### PR DESCRIPTION
By surfacing the output even in case of an error, the fleet ID and
    instance ID can be extracted if present. Thus the instance can be
    terminated before its dependencies are deleted.

---

We're seeing some behaviour where create fleet is not retried and subsequently the SI cleanup fails due to the security group already being tied to an existing instance. There is no error that an instance was launched anyway.

