### PR TITLE
Schutzfile: update osbuild commit (COMPOSER-2406)

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-39": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -45,7 +45,7 @@
   "fedora-40": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -88,56 +88,56 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-8.8": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-8.9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-8.10": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-9.2": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-9.3": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-9.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "rhel-9.5": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -183,7 +183,7 @@
   "rhel-9.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -229,7 +229,7 @@
   "rhel-10.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -275,14 +275,14 @@
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [
@@ -328,14 +328,14 @@
   "centos-10": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     }
   },
   "centos-stream-10": {
     "dependencies": {
       "osbuild": {
-        "commit": "ff0cd854c88de900e4fe62c8a0f24cbe2f2317ed"
+        "commit": "a8e8ebde4400e94036df35f72b08708f00bd4ffe"
       }
     },
     "repos": [


### PR DESCRIPTION
Newer osbuild uses dnf 4 on Fedora 41, as we've seen Fedora 41 in combination with dnf 5 (and SBOMs) failing.

