### PR TITLE
cloud/awscloud: give secure instances a name

### DIFF
--- a/internal/cloud/awscloud/secure-instance.go
+++ b/internal/cloud/awscloud/secure-instance.go
@@ -154,6 +154,10 @@ func (a *AWS) RunSecureInstance(iamProfile, keyName, cloudWatchGroup, hostname s
 						Key:   aws.String("parent"),
 						Value: aws.String(identity.InstanceID),
 					},
+					ec2types.Tag{
+						Key:   aws.String("Name"),
+						Value: aws.String(fmt.Sprintf("Executor-for-%s", identity.InstanceID)),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
That way you can just enter the parent instance id into the search bar and get both the worker and its executor.


