### PR TITLE
github: prevent script injections via PR branch names

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Checkout branch
         id: pr_data
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           PR_DATA=$(mktemp)
           # use uuid as a file terminator to avoid conflicts with data content
@@ -50,7 +52,7 @@ jobs:
             echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"
             git checkout -b PR-$PR
           else
-            git checkout ${{ github.event.workflow_run.head_branch }}
+            git checkout "${BRANCH}"
           fi
 
       - name: Download artifacts
@@ -89,7 +91,7 @@ jobs:
           if [[ "${SKIP_CI}" == true ]];then
             git push -f -o ci.variable="SKIP_CI=true" ci
           else
-            git push -f ci 
+            git push -f ci
           fi
 
       - name: Trigger GitLab nightly pipeline against this PR


### PR DESCRIPTION
Prior this commit, ${{ github.event.workflow_run.head_branch }} got expanded in the bash script. A malicious actor could inject an arbitrary shell script. Since this action has access to a token with write rights the malicious actor can easily steal this token.

This commit moves the expansion into an env block where such an injection cannot happen. This is the preferred way according to the github docs:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable