### PR TITLE
Clean up orphaned instances and security groups (HMS-3632)

### DIFF
--- a/cmd/osbuild-service-maintenance/aws.go
+++ b/cmd/osbuild-service-maintenance/aws.go
@@ -158,9 +158,11 @@ func terminateOrphanedSecureInstances(a *awscloud.AWS, dryRun bool) error {
 	instanceIDs = filterOnTooOld(instanceIDs, reservations)
 	logrus.Infof("Cleaning up executor instances: %v", instanceIDs)
 	if !dryRun {
-		err = a.TerminateInstances(instanceIDs)
-		if err != nil {
-			return fmt.Errorf("Unable to terminate secure instances: %w", err)
+		if len(instanceIDs) > 0 {
+			err = a.TerminateInstances(instanceIDs)
+			if err != nil {
+				return fmt.Errorf("Unable to terminate secure instances: %w", err)
+			}
 		}
 	} else {
 		logrus.Info("Dry run, didn't actually terminate any instances")

--- a/cmd/osbuild-service-maintenance/aws.go
+++ b/cmd/osbuild-service-maintenance/aws.go
@@ -14,9 +14,21 @@ import (
 )
 
 func AWSCleanup(maxConcurrentRequests int, dryRun bool, accessKeyID, accessKey string, cutoff time.Time) error {
-	a, err := awscloud.New("us-east-1", accessKeyID, accessKey, "")
-	if err != nil {
-		return err
+	const region = "us-east-1"
+	var a *awscloud.AWS
+	var err error
+
+	if accessKeyID != "" && accessKey != "" {
+		a, err = awscloud.New(region, accessKeyID, accessKey, "")
+		if err != nil {
+			return err
+		}
+	} else {
+		logrus.Infof("One of AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY is missing, trying default credentials…")
+		a, err = awscloud.NewDefault(region)
+		if err != nil {
+			return err
+		}
 	}
 
 	regions, err := a.Regions()

--- a/cmd/osbuild-service-maintenance/aws_test.go
+++ b/cmd/osbuild-service-maintenance/aws_test.go
@@ -17,7 +17,7 @@ func TestFilterReservations(t *testing.T) {
 			Instances: []ec2types.Instance{
 				{
 					LaunchTime: common.ToPtr(time.Now().Add(-time.Hour * 24)),
-					InstanceId: common.ToPtr("not filtered"),
+					InstanceId: common.ToPtr("not filtered 1"),
 				},
 			},
 		},
@@ -25,7 +25,7 @@ func TestFilterReservations(t *testing.T) {
 			Instances: []ec2types.Instance{
 				{
 					LaunchTime: common.ToPtr(time.Now().Add(-time.Minute * 121)),
-					InstanceId: common.ToPtr("not filtered"),
+					InstanceId: common.ToPtr("not filtered 2"),
 				},
 			},
 		},
@@ -33,7 +33,7 @@ func TestFilterReservations(t *testing.T) {
 			Instances: []ec2types.Instance{
 				{
 					LaunchTime: common.ToPtr(time.Now().Add(-time.Minute * 119)),
-					InstanceId: common.ToPtr("filtered"),
+					InstanceId: common.ToPtr("filtered 1"),
 				},
 			},
 		},
@@ -41,12 +41,87 @@ func TestFilterReservations(t *testing.T) {
 			Instances: []ec2types.Instance{
 				{
 					LaunchTime: common.ToPtr(time.Now()),
-					InstanceId: common.ToPtr("filtered"),
+					InstanceId: common.ToPtr("filtered 2"),
 				},
 			},
 		},
 	}
 
-	instanceIDs := main.FilterReservations(reservations)
-	require.Equal(t, []string{"not filtered", "not filtered"}, instanceIDs)
+	instanceIDs := main.FilterOnTooOld([]string{}, reservations)
+	require.Equal(t, []string{"not filtered 1", "not filtered 2"}, instanceIDs)
+}
+
+func TestCheckValidParent(t *testing.T) {
+	testInstanceID := "TestInstance"
+	tests :=
+		[]struct {
+			parent []ec2types.Reservation
+			result bool
+		}{
+			// no parent
+			{
+				parent: []ec2types.Reservation{},
+				result: false,
+			},
+			// many parents - "valid" to leave as is
+			{
+				parent: []ec2types.Reservation{
+					{}, {},
+				},
+				result: true,
+			},
+			// no parent instance
+			{
+				parent: []ec2types.Reservation{
+					{Instances: []ec2types.Instance{}},
+				},
+				result: false,
+			},
+			// many parent instances - "valid" to leave as is
+			{
+				parent: []ec2types.Reservation{
+					{Instances: []ec2types.Instance{{}, {}}},
+				},
+				result: true,
+			},
+			// pending parent
+			{
+				parent: []ec2types.Reservation{
+					{Instances: []ec2types.Instance{{
+						InstanceId: &testInstanceID,
+						State: &ec2types.InstanceState{
+							Name: ec2types.InstanceStateNamePending,
+						},
+					}}},
+				},
+				result: true,
+			},
+			// running parent
+			{
+				parent: []ec2types.Reservation{
+					{Instances: []ec2types.Instance{{
+						InstanceId: &testInstanceID,
+						State: &ec2types.InstanceState{
+							Name: ec2types.InstanceStateNameRunning,
+						},
+					}}},
+				},
+				result: true,
+			},
+			// terminated parent - not valid instance
+			{
+				parent: []ec2types.Reservation{
+					{Instances: []ec2types.Instance{{
+						InstanceId: &testInstanceID,
+						State: &ec2types.InstanceState{
+							Name: ec2types.InstanceStateNameTerminated,
+						},
+					}}},
+				},
+				result: false,
+			},
+		}
+	for _, tc := range tests {
+		require.Equal(t, tc.result, main.CheckValidParent("testChildId", tc.parent))
+	}
 }

--- a/cmd/osbuild-service-maintenance/export_test.go
+++ b/cmd/osbuild-service-maintenance/export_test.go
@@ -1,3 +1,4 @@
 package main
 
-var FilterReservations = filterReservations
+var FilterOnTooOld = filterOnTooOld
+var CheckValidParent = checkValidParent

--- a/cmd/osbuild-service-maintenance/export_test.go
+++ b/cmd/osbuild-service-maintenance/export_test.go
@@ -2,3 +2,4 @@ package main
 
 var FilterOnTooOld = filterOnTooOld
 var CheckValidParent = checkValidParent
+var AllTerminated = allTerminated

--- a/internal/cloud/awscloud/maintenance.go
+++ b/internal/cloud/awscloud/maintenance.go
@@ -84,6 +84,19 @@ func (a *AWS) DescribeInstancesByTag(tagKey, tagValue string) ([]ec2types.Reserv
 	return res.Reservations, nil
 }
 
+func (a *AWS) DescribeInstancesByInstanceID(instanceID string) ([]ec2types.Reservation, error) {
+	res, err := a.ec2.DescribeInstances(
+		context.Background(),
+		&ec2.DescribeInstancesInput{
+			InstanceIds: []string{instanceID},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return res.Reservations, nil
+}
+
 func (a *AWS) TerminateInstances(instanceIDs []string) error {
 	_, err := a.ec2.TerminateInstances(
 		context.Background(),


### PR DESCRIPTION
This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

Implement removal of orphaned items as described in https://issues.redhat.com/browse/HMS-3632
removal of launch templates is not yet implemented (that's why it's a draft for now)