### PR TITLE
tools/tests: Update rhel10 compose url

### DIFF
--- a/tools/define-compose-url.sh
+++ b/tools/define-compose-url.sh
@@ -21,10 +21,10 @@ if [[ $ID == rhel && ${VERSION_ID%.*} == 9 ]]; then
   COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/$COMPOSE_ID}"
 
 elif [[ $ID == rhel && ${VERSION_ID%.*} == 10 ]]; then
-  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-"${VERSION_ID}"/COMPOSE_ID)
+  COMPOSE_ID=$(curl -L http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-"${VERSION_ID}"/COMPOSE_ID)
 
   # default to a nightly tree but respect values passed from ENV so we can test rel-eng composes as well
-  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/$COMPOSE_ID}"
+  COMPOSE_URL="${COMPOSE_URL:-http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/$COMPOSE_ID}"
 fi
 
 # in case COMPOSE_URL was defined from the outside refresh COMPOSE_ID file,


### PR DESCRIPTION
Update a RHEL 10 compose URL to point to nightly instead of public beta. This PR should fix a failing RHEL10 nightly pipeline as the url will point now to correct repositories.