### PR TITLE
Update osbuild/images to v0.105.0 (COMPOSER-2357, COMPOSER-2400)

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -55,15 +55,17 @@ func TestCrossArchDepsolve(t *testing.T) {
 							InstallationDevice: "/dev/null",
 						}
 					}
+					var options distro.ImageOptions
+					if imgType.OSTreeRef() != "" {
+						options.OSTree = &ostree.ImageOptions{
+							URL: "https://example.com",
+						}
+					}
 					manifest, _, err := imgType.Manifest(
 						&blueprint.Blueprint{
 							Customizations: customizations,
 						},
-						distro.ImageOptions{
-							OSTree: &ostree.ImageOptions{
-								URL: "https://example.com", // required by some image types
-							},
-						},
+						options,
 						repos[archStr], 0)
 					assert.NoError(t, err)
 

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.102.0
+	github.com/osbuild/images v0.105.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.438 h1:tsLCCUzbLCTL4RZG02y9RuopmGCXp
 github.com/openshift-online/ocm-sdk-go v0.1.438/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.102.0 h1:RQuxZM2w/afCa+Q8mrEG9S60Zbi4j9aSFoFUKFo/Tkk=
-github.com/osbuild/images v0.102.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
+github.com/osbuild/images v0.105.0 h1:KVFKmBhxDzpdZuzLfM84TpfNP40feC5DjRKn+OJcOZ8=
+github.com/osbuild/images v0.105.0/go.mod h1:4bNmMQOVadIKVC1q8zsLO8tdEQFH90zIp+MQBQUnCiE=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2415,12 +2415,12 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	// https://weldr.io/lorax/pylorax.api.html#pylorax.api.v0.v0_compose_start
 	type ComposeRequest struct {
-		BlueprintName string              `json:"blueprint_name"`
-		ComposeType   string              `json:"compose_type"`
-		Size          uint64              `json:"size"`
-		OSTree        ostree.ImageOptions `json:"ostree"`
-		Branch        string              `json:"branch"`
-		Upload        *uploadRequest      `json:"upload"`
+		BlueprintName string               `json:"blueprint_name"`
+		ComposeType   string               `json:"compose_type"`
+		Size          uint64               `json:"size"`
+		OSTree        *ostree.ImageOptions `json:"ostree,omitempty"`
+		Branch        string               `json:"branch"`
+		Upload        *uploadRequest       `json:"upload"`
 	}
 	type ComposeReply struct {
 		BuildID  uuid.UUID `json:"build_id"`
@@ -2549,7 +2549,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 
 	options := distro.ImageOptions{
 		Size:             size,
-		OSTree:           &cr.OSTree,
+		OSTree:           cr.OSTree,
 		PartitioningMode: pm,
 	}
 	options.Facts = &facts.ImageOptions{

--- a/vendor/github.com/osbuild/images/pkg/blueprint/ca_customizations.go
+++ b/vendor/github.com/osbuild/images/pkg/blueprint/ca_customizations.go
@@ -1,5 +1,0 @@
-package blueprint
-
-type CACustomization struct {
-	PEMCerts []string `json:"pem_certs,omitempty" toml:"pem_certs,omitempty"`
-}

--- a/vendor/github.com/osbuild/images/pkg/blueprint/customizations.go
+++ b/vendor/github.com/osbuild/images/pkg/blueprint/customizations.go
@@ -33,7 +33,7 @@ type Customizations struct {
 	Installer          *InstallerCustomization        `json:"installer,omitempty" toml:"installer,omitempty"`
 	RPM                *RPMCustomization              `json:"rpm,omitempty" toml:"rpm,omitempty"`
 	RHSM               *RHSMCustomization             `json:"rhsm,omitempty" toml:"rhsm,omitempty"`
-	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"ca,omitempty"`
+	CACerts            *CACustomization               `json:"cacerts,omitempty" toml:"cacerts,omitempty"`
 }
 
 type IgnitionCustomization struct {
@@ -142,6 +142,10 @@ type OpenSCAPJSONTailoringCustomizations struct {
 type ContainerStorageCustomization struct {
 	// destination is always `containers-storage`, so we won't expose this
 	StoragePath *string `json:"destination-path,omitempty" toml:"destination-path,omitempty"`
+}
+
+type CACustomization struct {
+	PEMCerts []string `json:"pem_certs,omitempty" toml:"pem_certs,omitempty"`
 }
 
 type CustomizationError struct {
@@ -441,16 +445,14 @@ func (c *Customizations) GetRHSM() *RHSMCustomization {
 }
 
 func (c *Customizations) checkCACerts() error {
-	if c == nil {
+	if c == nil || c.CACerts == nil {
 		return nil
 	}
 
-	if c.CACerts != nil {
-		for _, bundle := range c.CACerts.PEMCerts {
-			_, err := cert.ParseCerts(bundle)
-			if err != nil {
-				return err
-			}
+	for _, bundle := range c.CACerts.PEMCerts {
+		_, err := cert.ParseCerts(bundle)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/vendor/github.com/osbuild/images/pkg/disk/btrfs.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/btrfs.go
@@ -155,6 +155,10 @@ func (bs *BtrfsSubvolume) GetMountpoint() string {
 	return bs.Mountpoint
 }
 
+func (bs *BtrfsSubvolume) GetFSFile() string {
+	return bs.GetMountpoint()
+}
+
 func (bs *BtrfsSubvolume) GetFSType() string {
 	return "btrfs"
 }

--- a/vendor/github.com/osbuild/images/pkg/disk/disk.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/disk.go
@@ -56,6 +56,8 @@ const (
 
 	RootPartitionUUID = "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
 
+	SwapPartitionGUID = "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"
+
 	// Extended Boot Loader Partition
 	XBootLDRPartitionGUID = "BC13C2FF-59E6-4262-A352-B275FD6F7172"
 
@@ -70,6 +72,9 @@ const (
 
 	// Partition type ID for ESP on dos
 	DosESPID = "ef00"
+
+	// Partition type ID for swap
+	DosSwapID = "82"
 )
 
 // pt type -> type -> ID mapping for convenience
@@ -80,6 +85,7 @@ var idMap = map[PartitionTableType]map[string]string{
 		"data": DosLinuxTypeID,
 		"esp":  DosESPID,
 		"lvm":  DosLinuxTypeID,
+		"swap": DosSwapID,
 	},
 	PT_GPT: {
 		"bios": BIOSBootPartitionGUID,
@@ -87,6 +93,7 @@ var idMap = map[PartitionTableType]map[string]string{
 		"data": FilesystemDataGUID,
 		"esp":  EFISystemPartitionGUID,
 		"lvm":  LVMPartitionGUID,
+		"swap": SwapPartitionGUID,
 	},
 }
 
@@ -248,13 +255,21 @@ type Mountable interface {
 	// GetMountPoint returns the path of the mount point.
 	GetMountpoint() string
 
-	// GetFSType returns the file system type, e.g. 'xfs'.
-	GetFSType() string
+	FSTabEntity
+}
 
-	// GetFSSpec returns the file system spec information.
+// FSTabEntity describes any entity that can appear in the fstab file.
+type FSTabEntity interface {
+	// FSSpec for the entity (UUID and Label); the first field of fstab(5).
 	GetFSSpec() FSSpec
 
-	// GetFSTabOptions returns options for mounting the entity.
+	// The mount point (target) for a filesystem or "none" for swap areas; the second field of fstab(5).
+	GetFSFile() string
+
+	// The type of the filesystem or swap for swap areas; the third field of fstab(5).
+	GetFSType() string
+
+	// The mount options, freq, and passno for the entity; the fourth fifth, and sixth fields of fstab(5) respectively.
 	GetFSTabOptions() (FSTabOptions, error)
 }
 

--- a/vendor/github.com/osbuild/images/pkg/disk/filesystem.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/filesystem.go
@@ -55,6 +55,10 @@ func (fs *Filesystem) GetMountpoint() string {
 	return fs.Mountpoint
 }
 
+func (fs *Filesystem) GetFSFile() string {
+	return fs.GetMountpoint()
+}
+
 func (fs *Filesystem) GetFSType() string {
 	if fs == nil {
 		return ""

--- a/vendor/github.com/osbuild/images/pkg/disk/swap.go
+++ b/vendor/github.com/osbuild/images/pkg/disk/swap.go
@@ -1,0 +1,77 @@
+package disk
+
+import (
+	"math/rand"
+	"reflect"
+
+	"github.com/google/uuid"
+)
+
+// Swap defines the payload for a swap partition. It's similar to a
+// [Filesystem] but with fewer fields. It is a [PayloadEntity] and also a
+// [FSTabEntity].
+type Swap struct {
+	UUID  string
+	Label string
+
+	// The fourth field of fstab(5); fs_mntops
+	FSTabOptions string
+}
+
+func init() {
+	payloadEntityMap["swap"] = reflect.TypeOf(Swap{})
+}
+
+func (s *Swap) EntityName() string {
+	return "swap"
+}
+
+func (s *Swap) Clone() Entity {
+	if s == nil {
+		return nil
+	}
+
+	return &Swap{
+		UUID:         s.UUID,
+		Label:        s.Label,
+		FSTabOptions: s.FSTabOptions,
+	}
+}
+
+// For swap, the fs_file entry in the fstab is always "none".
+func (s *Swap) GetFSFile() string {
+	return "none"
+}
+
+// For swap, the fs_vfstype entry in the fstab is always "swap".
+func (s *Swap) GetFSType() string {
+	return "swap"
+}
+
+func (s *Swap) GetFSSpec() FSSpec {
+	if s == nil {
+		return FSSpec{}
+	}
+	return FSSpec{
+		UUID:  s.UUID,
+		Label: s.Label,
+	}
+}
+
+// For swap, the Freq and PassNo are always 0.
+func (s *Swap) GetFSTabOptions() (FSTabOptions, error) {
+	if s == nil {
+		return FSTabOptions{}, nil
+	}
+	return FSTabOptions{
+		MntOps: s.FSTabOptions,
+		Freq:   0,
+		PassNo: 0,
+	}, nil
+}
+
+func (s *Swap) GenUUID(rng *rand.Rand) {
+	if s.UUID == "" {
+		s.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()
+	}
+}

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
@@ -377,7 +377,7 @@ func DiskImage(workload workload.Workload,
 	img.Workload = workload
 	img.Compression = t.Compression
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func EdgeRawImage(workload workload.Workload,
 	img.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func EdgeSimplifiedInstallerImage(workload workload.Workload,
 	rawImg.OSName = "rhel-edge"
 
 	// TODO: move generation into LiveImage
-	pt, err := t.GetPartitionTable(customizations.GetFilesystems(), options, rng)
+	pt, err := t.GetPartitionTable(customizations, options, rng)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/azure.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/azure.go
@@ -2,15 +2,17 @@ package rhel10
 
 import (
 	"github.com/osbuild/images/internal/common"
+	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/datasizes"
+	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
-// Azure non-RHEL image type
-func mkAzureImgType() *rhel.ImageType {
+// Azure image type
+func mkAzureImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
 		"vhd",
 		"disk.vhd",
@@ -27,32 +29,57 @@ func mkAzureImgType() *rhel.ImageType {
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultAzureImageConfig
+	it.DefaultImageConfig = defaultAzureImageConfig(rd)
 	it.BasePartitionTables = defaultBasePartitionTables
 
 	return it
 }
 
-// Azure BYOS image type
-func mkAzureByosImgType(rd distro.Distro) *rhel.ImageType {
+// Azure RHEL-internal image type
+func mkAzureInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
 	it := rhel.NewImageType(
-		"vhd",
-		"disk.vhd",
-		"application/x-vhd",
+		"azure-rhui",
+		"disk.vhd.xz",
+		"application/xz",
 		map[string]rhel.PackageSetFunc{
 			rhel.OSPkgsKey: azurePackageSet,
 		},
 		rhel.DiskImage,
 		[]string{"build"},
-		[]string{"os", "image", "vpc"},
-		[]string{"vpc"},
+		[]string{"os", "image", "vpc", "xz"},
+		[]string{"xz"},
 	)
 
+	it.Compression = "xz"
 	it.KernelOptions = defaultAzureKernelOptions
 	it.Bootable = true
-	it.DefaultSize = 4 * datasizes.GibiByte
-	it.DefaultImageConfig = defaultAzureImageConfig
-	it.BasePartitionTables = defaultBasePartitionTables
+	it.DefaultSize = 64 * datasizes.GibiByte
+	it.DefaultImageConfig = defaultAzureImageConfig(rd)
+	it.BasePartitionTables = azureInternalBasePartitionTables
+
+	return it
+}
+
+func mkAzureSapInternalImgType(rd *rhel.Distribution) *rhel.ImageType {
+	it := rhel.NewImageType(
+		"azure-sap-rhui",
+		"disk.vhd.xz",
+		"application/xz",
+		map[string]rhel.PackageSetFunc{
+			rhel.OSPkgsKey: azureSapPackageSet,
+		},
+		rhel.DiskImage,
+		[]string{"build"},
+		[]string{"os", "image", "vpc", "xz"},
+		[]string{"xz"},
+	)
+
+	it.Compression = "xz"
+	it.KernelOptions = defaultAzureKernelOptions
+	it.Bootable = true
+	it.DefaultSize = 64 * datasizes.GibiByte
+	it.DefaultImageConfig = sapAzureImageConfig(rd)
+	it.BasePartitionTables = azureInternalBasePartitionTables
 
 	return it
 }
@@ -143,161 +170,401 @@ func azurePackageSet(t *rhel.ImageType) rpmmd.PackageSet {
 	return azureCommonPackageSet(t)
 }
 
+// Azure SAP image package set
+// Includes the common azure package set, the common SAP packages
+func azureSapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	return azureCommonPackageSet(t).Append(SapPackageSet(t))
+}
+
+// PARTITION TABLES
+func azureInternalBasePartitionTables(t *rhel.ImageType) (disk.PartitionTable, bool) {
+	switch t.Arch().Name() {
+	case arch.ARCH_X86_64.String():
+		return disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Size: 64 * datasizes.GibiByte,
+			Partitions: []disk.Partition{
+				{
+					Size: 500 * datasizes.MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				// NB: we currently don't support /boot on LVM
+				{
+					Size: 1 * datasizes.GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.FilesystemDataUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Size:     2 * datasizes.MebiByte,
+					Bootable: true,
+					Type:     disk.BIOSBootPartitionGUID,
+					UUID:     disk.BIOSBootPartitionUUID,
+				},
+				{
+					Type: disk.LVMPartitionGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.LVMVolumeGroup{
+						Name:        "rootvg",
+						Description: "built with lvm2 and osbuild",
+						LogicalVolumes: []disk.LVMLogicalVolume{
+							{
+								Size: 1 * datasizes.GibiByte,
+								Name: "homelv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "home",
+									Mountpoint:   "/home",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 2 * datasizes.GibiByte,
+								Name: "rootlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "root",
+									Mountpoint:   "/",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 2 * datasizes.GibiByte,
+								Name: "tmplv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "tmp",
+									Mountpoint:   "/tmp",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 10 * datasizes.GibiByte,
+								Name: "usrlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "usr",
+									Mountpoint:   "/usr",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 10 * datasizes.GibiByte,
+								Name: "varlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "var",
+									Mountpoint:   "/var",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+						},
+					},
+				},
+			},
+		}, true
+	case arch.ARCH_AARCH64.String():
+		return disk.PartitionTable{
+			UUID: "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+			Type: disk.PT_GPT,
+			Size: 64 * datasizes.GibiByte,
+			Partitions: []disk.Partition{
+				{
+					Size: 500 * datasizes.MebiByte,
+					Type: disk.EFISystemPartitionGUID,
+					UUID: disk.EFISystemPartitionUUID,
+					Payload: &disk.Filesystem{
+						Type:         "vfat",
+						UUID:         disk.EFIFilesystemUUID,
+						Mountpoint:   "/boot/efi",
+						FSTabOptions: "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+						FSTabFreq:    0,
+						FSTabPassNo:  2,
+					},
+				},
+				// NB: we currently don't support /boot on LVM
+				{
+					Size: 1 * datasizes.GibiByte,
+					Type: disk.FilesystemDataGUID,
+					UUID: disk.FilesystemDataUUID,
+					Payload: &disk.Filesystem{
+						Type:         "xfs",
+						Mountpoint:   "/boot",
+						FSTabOptions: "defaults",
+						FSTabFreq:    0,
+						FSTabPassNo:  0,
+					},
+				},
+				{
+					Type: disk.LVMPartitionGUID,
+					UUID: disk.RootPartitionUUID,
+					Payload: &disk.LVMVolumeGroup{
+						Name:        "rootvg",
+						Description: "built with lvm2 and osbuild",
+						LogicalVolumes: []disk.LVMLogicalVolume{
+							{
+								Size: 1 * datasizes.GibiByte,
+								Name: "homelv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "home",
+									Mountpoint:   "/home",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 2 * datasizes.GibiByte,
+								Name: "rootlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "root",
+									Mountpoint:   "/",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 2 * datasizes.GibiByte,
+								Name: "tmplv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "tmp",
+									Mountpoint:   "/tmp",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 10 * datasizes.GibiByte,
+								Name: "usrlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "usr",
+									Mountpoint:   "/usr",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+							{
+								Size: 10 * datasizes.GibiByte,
+								Name: "varlv",
+								Payload: &disk.Filesystem{
+									Type:         "xfs",
+									Label:        "var",
+									Mountpoint:   "/var",
+									FSTabOptions: "defaults",
+									FSTabFreq:    0,
+									FSTabPassNo:  0,
+								},
+							},
+						},
+					},
+				},
+			},
+		}, true
+	default:
+		return disk.PartitionTable{}, false
+	}
+}
+
 // IMAGE CONFIG
 
 // use loglevel=3 as described in the RHEL documentation and used in existing RHEL images built by MSFT
 const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
 
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
-var defaultAzureImageConfig = &distro.ImageConfig{
-	Timezone: common.ToPtr("Etc/UTC"),
-	Locale:   common.ToPtr("en_US.UTF-8"),
-	Keyboard: &osbuild.KeymapStageOptions{
-		Keymap: "us",
-		X11Keymap: &osbuild.X11KeymapOptions{
-			Layouts: []string{"us"},
-		},
-	},
-	Sysconfig: []*osbuild.SysconfigStageOptions{
-		{
-			Kernel: &osbuild.SysconfigKernelOptions{
-				UpdateDefault: true,
-				DefaultKernel: "kernel-core",
-			},
-			Network: &osbuild.SysconfigNetworkOptions{
-				Networking: true,
-				NoZeroConf: true,
+func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
+	ic := &distro.ImageConfig{
+		Timezone: common.ToPtr("Etc/UTC"),
+		Locale:   common.ToPtr("en_US.UTF-8"),
+		Keyboard: &osbuild.KeymapStageOptions{
+			Keymap: "us",
+			X11Keymap: &osbuild.X11KeymapOptions{
+				Layouts: []string{"us"},
 			},
 		},
-	},
-	EnabledServices: []string{
-		"firewalld",
-		"nm-cloud-setup.service",
-		"nm-cloud-setup.timer",
-		"sshd",
-		"waagent",
-	},
-	SshdConfig: &osbuild.SshdConfigStageOptions{
-		Config: osbuild.SshdConfigConfig{
-			ClientAliveInterval: common.ToPtr(180),
-		},
-	},
-	Modprobe: []*osbuild.ModprobeStageOptions{
-		{
-			Filename: "blacklist-amdgpu.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
-			},
-		},
-		{
-			Filename: "blacklist-intel-cstate.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
-			},
-		},
-		{
-			Filename: "blacklist-floppy.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("floppy"),
-			},
-		},
-		{
-			Filename: "blacklist-nouveau.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
-				osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
-			},
-		},
-		{
-			Filename: "blacklist-skylake-edac.conf",
-			Commands: osbuild.ModprobeConfigCmdList{
-				osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
-			},
-		},
-	},
-	CloudInit: []*osbuild.CloudInitStageOptions{
-		{
-			Filename: "10-azure-kvp.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Reporting: &osbuild.CloudInitConfigReporting{
-					Logging: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "log",
-					},
-					Telemetry: &osbuild.CloudInitConfigReportingHandlers{
-						Type: "hyperv",
-					},
+		Sysconfig: []*osbuild.SysconfigStageOptions{
+			{
+				Kernel: &osbuild.SysconfigKernelOptions{
+					UpdateDefault: true,
+					DefaultKernel: "kernel-core",
+				},
+				Network: &osbuild.SysconfigNetworkOptions{
+					Networking: true,
+					NoZeroConf: true,
 				},
 			},
 		},
-		{
-			Filename: "91-azure_datasource.cfg",
-			Config: osbuild.CloudInitConfigFile{
-				Datasource: &osbuild.CloudInitConfigDatasource{
-					Azure: &osbuild.CloudInitConfigDatasourceAzure{
-						ApplyNetworkConfig: false,
+		EnabledServices: []string{
+			"firewalld",
+			"nm-cloud-setup.service",
+			"nm-cloud-setup.timer",
+			"sshd",
+			"waagent",
+		},
+		SshdConfig: &osbuild.SshdConfigStageOptions{
+			Config: osbuild.SshdConfigConfig{
+				ClientAliveInterval: common.ToPtr(180),
+			},
+		},
+		Modprobe: []*osbuild.ModprobeStageOptions{
+			{
+				Filename: "blacklist-amdgpu.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+				},
+			},
+			{
+				Filename: "blacklist-intel-cstate.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("intel_cstate"),
+				},
+			},
+			{
+				Filename: "blacklist-floppy.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("floppy"),
+				},
+			},
+			{
+				Filename: "blacklist-nouveau.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
+					osbuild.NewModprobeConfigCmdBlacklist("lbm-nouveau"),
+				},
+			},
+			{
+				Filename: "blacklist-skylake-edac.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("skx_edac"),
+				},
+			},
+		},
+		CloudInit: []*osbuild.CloudInitStageOptions{
+			{
+				Filename: "10-azure-kvp.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Reporting: &osbuild.CloudInitConfigReporting{
+						Logging: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "log",
+						},
+						Telemetry: &osbuild.CloudInitConfigReportingHandlers{
+							Type: "hyperv",
+						},
 					},
 				},
-				DatasourceList: []string{
-					"Azure",
+			},
+			{
+				Filename: "91-azure_datasource.cfg",
+				Config: osbuild.CloudInitConfigFile{
+					Datasource: &osbuild.CloudInitConfigDatasource{
+						Azure: &osbuild.CloudInitConfigDatasourceAzure{
+							ApplyNetworkConfig: false,
+						},
+					},
+					DatasourceList: []string{
+						"Azure",
+					},
 				},
 			},
 		},
-	},
-	PwQuality: &osbuild.PwqualityConfStageOptions{
-		Config: osbuild.PwqualityConfConfig{
-			Minlen:   common.ToPtr(6),
-			Minclass: common.ToPtr(3),
-			Dcredit:  common.ToPtr(0),
-			Ucredit:  common.ToPtr(0),
-			Lcredit:  common.ToPtr(0),
-			Ocredit:  common.ToPtr(0),
-		},
-	},
-	WAAgentConfig: &osbuild.WAAgentConfStageOptions{
-		Config: osbuild.WAAgentConfig{
-			RDFormat:     common.ToPtr(false),
-			RDEnableSwap: common.ToPtr(false),
-		},
-	},
-	Grub2Config: &osbuild.GRUB2Config{
-		DisableRecovery: common.ToPtr(true),
-		DisableSubmenu:  common.ToPtr(true),
-		Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
-		Terminal:        []string{"serial", "console"},
-		Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
-		Timeout:         10,
-		TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
-	},
-	UdevRules: &osbuild.UdevRulesStageOptions{
-		Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
-		Rules: osbuild.UdevRules{
-			osbuild.UdevRuleComment{
-				Comment: []string{
-					"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
-					"This interface is transparently bonded to the synthetic interface,",
-					"so NetworkManager should just ignore any SRIOV interfaces.",
-				},
-			},
-			osbuild.NewUdevRule(
-				[]osbuild.UdevKV{
-					{K: "SUBSYSTEM", O: "==", V: "net"},
-					{K: "DRIVERS", O: "==", V: "hv_pci"},
-					{K: "ACTION", O: "==", V: "add"},
-					{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
-				},
-			),
-		},
-	},
-	SystemdUnit: []*osbuild.SystemdUnitStageOptions{
-		{
-			Unit:   "nm-cloud-setup.service",
-			Dropin: "10-rh-enable-for-azure.conf",
-			Config: osbuild.SystemdServiceUnitDropin{
-				Service: &osbuild.SystemdUnitServiceSection{
-					Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_AZURE", Value: "yes"}},
-				},
+		PwQuality: &osbuild.PwqualityConfStageOptions{
+			Config: osbuild.PwqualityConfConfig{
+				Minlen:   common.ToPtr(6),
+				Minclass: common.ToPtr(3),
+				Dcredit:  common.ToPtr(0),
+				Ucredit:  common.ToPtr(0),
+				Lcredit:  common.ToPtr(0),
+				Ocredit:  common.ToPtr(0),
 			},
 		},
-	},
-	DefaultTarget: common.ToPtr("multi-user.target"),
+		WAAgentConfig: &osbuild.WAAgentConfStageOptions{
+			Config: osbuild.WAAgentConfig{
+				RDFormat:     common.ToPtr(false),
+				RDEnableSwap: common.ToPtr(false),
+			},
+		},
+		Grub2Config: &osbuild.GRUB2Config{
+			DisableRecovery: common.ToPtr(true),
+			DisableSubmenu:  common.ToPtr(true),
+			Distributor:     "$(sed 's, release .*$,,g' /etc/system-release)",
+			Terminal:        []string{"serial", "console"},
+			Serial:          "serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1",
+			Timeout:         10,
+			TimeoutStyle:    osbuild.GRUB2ConfigTimeoutStyleCountdown,
+		},
+		UdevRules: &osbuild.UdevRulesStageOptions{
+			Filename: "/etc/udev/rules.d/68-azure-sriov-nm-unmanaged.rules",
+			Rules: osbuild.UdevRules{
+				osbuild.UdevRuleComment{
+					Comment: []string{
+						"Accelerated Networking on Azure exposes a new SRIOV interface to the VM.",
+						"This interface is transparently bonded to the synthetic interface,",
+						"so NetworkManager should just ignore any SRIOV interfaces.",
+					},
+				},
+				osbuild.NewUdevRule(
+					[]osbuild.UdevKV{
+						{K: "SUBSYSTEM", O: "==", V: "net"},
+						{K: "DRIVERS", O: "==", V: "hv_pci"},
+						{K: "ACTION", O: "==", V: "add"},
+						{K: "ENV", A: "NM_UNMANAGED", O: "=", V: "1"},
+					},
+				),
+			},
+		},
+		SystemdUnit: []*osbuild.SystemdUnitStageOptions{
+			{
+				Unit:   "nm-cloud-setup.service",
+				Dropin: "10-rh-enable-for-azure.conf",
+				Config: osbuild.SystemdServiceUnitDropin{
+					Service: &osbuild.SystemdUnitServiceSection{
+						Environment: []osbuild.EnvironmentVariable{{Key: "NM_CLOUD_SETUP_AZURE", Value: "yes"}},
+					},
+				},
+			},
+		},
+		DefaultTarget: common.ToPtr("multi-user.target"),
+	}
+
+	if rd.IsRHEL() {
+		ic.GPGKeyFiles = append(ic.GPGKeyFiles, "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release")
+	}
+
+	return ic
+}
+
+func sapAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
+	return sapImageConfig(rd.OsVersion()).InheritFrom(defaultAzureImageConfig(rd))
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/options.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/options.go
@@ -2,7 +2,6 @@ package rhel10
 
 import (
 	"fmt"
-	"log"
 
 	"slices"
 
@@ -27,9 +26,24 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	}
 
 	mountpoints := customizations.GetFilesystems()
-
-	err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies)
+	partitioning, err := customizations.GetPartitioning()
 	if err != nil {
+		return nil, err
+	}
+
+	if err := blueprint.CheckMountpointsPolicy(mountpoints, policies.MountpointPolicies); err != nil {
+		return warnings, err
+	}
+
+	if len(mountpoints) > 0 && partitioning != nil {
+		return nil, fmt.Errorf("partitioning customizations cannot be used with custom filesystems (mountpoints)")
+	}
+
+	if err := blueprint.CheckDiskMountpointsPolicy(partitioning, policies.MountpointPolicies); err != nil {
+		return warnings, err
+	}
+
+	if err := partitioning.ValidateLayoutConstraints(); err != nil {
 		return warnings, err
 	}
 
@@ -76,9 +90,7 @@ func checkOptions(t *rhel.ImageType, bp *blueprint.Blueprint, options distro.Ima
 	}
 
 	if customizations.GetFIPS() && !common.IsBuildHostFIPSEnabled() {
-		w := fmt.Sprintln(common.FIPSEnabledImageWarning)
-		log.Print(w)
-		warnings = append(warnings, w)
+		warnings = append(warnings, fmt.Sprintln(common.FIPSEnabledImageWarning))
 	}
 
 	instCust, err := customizations.GetInstaller()

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/sap.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/sap.go
@@ -1,0 +1,174 @@
+package rhel10
+
+import (
+	"github.com/osbuild/images/pkg/distro"
+	"github.com/osbuild/images/pkg/distro/rhel"
+	"github.com/osbuild/images/pkg/osbuild"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+// sapImageConfig returns the SAP specific ImageConfig data
+func sapImageConfig(osVersion string) *distro.ImageConfig {
+	return &distro.ImageConfig{
+		SELinuxConfig: &osbuild.SELinuxConfigStageOptions{
+			State: osbuild.SELinuxStatePermissive,
+		},
+		// RHBZ#1960617
+		Tuned: osbuild.NewTunedStageOptions("sap-hana"),
+		// RHBZ#1959979
+		Tmpfilesd: []*osbuild.TmpfilesdStageOptions{
+			osbuild.NewTmpfilesdStageOptions("sap.conf",
+				[]osbuild.TmpfilesdConfigLine{
+					{
+						Type: "x",
+						Path: "/tmp/.sap*",
+					},
+					{
+						Type: "x",
+						Path: "/tmp/.hdb*lock",
+					},
+					{
+						Type: "x",
+						Path: "/tmp/.trex*lock",
+					},
+				},
+			),
+		},
+		// RHBZ#1959963
+		PamLimitsConf: []*osbuild.PamLimitsConfStageOptions{
+			osbuild.NewPamLimitsConfStageOptions("99-sap.conf",
+				[]osbuild.PamLimitsConfigLine{
+					{
+						Domain: "@sapsys",
+						Type:   osbuild.PamLimitsTypeHard,
+						Item:   osbuild.PamLimitsItemNofile,
+						Value:  osbuild.PamLimitsValueInt(1048576),
+					},
+					{
+						Domain: "@sapsys",
+						Type:   osbuild.PamLimitsTypeSoft,
+						Item:   osbuild.PamLimitsItemNofile,
+						Value:  osbuild.PamLimitsValueInt(1048576),
+					},
+					{
+						Domain: "@dba",
+						Type:   osbuild.PamLimitsTypeHard,
+						Item:   osbuild.PamLimitsItemNofile,
+						Value:  osbuild.PamLimitsValueInt(1048576),
+					},
+					{
+						Domain: "@dba",
+						Type:   osbuild.PamLimitsTypeSoft,
+						Item:   osbuild.PamLimitsItemNofile,
+						Value:  osbuild.PamLimitsValueInt(1048576),
+					},
+					{
+						Domain: "@sapsys",
+						Type:   osbuild.PamLimitsTypeHard,
+						Item:   osbuild.PamLimitsItemNproc,
+						Value:  osbuild.PamLimitsValueUnlimited,
+					},
+					{
+						Domain: "@sapsys",
+						Type:   osbuild.PamLimitsTypeSoft,
+						Item:   osbuild.PamLimitsItemNproc,
+						Value:  osbuild.PamLimitsValueUnlimited,
+					},
+					{
+						Domain: "@dba",
+						Type:   osbuild.PamLimitsTypeHard,
+						Item:   osbuild.PamLimitsItemNproc,
+						Value:  osbuild.PamLimitsValueUnlimited,
+					},
+					{
+						Domain: "@dba",
+						Type:   osbuild.PamLimitsTypeSoft,
+						Item:   osbuild.PamLimitsItemNproc,
+						Value:  osbuild.PamLimitsValueUnlimited,
+					},
+				},
+			),
+		},
+		// RHBZ#1959962
+		Sysctld: []*osbuild.SysctldStageOptions{
+			osbuild.NewSysctldStageOptions("sap.conf",
+				[]osbuild.SysctldConfigLine{
+					{
+						Key:   "kernel.pid_max",
+						Value: "4194304",
+					},
+					{
+						Key:   "vm.max_map_count",
+						Value: "2147483647",
+					},
+				},
+			),
+		},
+		// E4S/EUS
+		DNFConfig: []*osbuild.DNFConfigStageOptions{
+			osbuild.NewDNFConfigStageOptions(
+				[]osbuild.DNFVariable{
+					{
+						Name:  "releasever",
+						Value: osVersion,
+					},
+				},
+				nil,
+			),
+		},
+	}
+}
+
+func SapPackageSet(t *rhel.ImageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			// RHBZ#2076763
+			"@Server",
+			// SAP System Roles
+			// https://access.redhat.com/sites/default/files/attachments/rhel_system_roles_for_sap_1.pdf
+			"ansible-core",
+			"rhel-system-roles-sap",
+			// RHBZ#1959813
+			"bind-utils",
+			"nfs-utils",
+			"tcsh",
+			// RHBZ#1959955
+			"uuidd",
+			// RHBZ#1959923
+			"cairo",
+			"expect",
+			"graphviz",
+			//"gtk2", // gtk2 is not available in RHEL-10
+			"iptraf-ng",
+			"krb5-workstation",
+			"libaio",
+			"libatomic",
+			"libicu",
+			"libtool-ltdl",
+			"lm_sensors",
+			"net-tools",
+			"numactl",
+			"PackageKit-gtk3-module",
+			"xorg-x11-xauth",
+			// RHBZ#1960617
+			"tuned-profiles-sap-hana",
+			// RHBZ#1961168
+			"libnsl",
+		},
+		Exclude: []string{
+			"iwl1000-firmware",
+			"iwl100-firmware",
+			"iwl105-firmware",
+			"iwl135-firmware",
+			"iwl2000-firmware",
+			"iwl2030-firmware",
+			"iwl3160-firmware",
+			"iwl5000-firmware",
+			"iwl5150-firmware",
+			"iwl6000g2a-firmware",
+			"iwl6000g2b-firmware",
+			"iwl6050-firmware",
+			"iwl7260-firmware",
+		},
+	}
+}

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel8/distro.go
@@ -115,6 +115,15 @@ func newDistro(name string, minor int) *rhel.Distribution {
 			ImageFormat: platform.FORMAT_RAW,
 		},
 	}
+
+	// Keep the RHEL EC2 x86_64 images before 8.9 BIOS-only for backward compatibility.
+	// RHEL-internal EC2 images and RHEL AMI images are kept intentionally in sync
+	// with regard to not supporting hybrid boot mode before RHEL version 8.9.
+	// The partitioning table for these reflects that and is also intentionally in sync.
+	if rd.IsRHEL() && common.VersionLessThan(rd.OsVersion(), "8.9") {
+		ec2X86Platform.UEFIVendor = ""
+	}
+
 	x86_64.AddImageTypes(
 		ec2X86Platform,
 		mkAmiImgTypeX86_64(),
@@ -341,16 +350,6 @@ func newDistro(name string, minor int) *rhel.Distribution {
 			mkAzureByosImgType(),
 			mkAzureSapRhuiImgType(rd),
 		)
-
-		// keep the RHEL EC2 x86_64 images before 8.9 BIOS-only for backward compatibility
-		if common.VersionLessThan(rd.OsVersion(), "8.9") {
-			ec2X86Platform = &platform.X86{
-				BIOS: true,
-				BasePlatform: platform.BasePlatform{
-					ImageFormat: platform.FORMAT_RAW,
-				},
-			}
-		}
 
 		// add ec2 image types to RHEL distro only
 		x86_64.AddImageTypes(

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/distro.go
@@ -202,6 +202,15 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 			ImageFormat: platform.FORMAT_RAW,
 		},
 	}
+
+	// Keep the RHEL EC2 x86_64 images before 9.3 BIOS-only for backward compatibility.
+	// RHEL-internal EC2 images and RHEL AMI images are kept intentionally in sync
+	// with regard to not supporting hybrid boot mode before RHEL version 9.3.
+	// The partitioning table for these reflects that and is also intentionally in sync.
+	if rd.IsRHEL() && common.VersionLessThan(rd.OsVersion(), "9.3") {
+		ec2X86Platform.UEFIVendor = ""
+	}
+
 	x86_64.AddImageTypes(
 		ec2X86Platform,
 		mkAMIImgTypeX86_64(),
@@ -336,16 +345,6 @@ func newDistro(name string, major, minor int) *rhel.Distribution {
 		aarch64.AddImageTypes(azureAarch64Platform, mkAzureInternalImgType(rd))
 
 		x86_64.AddImageTypes(azureX64Platform, mkAzureSapInternalImgType(rd))
-
-		// keep the RHEL EC2 x86_64 images before 9.3 BIOS-only for backward compatibility
-		if common.VersionLessThan(rd.OsVersion(), "9.3") {
-			ec2X86Platform = &platform.X86{
-				BIOS: true,
-				BasePlatform: platform.BasePlatform{
-					ImageFormat: platform.FORMAT_RAW,
-				},
-			}
-		}
 
 		// add ec2 image types to RHEL distro only
 		x86_64.AddImageTypes(ec2X86Platform, mkEc2ImgTypeX86_64(), mkEc2HaImgTypeX86_64(), mkEC2SapImgTypeX86_64(rd.OsVersion()))

--- a/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer_iso_tree.go
@@ -303,7 +303,7 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 		Size:     fmt.Sprintf("%d", p.PartitionTable.Size),
 	}))
 
-	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, filename) {
+	for _, stage := range osbuild.GenFsStages(p.PartitionTable, filename) {
 		pipeline.AddStage(stage)
 	}
 

--- a/vendor/github.com/osbuild/images/pkg/manifest/coi_iso_tree.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/coi_iso_tree.go
@@ -111,7 +111,7 @@ func (p *CoreOSISOTree) serialize() osbuild.Pipeline {
 		Size:     fmt.Sprintf("%d", p.PartitionTable.Size),
 	}))
 
-	for _, stage := range osbuild.GenMkfsStages(p.PartitionTable, filename) {
+	for _, stage := range osbuild.GenFsStages(p.PartitionTable, filename) {
 		pipeline.AddStage(stage)
 	}
 

--- a/vendor/github.com/osbuild/images/pkg/osbuild/btrfs_subvol_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/btrfs_subvol_stage.go
@@ -1,9 +1,5 @@
 package osbuild
 
-import (
-	"github.com/osbuild/images/pkg/disk"
-)
-
 type BtrfsSubVolOptions struct {
 	Subvolumes []BtrfsSubVol `json:"subvolumes"`
 }
@@ -21,53 +17,4 @@ func NewBtrfsSubVol(options *BtrfsSubVolOptions, devices *map[string]Device, mou
 		Devices: *devices,
 		Mounts:  *mounts,
 	}
-}
-
-func GenBtrfsSubVolStage(filename string, pt *disk.PartitionTable) *Stage {
-	var subvolumes []BtrfsSubVol
-
-	genStage := func(mnt disk.Mountable, path []disk.Entity) error {
-		if mnt.GetFSType() != "btrfs" {
-			return nil
-		}
-
-		btrfs := mnt.(*disk.BtrfsSubvolume)
-		subvolumes = append(subvolumes, BtrfsSubVol{Name: "/" + btrfs.Name})
-
-		return nil
-	}
-
-	_ = pt.ForEachMountable(genStage)
-
-	if len(subvolumes) == 0 {
-		return nil
-	}
-
-	devices, mounts := genBtrfsMountDevices(filename, pt)
-
-	return NewBtrfsSubVol(&BtrfsSubVolOptions{subvolumes}, devices, mounts)
-}
-
-func genBtrfsMountDevices(filename string, pt *disk.PartitionTable) (*map[string]Device, *[]Mount) {
-	devices := make(map[string]Device, len(pt.Partitions))
-	mounts := make([]Mount, 0, len(pt.Partitions))
-	genMounts := func(ent disk.Entity, path []disk.Entity) error {
-		if _, isBtrfs := ent.(*disk.Btrfs); !isBtrfs {
-			return nil
-		}
-
-		stageDevices, name := getDevices(path, filename, false)
-
-		mounts = append(mounts, *NewBtrfsMount(name, name, "/", "", ""))
-
-		// update devices map with new elements from stageDevices
-		for devName := range stageDevices {
-			devices[devName] = stageDevices[devName]
-		}
-		return nil
-	}
-
-	_ = pt.ForEachEntity(genMounts)
-
-	return &devices, &mounts
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/device.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/device.go
@@ -162,6 +162,8 @@ func deviceName(p disk.Entity) string {
 		return payload.Name
 	case *disk.Btrfs:
 		return "btrfs-" + payload.UUID[:4]
+	case *disk.Swap:
+		return "swap-" + payload.UUID[:4]
 	}
 	panic(fmt.Sprintf("unsupported device type in deviceName: '%T'", p))
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/disk.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/disk.go
@@ -99,14 +99,10 @@ func GenImagePrepareStages(pt *disk.PartitionTable, filename string, partTool Pa
 	s := GenDeviceCreationStages(pt, filename)
 	stages = append(stages, s...)
 
-	// Generate all the filesystems on partitons and devices
-	s = GenMkfsStages(pt, filename)
+	// Generate all the filesystems, subvolumes, and swap areas on partitons
+	// and devices
+	s = GenFsStages(pt, filename)
 	stages = append(stages, s...)
-
-	subvolStage := GenBtrfsSubVolStage(filename, pt)
-	if subvolStage != nil {
-		stages = append(stages, subvolStage)
-	}
 
 	return stages
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/fstab_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/fstab_stage.go
@@ -58,13 +58,13 @@ func (options *FSTabStageOptions) AddFilesystem(id string, vfsType string, path 
 
 func NewFSTabStageOptions(pt *disk.PartitionTable) (*FSTabStageOptions, error) {
 	var options FSTabStageOptions
-	genOption := func(mnt disk.Mountable, path []disk.Entity) error {
+	genOption := func(mnt disk.FSTabEntity, path []disk.Entity) error {
 		fsSpec := mnt.GetFSSpec()
 		fsOptions, err := mnt.GetFSTabOptions()
 		if err != nil {
 			return err
 		}
-		options.AddFilesystem(fsSpec.UUID, mnt.GetFSType(), mnt.GetMountpoint(), fsOptions.MntOps, fsOptions.Freq, fsOptions.PassNo)
+		options.AddFilesystem(fsSpec.UUID, mnt.GetFSType(), mnt.GetFSFile(), fsOptions.MntOps, fsOptions.Freq, fsOptions.PassNo)
 		return nil
 	}
 
@@ -72,7 +72,7 @@ func NewFSTabStageOptions(pt *disk.PartitionTable) (*FSTabStageOptions, error) {
 		return fmt.Sprintf("%d%s", fs.PassNo, fs.Path)
 	}
 
-	err := pt.ForEachMountable(genOption)
+	err := pt.ForEachFSTabEntity(genOption)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/mkfs_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/mkfs_stage.go
@@ -7,81 +7,96 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 )
 
-// GenMkfsStages generates a list of org.mkfs.* stages based on a
-// partition table description for a single device node
-// filename is the path to the underlying image file (to be used as a source for the loopback device)
-func GenMkfsStages(pt *disk.PartitionTable, filename string) []*Stage {
+// GenFsStages generates a list of stages that create the filesystem and other
+// related entities. Specifically, it creates stages for:
+//   - org.osbuild.mkfs.*: for all filesystems and btrfs volumes
+//   - org.osbuild.btrfs.subvol: for all btrfs subvolumes
+//   - org.osbuild.mkswap: for swap areas
+func GenFsStages(pt *disk.PartitionTable, filename string) []*Stage {
 	stages := make([]*Stage, 0, len(pt.Partitions))
 
-	processedBtrfsPartitions := make(map[string]bool)
-	genStage := func(mnt disk.Mountable, path []disk.Entity) error {
-		t := mnt.GetFSType()
-		var stage *Stage
+	genStage := func(ent disk.Entity, path []disk.Entity) error {
+		switch e := ent.(type) {
+		case *disk.Filesystem:
+			// TODO: extract last device renaming into helper
+			stageDevices, lastName := getDevices(path, filename, true)
 
-		stageDevices, lastName := getDevices(path, filename, true)
+			// The last device in the chain must be named "device", because that's
+			// the device that mkfs stages run on. See the stage schemas for
+			// reference.
+			lastDevice := stageDevices[lastName]
+			delete(stageDevices, lastName)
+			stageDevices["device"] = lastDevice
 
-		// The last device in the chain must be named "device", because that's the device that mkfs stages run on.
-		// See their schema for reference.
-		lastDevice := stageDevices[lastName]
-		delete(stageDevices, lastName)
-		stageDevices["device"] = lastDevice
+			switch e.GetFSType() {
+			case "xfs":
+				options := &MkfsXfsStageOptions{
+					UUID:  e.UUID,
+					Label: e.Label,
+				}
+				stages = append(stages, NewMkfsXfsStage(options, stageDevices))
+			case "vfat":
+				options := &MkfsFATStageOptions{
+					VolID: strings.Replace(e.UUID, "-", "", -1),
+				}
+				stages = append(stages, NewMkfsFATStage(options, stageDevices))
+			case "ext4":
+				options := &MkfsExt4StageOptions{
+					UUID:  e.UUID,
+					Label: e.Label,
+				}
+				stages = append(stages, NewMkfsExt4Stage(options, stageDevices))
+			default:
+				panic(fmt.Sprintf("unknown fs type: %s", e.GetFSType()))
+			}
+		case *disk.Btrfs:
+			stageDevices, lastName := getDevices(path, filename, true)
 
-		fsSpec := mnt.GetFSSpec()
-		switch t {
-		case "xfs":
-			options := &MkfsXfsStageOptions{
-				UUID:  fsSpec.UUID,
-				Label: fsSpec.Label,
-			}
-			stage = NewMkfsXfsStage(options, stageDevices)
-		case "vfat":
-			options := &MkfsFATStageOptions{
-				VolID: strings.Replace(fsSpec.UUID, "-", "", -1),
-			}
-			stage = NewMkfsFATStage(options, stageDevices)
-		case "btrfs":
-			// the disk library allows only subvolumes as Mountable, so we need to find the underlying btrfs partition
-			// and mkfs it
-			btrfsPart := findBtrfsPartition(path)
-			if btrfsPart == nil {
-				panic(fmt.Sprintf("found btrfs subvolume without btrfs partition: %s", mnt.GetMountpoint()))
-			}
-
-			// btrfs partitions can be shared between multiple subvolumes, so we need to make sure we only create
-			// one
-			if processedBtrfsPartitions[btrfsPart.UUID] {
-				return nil
-			}
-			processedBtrfsPartitions[btrfsPart.UUID] = true
+			// The last device in the chain must be named "device", because that's
+			// the device that mkfs stages run on. See the stage schemas for
+			// reference.
+			lastDevice := stageDevices[lastName]
+			delete(stageDevices, lastName)
+			stageDevices["device"] = lastDevice
 
 			options := &MkfsBtrfsStageOptions{
-				UUID:  btrfsPart.UUID,
-				Label: btrfsPart.Label,
+				UUID:  e.UUID,
+				Label: e.Label,
 			}
-			stage = NewMkfsBtrfsStage(options, stageDevices)
-		case "ext4":
-			options := &MkfsExt4StageOptions{
-				UUID:  fsSpec.UUID,
-				Label: fsSpec.Label,
+			stages = append(stages, NewMkfsBtrfsStage(options, stageDevices))
+			// Handle subvolumes here directly instead of collecting them in
+			// their own case, since we already have access to the parent volume.
+			subvolumes := make([]BtrfsSubVol, len(e.Subvolumes))
+			for idx, subvol := range e.Subvolumes {
+				subvolumes[idx] = BtrfsSubVol{Name: "/" + strings.TrimLeft(subvol.Name, "/")}
 			}
-			stage = NewMkfsExt4Stage(options, stageDevices)
-		default:
-			panic("unknown fs type " + t)
-		}
-		stages = append(stages, stage)
 
+			// Subvolume creation does not require locking the device, nor does
+			// it require the renaming to "device", but let's reuse the volume
+			// device for convenience
+			mount := *NewBtrfsMount("volume", "device", "/", "", "")
+			stages = append(stages, NewBtrfsSubVol(&BtrfsSubVolOptions{subvolumes}, &stageDevices, &[]Mount{mount}))
+		case *disk.Swap:
+			// TODO: extract last device renaming into helper
+			stageDevices, lastName := getDevices(path, filename, true)
+
+			// The last device in the chain must be named "device", because that's
+			// the device that the mkswap stage runs on. See the stage schema
+			// for reference.
+			lastDevice := stageDevices[lastName]
+			delete(stageDevices, lastName)
+			stageDevices["device"] = lastDevice
+
+			options := &MkswapStageOptions{
+				UUID:  e.UUID,
+				Label: e.Label,
+			}
+			stages = append(stages, NewMkswapStage(options, stageDevices))
+		}
 		return nil
 	}
 
-	_ = pt.ForEachMountable(genStage) // genStage always returns nil
+	_ = pt.ForEachEntity(genStage) // genStage always returns nil
 	return stages
-}
 
-func findBtrfsPartition(path []disk.Entity) *disk.Btrfs {
-	for _, e := range path {
-		if btrfsPartition, ok := e.(*disk.Btrfs); ok {
-			return btrfsPartition
-		}
-	}
-	return nil
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/mkswap_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/mkswap_stage.go
@@ -1,0 +1,16 @@
+package osbuild
+
+type MkswapStageOptions struct {
+	UUID  string `json:"uuid"`
+	Label string `json:"label,omitempty"`
+}
+
+func (MkswapStageOptions) isStageOptions() {}
+
+func NewMkswapStage(options *MkswapStageOptions, devices map[string]Device) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.mkswap",
+		Options: options,
+		Devices: devices,
+	}
+}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/monitor.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/monitor.go
@@ -1,0 +1,180 @@
+package osbuild
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// Status is a high level aggregation of the low-level osbuild monitor
+// messages. It is more structured and meant to be used by UI frontends.
+//
+// this is intentionally minimal at the beginning until we figure
+// out the best API, exposing the jsonseq direct feels too messy
+// and based on what we learn here we may consider tweaking
+// the osbuild progress
+type Status struct {
+	// Trace contains a single log line, usually very low-level or
+	// stage output but useful for e.g. bug reporting. Should in
+	// general not be displayed to the user but the concatenation
+	// of all "trace" lines should give the same information as
+	// running osbuild on a terminal
+	Trace string
+
+	// Message contains a high level user-visible message about
+	// e.g. a startus change
+	Message string
+
+	// Progress contains the current progress.
+	Progress *Progress
+
+	// Timestamp contains the timestamp the message was recieved in
+	Timestamp time.Time
+}
+
+// Progress provides progress information from an osbuild build.
+// Each progress can have an arbitrary number of sub-progress information
+//
+// Note while those can be nested arbitrarly deep in practise
+// we are at 2 levels currently:
+//  1. overall pipeline progress
+//  2. stages inside each pipeline
+//
+// we might get
+//  3. stage progress (e.g. rpm install progress)
+//
+// in the future
+type Progress struct {
+	// A human readable message about what is going on
+	Message string
+	// The amount of work already done
+	Done int
+	// The total amount of work for this (sub)progress
+	Total int
+
+	SubProgress *Progress
+}
+
+// NewStatusScanner returns a StatusScanner that can parse osbuild
+// jsonseq monitor status messages
+func NewStatusScanner(r io.Reader) *StatusScanner {
+	return &StatusScanner{
+		scanner:         bufio.NewScanner(r),
+		contextMap:      make(map[string]*contextJSON),
+		stageContextMap: make(map[string]*stageContextJSON),
+	}
+}
+
+// StatusScanner scan scan the osbuild jsonseq monitor output
+type StatusScanner struct {
+	scanner         *bufio.Scanner
+	contextMap      map[string]*contextJSON
+	stageContextMap map[string]*stageContextJSON
+}
+
+// Status returns a single status struct from the scanner or nil
+// if the end of the status reporting is reached.
+func (sr *StatusScanner) Status() (*Status, error) {
+	if !sr.scanner.Scan() {
+		return nil, sr.scanner.Err()
+	}
+
+	var status statusJSON
+	line := sr.scanner.Bytes()
+	line = bytes.Trim(line, "\x1e")
+	if err := json.Unmarshal(line, &status); err != nil {
+		return nil, fmt.Errorf("cannot scan line %q: %w", line, err)
+	}
+	// keep track of the context
+	id := status.Context.ID
+	context := sr.contextMap[id]
+	if context == nil {
+		sr.contextMap[id] = &status.Context
+		context = &status.Context
+	}
+	ts := time.UnixMilli(int64(status.Timestamp * 1000))
+	pipelineName := context.Pipeline.Name
+
+	var trace, msg string
+	// This is a convention, "osbuild.montior" sends the high level
+	// status, the other messages contain low-level stdout/stderr
+	// output from individual stages like "org.osbuild.rpm".
+	if context.Origin == "osbuild.monitor" {
+		msg = strings.TrimSpace(status.Message)
+	} else {
+		trace = strings.TrimSpace(status.Message)
+	}
+
+	st := &Status{
+		Trace:   trace,
+		Message: msg,
+		Progress: &Progress{
+			Done:    status.Progress.Done,
+			Total:   status.Progress.Total,
+			Message: fmt.Sprintf("Pipeline %s", pipelineName),
+		},
+		Timestamp: ts,
+	}
+
+	// add subprogress
+	stageID := context.Pipeline.Stage.ID
+	stageContext := sr.stageContextMap[stageID]
+	if stageContext == nil {
+		sr.stageContextMap[id] = &context.Pipeline.Stage
+		stageContext = &context.Pipeline.Stage
+	}
+	stageName := fmt.Sprintf("Stage %s", stageContext.Name)
+	prog := st.Progress
+	for subProg := status.Progress.SubProgress; subProg != nil; subProg = subProg.SubProgress {
+		prog.SubProgress = &Progress{
+			Done:    subProg.Done,
+			Total:   subProg.Total,
+			Message: stageName,
+		}
+		prog = prog.SubProgress
+	}
+
+	return st, nil
+}
+
+// statusJSON is a single status entry from the osbuild monitor
+type statusJSON struct {
+	Context  contextJSON  `json:"context"`
+	Progress progressJSON `json:"progress"`
+	// Add "Result" here once
+	// https://github.com/osbuild/osbuild/pull/1831 is merged
+
+	Message   string  `json:"message"`
+	Timestamp float64 `json:"timestamp"`
+}
+
+// contextJSON is the context for which a status is given. Once a context
+// was sent to the user from then on it is only referenced by the ID
+type contextJSON struct {
+	Origin   string `json:"origin"`
+	ID       string `json:"id"`
+	Pipeline struct {
+		ID    string           `json:"id"`
+		Name  string           `json:"name"`
+		Stage stageContextJSON `json:"stage"`
+	} `json:"pipeline"`
+}
+
+type stageContextJSON struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+// progress is the progress information associcated with a given status.
+// The details about nesting are the same as for "Progress" above.
+type progressJSON struct {
+	Name  string `json:"name"`
+	Total int    `json:"total"`
+	Done  int    `json:"done"`
+
+	SubProgress *progressJSON `json:"progress"`
+}

--- a/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
+++ b/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
@@ -75,7 +75,7 @@ func LoadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, err
 					return nil, err
 				}
 
-				logrus.Infof("Loaded repository configuration file: %s", configFile)
+				logrus.Infof("Loaded repository configuration file: %s", fileEntry.Name())
 
 				distrosRepoConfigs[distro] = distroRepos
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1022,7 +1022,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.102.0
+# github.com/osbuild/images v0.105.0
 ## explicit; go 1.21.0
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
This brings a lot of new stuff, among others:
 - Internal image types for RHEL-10 (COMPOSER-2357)
 - Support for Swap partitions in DiskCustomizations (COMPOSER-2400)
 - Support for new partitioning customizations for CS and RHEL
 - Fix for RHEL 8 and 9 AMI boot mode (RHEL-69628)


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
