### PR TITLE
internal/cloudapi/v2/handler: use compose id for filename

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1233,7 +1233,7 @@ func (h *apiHandlers) postCloneComposeImpl(ctx echo.Context, id string) error {
 					Ami:          options.Ami,
 					SourceRegion: options.Region,
 					TargetRegion: img.Region,
-					TargetName:   fmt.Sprintf("composer-api-%s", uuid.New().String()),
+					TargetName:   fmt.Sprintf("composer-api-%s", finalJob),
 				}
 				finalJob, err = h.server.workers.EnqueueAWSEC2CopyJob(copyJob, finalJob, channel)
 				if err != nil {


### PR DESCRIPTION
For easier tracing and finding the result in AWS,
can we use the compose id in the filename?

Is this a valid suggestion?

If this might not be unique enough, we could also append some random string?
```
TargetName:   fmt.Sprintf("composer-api-%s-%s", finalJob, uuid.New().String()[:8]),
```
