### PR TITLE
Exclude vendor directory ci: do not perform linting on vendor/from linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+exclude-dirs:
+  - vendor
+
 linters-settings:
   govet:
     disable:


### PR DESCRIPTION
Prevent linting processes from running on the vendor directory to improve efficiency.