### PR TITLE
README: remove mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ instance, includes a
 
  * **Website**: <https://www.osbuild.org>
  * **Bug Tracker**: <https://github.com/osbuild/osbuild-composer/issues>
- * **Matrix**: <https://matrix.to/#/#image-builder:fedoraproject.org?web-instance[element.io]=chat.fedoraproject.org>
- * **Mailing List**: image-builder@redhat.com
+ * **Discussions**: <https://github.com/orgs/osbuild/discussions>
+ * **Matrix**: [#image-builder on fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
  * **Changelog**: <https://github.com/osbuild/osbuild-composer/releases>
 
 ### Principles


### PR DESCRIPTION
The mailing list was sunset by the IT department and was rarely used, so we'll replace it with matrix & discussions.
