### PR TITLE
Fix non-constant log strings

### DIFF
--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -131,7 +131,7 @@ func main() {
 
 	listeners, err := activation.ListenersWithNames()
 	if err != nil {
-		logrus.Fatalf("Could not get listening sockets: " + err.Error())
+		logrus.Fatalf("Could not get listening sockets: %v", err)
 	}
 
 	if l, exists := listeners["osbuild-composer.socket"]; exists {

--- a/cmd/osbuild-worker-executor/handler_build.go
+++ b/cmd/osbuild-worker-executor/handler_build.go
@@ -94,7 +94,7 @@ func runOsbuild(logger *logrus.Logger, buildDir string, control *controlJSON, ou
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf("cannot tar output directory: %w, output:\n%s", err, out)
-		logger.Errorf(err.Error())
+		logger.Errorf("%v", err)
 		_, _ = mw.Write([]byte(err.Error()))
 		return "", err
 	}

--- a/internal/auth/jwt_auth_handler.go
+++ b/internal/auth/jwt_auth_handler.go
@@ -26,7 +26,7 @@ func BuildJWTAuthHandler(keysURLs []string, caFile, aclFile string, exclude []st
 		return
 	}
 
-	logger.Info(context.Background(), aclFile)
+	logger.Info(context.Background(), "aclFile = %s", aclFile)
 
 	builder := authentication.NewHandler().
 		Logger(logger)


### PR DESCRIPTION
Newer versions of the go compiler (1.24 in this case) fail when running go test during a mock rebuild of the srpm created by 'make srpm' on Fedora 42.

Even though we currently don't support go1.24, fix these so they don't become an issue when we do.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
