### PR TITLE
Update osbuild/images to v0.111.0

### DIFF
--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -29,24 +29,22 @@ func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d di
 	if err != nil {
 		panic(err)
 	}
-	pkgSpecSets := make(map[string][]rpmmd.PackageSpec)
-	repoConfigs := make(map[string][]rpmmd.RepoConfig)
+	depsolved := make(map[string]dnfjson.DepsolveResult)
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), a.Name(), d.Name(), cacheDir)
 	for name, packages := range manifest.GetPackageSetChains() {
 		res, err := solver.Depsolve(packages, sbom.StandardTypeNone)
 		if err != nil {
 			panic(err)
 		}
-		pkgSpecSets[name] = res.Packages
-		repoConfigs[name] = res.Repos
+		depsolved[name] = *res
 	}
 
-	mf, err := manifest.Serialize(pkgSpecSets, nil, nil, repoConfigs)
+	mf, err := manifest.Serialize(depsolved, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}
 
-	return mf, pkgSpecSets["packages"]
+	return mf, depsolved["packages"].Packages
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.109.0
+	github.com/osbuild/images v0.111.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.438 h1:tsLCCUzbLCTL4RZG02y9RuopmGCXp
 github.com/openshift-online/ocm-sdk-go v0.1.438/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.109.0 h1:yLY1Ul6O/4fp+y+UI2XIML9CcsKdPNTARk95hiz1syY=
-github.com/osbuild/images v0.109.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
+github.com/osbuild/images v0.111.0 h1:mnPLdSin/q1ZTaGZVJHepsikguFjUMAWblQdPgvZ02M=
+github.com/osbuild/images v0.111.0/go.mod h1:58tzp7jV50rjaH9gMpvmQdVati0c4TaC5Op7wmSD/tY=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/distrofactory"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/reporegistry"
@@ -664,7 +665,19 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 		}
 	}
 
-	ms, err := manifestSource.Serialize(depsolveResults.PackageSpecs, containerSpecs, ostreeCommitSpecs, depsolveResults.RepoConfigs)
+	// XXX: fix worker.DepsolveJobResult
+	depsolveResultsInTheRightFormat := map[string]dnfjson.DepsolveResult{}
+	for plName, res := range depsolveResults.PackageSpecs {
+		r := depsolveResultsInTheRightFormat[plName]
+		r.Packages = res
+		depsolveResultsInTheRightFormat[plName] = r
+	}
+	for plName, res := range depsolveResults.RepoConfigs {
+		r := depsolveResultsInTheRightFormat[plName]
+		r.Repos = res
+		depsolveResultsInTheRightFormat[plName] = r
+	}
+	ms, err := manifestSource.Serialize(depsolveResultsInTheRightFormat, containerSpecs, ostreeCommitSpecs, nil)
 	if err != nil {
 		reason := "Error serializing manifest"
 		jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, reason, nil)

--- a/internal/mocks/dnfjson/dnfjson.go
+++ b/internal/mocks/dnfjson/dnfjson.go
@@ -148,6 +148,7 @@ func BaseDeps() []rpmmd.PackageSpec {
 			Arch:     "x86_64",
 			CheckGPG: true,
 			Checksum: "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
+			RepoID:   "REPOID", // added by test case
 		},
 		{
 			Name:     "dep-package1",
@@ -157,6 +158,7 @@ func BaseDeps() []rpmmd.PackageSpec {
 			Arch:     "x86_64",
 			CheckGPG: true,
 			Checksum: "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
+			RepoID:   "REPOID", // added by test case
 		},
 		{
 			Name:     "dep-package2",
@@ -166,6 +168,7 @@ func BaseDeps() []rpmmd.PackageSpec {
 			Arch:     "x86_64",
 			CheckGPG: true,
 			Checksum: "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
+			RepoID:   "REPOID", // added by test case
 		},
 	}
 }

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -2057,7 +2057,8 @@ func TestModulesInfo(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run("Path = %s", func(t *testing.T) {
+		name := fmt.Sprintf("Path=%s", c.Path)
+		t.Run(name, func(t *testing.T) {
 			api, sf := createTestWeldrAPI(t.TempDir(), test_distro.TestDistro1Name, test_distro.TestArchName, c.Fixture, nil)
 			t.Cleanup(sf.Cleanup)
 			test.TestRoute(t, api, true, "GET", c.Path, ``, c.ExpectedStatus, c.ExpectedJSON)

--- a/internal/weldr/responses_test.go
+++ b/internal/weldr/responses_test.go
@@ -93,6 +93,7 @@ const depsolveTestResponse = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -102,6 +103,7 @@ const depsolveTestResponse = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -111,6 +113,7 @@ const depsolveTestResponse = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
@@ -1404,8 +1407,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1413,8 +1417,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1422,8 +1427,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1474,8 +1480,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1483,8 +1490,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1492,8 +1500,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1544,8 +1553,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1553,8 +1563,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1562,8 +1573,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1614,8 +1626,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1623,8 +1636,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1632,8 +1646,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1684,8 +1699,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1693,8 +1709,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1702,8 +1719,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1754,8 +1772,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1763,8 +1782,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1772,8 +1792,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1824,8 +1845,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1833,8 +1855,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1842,8 +1865,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1894,8 +1918,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1903,8 +1928,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1912,8 +1938,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -1964,8 +1991,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -1973,8 +2001,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -1982,8 +2011,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2034,8 +2064,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2043,8 +2074,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2052,8 +2084,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2104,8 +2137,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2113,8 +2147,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2122,8 +2157,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2174,8 +2210,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2183,8 +2220,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2192,8 +2230,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2244,8 +2283,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2253,8 +2293,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2262,8 +2303,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2314,8 +2356,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2323,8 +2366,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2332,8 +2376,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2384,8 +2429,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2393,8 +2439,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2402,8 +2449,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2454,8 +2502,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2463,8 +2512,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2472,8 +2522,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2524,8 +2575,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2533,8 +2585,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2542,8 +2595,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2594,8 +2648,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2603,8 +2658,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2612,8 +2668,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2664,8 +2721,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2673,8 +2731,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2682,8 +2741,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2734,8 +2794,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2743,8 +2804,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2752,8 +2814,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2804,8 +2867,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2813,8 +2877,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2822,8 +2887,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     },
@@ -2874,8 +2940,9 @@ const modulesInfoResponse = `
           "version": "3.0.3",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720",
           "check_gpg": true,
-          "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package1",
@@ -2883,8 +2950,9 @@ const modulesInfoResponse = `
           "version": "1.33",
           "release": "2.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893",
           "check_gpg": true,
-          "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         },
         {
           "name": "dep-package2",
@@ -2892,8 +2960,9 @@ const modulesInfoResponse = `
           "version": "2.9",
           "release": "1.fc30",
           "arch": "x86_64",
+          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2",
           "check_gpg": true,
-          "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e"
         }
       ]
     }
@@ -2950,6 +3019,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -2959,6 +3029,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -2968,6 +3039,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
@@ -3020,6 +3092,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -3029,6 +3102,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -3038,6 +3112,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
@@ -3090,6 +3165,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -3099,6 +3175,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -3108,6 +3185,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
@@ -3160,6 +3238,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -3169,6 +3248,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -3178,6 +3258,7 @@ const modulesInfoFilteredResponse = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "ac982f7c76771e898d1112d1a81d182eeb48af4a26792df248ebf6a47de06a4e",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"
@@ -3237,6 +3318,7 @@ const modulesInfoPackage16Response = `
           "epoch": 7,
           "version": "3.0.3",
           "release": "1.fc30",
+          "repo_id": "0a99a351a0031411571ddfacc8a131862cfc389d5516400d0cdbc9340a6ec423",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:62278d360aa5045eb202af39fe85743a4b5615f0c9c7439a04d75d785db4c720"
@@ -3246,6 +3328,7 @@ const modulesInfoPackage16Response = `
           "epoch": 0,
           "version": "1.33",
           "release": "2.fc30",
+          "repo_id": "0a99a351a0031411571ddfacc8a131862cfc389d5516400d0cdbc9340a6ec423",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:fe3951d112c3b1c84dc8eac57afe0830df72df1ca0096b842f4db5d781189893"
@@ -3255,6 +3338,7 @@ const modulesInfoPackage16Response = `
           "epoch": 0,
           "version": "2.9",
           "release": "1.fc30",
+          "repo_id": "0a99a351a0031411571ddfacc8a131862cfc389d5516400d0cdbc9340a6ec423",
           "arch": "x86_64",
           "check_gpg": true,
           "checksum": "sha256:5797c0b0489681596b5b3cd7165d49870b85b69d65e08770946380a3dcd49ea2"

--- a/vendor/github.com/osbuild/images/pkg/crypt/crypt.go
+++ b/vendor/github.com/osbuild/images/pkg/crypt/crypt.go
@@ -18,6 +18,7 @@ func CryptSHA512(phrase string) (string, error) {
 		return "", nil
 	}
 
+	// Note: update "crypt_impl_non_cgo.go" if new hash types get added
 	hashSettings := "$6$" + salt
 	return crypt(phrase, hashSettings)
 }

--- a/vendor/github.com/osbuild/images/pkg/crypt/crypt_impl_non_cgo.go
+++ b/vendor/github.com/osbuild/images/pkg/crypt/crypt_impl_non_cgo.go
@@ -1,0 +1,34 @@
+//go:build !cgo
+
+//
+// fallback implementation of "crypt" for cross building
+
+package crypt
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func crypt(pass, salt string) (string, error) {
+	// we could extract the "hash-type" here and pass it to
+	// openssl instead of hardcoding -6 but lets do that once we
+	// actually move away from sha512crypt
+	if !strings.HasPrefix(salt, "$6$") {
+		return "", fmt.Errorf("only crypt type SHA512 supported, got %q", salt)
+	}
+	cmd := exec.Command(
+		"openssl", "passwd", "-6",
+		// strip the $6$
+		"-salt", salt[3:],
+		"-stdin",
+	)
+	cmd.Stdin = bytes.NewBufferString(pass)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("cannot generate password: %v, output:%s\n", err, string(output))
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/distro.go
@@ -93,6 +93,9 @@ var (
 			osPkgsKey:        minimalrpmPackageSet,
 			installerPkgsKey: imageInstallerPackageSet,
 		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
+		},
 		bootable:  true,
 		bootISO:   true,
 		rpmOstree: false,
@@ -112,6 +115,9 @@ var (
 		mimeType:    "application/x-iso9660-image",
 		packageSets: map[string]packageSetFunc{
 			installerPkgsKey: liveInstallerPackageSet,
+		},
+		defaultImageConfig: &distro.ImageConfig{
+			Locale: common.ToPtr("en_US.UTF-8"),
 		},
 		bootable:               true,
 		bootISO:                true,

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
@@ -407,6 +407,10 @@ func liveInstallerImage(workload workload.Workload,
 		img.RootfsType = manifest.SquashfsRootfs
 	}
 
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
+	}
+
 	return img, nil
 }
 
@@ -423,6 +427,11 @@ func imageInstallerImage(workload workload.Workload,
 	img := image.NewAnacondaTarInstaller()
 
 	var err error
+	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
+	if err != nil {
+		return nil, err
+	}
+
 	img.Kickstart, err = kickstart.New(customizations)
 	if err != nil {
 		return nil, err
@@ -453,11 +462,6 @@ func imageInstallerImage(workload workload.Workload,
 	img.Platform = t.platform
 	img.Workload = workload
 
-	img.OSCustomizations, err = osCustomizations(t, packageSets[osPkgsKey], containers, bp.Customizations)
-	if err != nil {
-		return nil, err
-	}
-
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
 
 	d := t.arch.distro
@@ -479,7 +483,7 @@ func imageInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	img.SquashfsCompression = "lz4"
+	img.RootfsCompression = "lz4"
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
 	}
@@ -680,9 +684,13 @@ func iotInstallerImage(workload workload.Workload,
 
 	img.Filename = t.Filename()
 
-	img.SquashfsCompression = "lz4"
+	img.RootfsCompression = "lz4"
 	if common.VersionGreaterThanOrEqual(img.OSVersion, VERSION_ROOTFS_SQUASHFS) {
 		img.RootfsType = manifest.SquashfsRootfs
+	}
+
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
 	}
 
 	return img, nil

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/package_sets.go
@@ -97,7 +97,6 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			"cryptsetup",
 			"curl",
 			"dbus-parsec",
-			"dnsmasq",
 			"dosfstools",
 			"dracut-config-generic",
 			"dracut-network",
@@ -180,6 +179,13 @@ func iotCommitPackageSet(t *imageType) rpmmd.PackageSet {
 			Include: []string{
 				"passwd",         // provided by shadow-utils in F40+
 				"podman-plugins", // deprecated in podman 5
+			},
+		})
+	}
+	if common.VersionLessThan(t.arch.distro.osVersion, "41") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"dnsmasq", // deprecated for F41+
 			},
 		})
 	}
@@ -653,7 +659,6 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 			"coreos-installer-dracut",
 			"coreutils",
 			"device-mapper-multipath",
-			"dnsmasq",
 			"dosfstools",
 			"dracut-live",
 			"e2fsprogs",
@@ -694,6 +699,13 @@ func iotSimplifiedInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		ps = ps.Append(rpmmd.PackageSet{
 			Include: []string{
 				"passwd",
+			},
+		})
+	}
+	if common.VersionLessThan(t.arch.distro.osVersion, "41") {
+		ps = ps.Append(rpmmd.PackageSet{
+			Include: []string{
+				"dnsmasq", // deprecated for F41+
 			},
 		})
 	}

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
@@ -495,7 +495,7 @@ func EdgeInstallerImage(workload workload.Workload,
 	// kickstart though kickstart does support setting them
 	img.Kickstart.Timezone, _ = customizations.GetTimezoneSettings()
 
-	img.SquashfsCompression = "xz"
+	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
 		img.RootfsType = manifest.SquashfsRootfs
 	}
@@ -536,6 +536,10 @@ func EdgeInstallerImage(workload workload.Workload,
 	img.FIPS = customizations.GetFIPS()
 
 	img.Filename = t.Filename()
+
+	if locale := t.getDefaultImageConfig().Locale; locale != nil {
+		img.Locale = *locale
+	}
 
 	return img, nil
 }
@@ -716,7 +720,7 @@ func ImageInstallerImage(workload workload.Workload,
 	}
 	img.AdditionalAnacondaModules = append(img.AdditionalAnacondaModules, anaconda.ModuleUsers)
 
-	img.SquashfsCompression = "xz"
+	img.RootfsCompression = "xz"
 	if t.Arch().Distro().Releasever() == "10" {
 		img.RootfsType = manifest.SquashfsRootfs
 	}

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ami.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ami.go
@@ -166,8 +166,6 @@ const (
 // default EC2 images config (common for all architectures)
 func defaultEc2ImageConfig() *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Locale:   common.ToPtr("en_US.UTF-8"),
-		Timezone: common.ToPtr("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{
 				{

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/azure.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/azure.go
@@ -406,8 +406,6 @@ const defaultAzureKernelOptions = "ro loglevel=3 console=tty1 console=ttyS0 earl
 // based on https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/deploying_rhel_9_on_microsoft_azure/assembly_deploying-a-rhel-image-as-a-virtual-machine-on-microsoft-azure_cloud-content-azure#making-configuration-changes_configure-the-image-azure
 func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("Etc/UTC"),
-		Locale:   common.ToPtr("en_US.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 			X11Keymap: &osbuild.X11KeymapOptions{

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/distro.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/distro.go
@@ -51,7 +51,7 @@ func distroISOLabelFunc(t *rhel.ImageType) string {
 
 func defaultDistroImageConfig(d *rhel.Distribution) *distro.ImageConfig {
 	return &distro.ImageConfig{
-		Timezone: common.ToPtr("America/New_York"),
+		Timezone: common.ToPtr("UTC"),
 		Locale:   common.ToPtr("C.UTF-8"),
 		Sysconfig: []*osbuild.SysconfigStageOptions{
 			{

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/gce.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/gce.go
@@ -37,7 +37,6 @@ func mkGCEImageType() *rhel.ImageType {
 
 func baseGCEImageConfig() *distro.ImageConfig {
 	ic := &distro.ImageConfig{
-		Timezone: common.ToPtr("UTC"),
 		TimeSynchronization: &osbuild.ChronyStageOptions{
 			Servers: []osbuild.ChronyConfigServer{{Hostname: "metadata.google.internal"}},
 		},
@@ -59,7 +58,6 @@ func baseGCEImageConfig() *distro.ImageConfig {
 			"reboot.target",
 		},
 		DefaultTarget: common.ToPtr("multi-user.target"),
-		Locale:        common.ToPtr("en_US.UTF-8"),
 		Keyboard: &osbuild.KeymapStageOptions{
 			Keymap: "us",
 		},

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ubi.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ubi.go
@@ -23,7 +23,6 @@ func mkWSLImgType() *rhel.ImageType {
 	)
 
 	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale:    common.ToPtr("en_US.UTF-8"),
 		NoSElinux: common.ToPtr(true),
 		WSLConfig: &osbuild.WSLConfStageOptions{
 			Boot: osbuild.WSLConfBootOptions{

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/vmdk.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/vmdk.go
@@ -1,9 +1,7 @@
 package rhel10
 
 import (
-	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/datasizes"
-	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/rhel"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -24,9 +22,6 @@ func mkVMDKImgType() *rhel.ImageType {
 		[]string{"vmdk"},
 	)
 
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
-	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte
@@ -49,9 +44,6 @@ func mkOVAImgType() *rhel.ImageType {
 		[]string{"archive"},
 	)
 
-	it.DefaultImageConfig = &distro.ImageConfig{
-		Locale: common.ToPtr("en_US.UTF-8"),
-	}
 	it.KernelOptions = vmdkKernelOptions
 	it.Bootable = true
 	it.DefaultSize = 4 * datasizes.GibiByte

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/bare_metal.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/bare_metal.go
@@ -62,6 +62,10 @@ func mkImageInstallerImgType() *rhel.ImageType {
 		},
 	}
 
+	it.DefaultImageConfig = &distro.ImageConfig{
+		Locale: common.ToPtr("C.UTF-8"),
+	}
+
 	return it
 }
 

--- a/vendor/github.com/osbuild/images/pkg/dnfjson/dnfjson.go
+++ b/vendor/github.com/osbuild/images/pkg/dnfjson/dnfjson.go
@@ -586,6 +586,8 @@ func (result depsolveResult) toRPMMD(rhsm map[string]bool) ([]rpmmd.PackageSpec,
 		rpmDependencies[i].RemoteLocation = dep.RemoteLocation
 		rpmDependencies[i].Checksum = dep.Checksum
 		rpmDependencies[i].CheckGPG = repo.GPGCheck
+		rpmDependencies[i].RepoID = dep.RepoID
+		rpmDependencies[i].Path = dep.Path
 		if verify := repo.SSLVerify; verify != nil {
 			rpmDependencies[i].IgnoreSSL = !*verify
 		}

--- a/vendor/github.com/osbuild/images/pkg/image/anaconda_container_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/image/anaconda_container_installer.go
@@ -22,8 +22,8 @@ type AnacondaContainerInstaller struct {
 	Platform          platform.Platform
 	ExtraBasePackages rpmmd.PackageSet
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -51,6 +51,10 @@ type AnacondaContainerInstaller struct {
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.
 	UseLegacyAnacondaConfig bool
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaContainerInstaller(container container.SourceSpec, ref string) *AnacondaContainerInstaller {
@@ -98,6 +102,7 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 		)
 	}
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.Locale
 
 	var rootfsImagePipeline *manifest.ISORootfsImg
 	switch img.RootfsType {
@@ -132,7 +137,8 @@ func (img *AnacondaContainerInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.Kickstart = img.Kickstart
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	// For ostree installers, always put the kickstart file in the root of the ISO
 	isoTreePipeline.PayloadPath = "/container"

--- a/vendor/github.com/osbuild/images/pkg/image/anaconda_live_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/image/anaconda_live_installer.go
@@ -23,8 +23,8 @@ type AnacondaLiveInstaller struct {
 
 	ExtraBasePackages rpmmd.PackageSet
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -36,6 +36,10 @@ type AnacondaLiveInstaller struct {
 	Filename string
 
 	AdditionalKernelOpts []string
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaLiveInstaller() *AnacondaLiveInstaller {
@@ -67,6 +71,7 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	livePipeline.Variant = img.Variant
 	livePipeline.Biosdevname = (img.Platform.GetArch() == arch.ARCH_X86_64)
+	livePipeline.Locale = img.Locale
 
 	// The live installer has SElinux enabled and targeted
 	livePipeline.SElinux = "targeted"
@@ -107,7 +112,8 @@ func (img *AnacondaLiveInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.KernelOpts = kernelOpts
 	isoTreePipeline.ISOLinux = isoLinuxEnabled
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoPipeline := manifest.NewISO(buildPipeline, isoTreePipeline, img.ISOLabel)
 	isoPipeline.SetFilename(img.Filename)

--- a/vendor/github.com/osbuild/images/pkg/image/anaconda_ostree_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/image/anaconda_ostree_installer.go
@@ -28,8 +28,8 @@ type AnacondaOSTreeInstaller struct {
 	// Subscription options to include
 	Subscription *subscription.ImageOptions
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -51,6 +51,10 @@ type AnacondaOSTreeInstaller struct {
 	// Uses the old, deprecated, Anaconda config option "kickstart-modules".
 	// Only for RHEL 8.
 	UseLegacyAnacondaConfig bool
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaOSTreeInstaller(commit ostree.SourceSpec) *AnacondaOSTreeInstaller {
@@ -101,6 +105,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.Locale
 
 	var rootfsImagePipeline *manifest.ISORootfsImg
 	switch img.RootfsType {
@@ -139,7 +144,8 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline.PartitionTable = efiBootPartitionTable(rng)
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.Kickstart = img.Kickstart
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoTreePipeline.PayloadPath = "/ostree/repo"
 

--- a/vendor/github.com/osbuild/images/pkg/image/anaconda_tar_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/image/anaconda_tar_installer.go
@@ -56,8 +56,8 @@ type AnacondaTarInstaller struct {
 	ISORootKickstart bool
 	Kickstart        *kickstart.Options
 
-	SquashfsCompression string
-	RootfsType          manifest.RootfsType
+	RootfsCompression string
+	RootfsType        manifest.RootfsType
 
 	ISOLabel  string
 	Product   string
@@ -144,6 +144,7 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 	anacondaPipeline.DisabledAnacondaModules = img.DisabledAnacondaModules
 	anacondaPipeline.AdditionalDracutModules = img.AdditionalDracutModules
 	anacondaPipeline.AdditionalDrivers = img.AdditionalDrivers
+	anacondaPipeline.Locale = img.OSCustomizations.Language
 
 	tarPath := "/liveimg.tar.gz"
 
@@ -195,7 +196,8 @@ func (img *AnacondaTarInstaller) InstantiateManifest(m *manifest.Manifest,
 		isoTreePipeline.Kickstart.Path = img.Kickstart.Path
 	}
 
-	isoTreePipeline.SquashfsCompression = img.SquashfsCompression
+	isoTreePipeline.RootfsCompression = img.RootfsCompression
+	isoTreePipeline.RootfsType = img.RootfsType
 
 	isoTreePipeline.OSPipeline = osPipeline
 	isoTreePipeline.KernelOpts = img.AdditionalKernelOpts

--- a/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/osbuild/images/internal/common"
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fsnode"
 	"github.com/osbuild/images/pkg/customizations/kickstart"
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -89,6 +87,10 @@ type AnacondaInstaller struct {
 	// tree with the selected profile and selects the required package
 	// for depsolving
 	SElinux string
+
+	// Locale for the installer. This should be set to the same locale as the
+	// ISO OS payload, if known.
+	Locale string
 }
 
 func NewAnacondaInstaller(installerType AnacondaInstallerType,
@@ -196,15 +198,15 @@ func (p *AnacondaInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *AnacondaInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *AnacondaInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *AnacondaInstaller) serializeEnd() {
@@ -236,7 +238,13 @@ func (p *AnacondaInstaller) serialize() osbuild.Pipeline {
 		Version: p.version,
 		Final:   !p.preview,
 	}))
-	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: "en_US.UTF-8"}))
+
+	locale := p.Locale
+	if locale == "" {
+		// default to C.UTF-8 if unset
+		locale = "C.UTF-8"
+	}
+	pipeline.AddStage(osbuild.NewLocaleStage(&osbuild.LocaleStageOptions{Language: locale}))
 
 	// Let's do a bunch of sanity checks that are dependent on the installer type
 	// being serialized

--- a/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer_iso_tree.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/anaconda_installer_iso_tree.go
@@ -14,7 +14,6 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 type RootfsType uint64
@@ -23,6 +22,7 @@ type RootfsType uint64
 const ( // Rootfs type enum
 	SquashfsExt4Rootfs RootfsType = iota // Create an EXT4 rootfs compressed by Squashfs
 	SquashfsRootfs                       // Create a plain squashfs rootfs
+	ErofsRootfs                          // Create a plain erofs rootfs
 )
 
 // An AnacondaInstallerISOTree represents a tree containing the anaconda installer,
@@ -49,7 +49,8 @@ type AnacondaInstallerISOTree struct {
 
 	isoLabel string
 
-	SquashfsCompression string
+	RootfsCompression string
+	RootfsType        RootfsType
 
 	OSPipeline         *OS
 	OSTreeCommitSource *ostree.SourceSpec
@@ -135,8 +136,13 @@ func (p *AnacondaInstallerISOTree) getInline() []string {
 	return inlineData
 }
 func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
-	packages := []string{
-		"squashfs-tools",
+	var packages []string
+	switch p.RootfsType {
+	case SquashfsExt4Rootfs, SquashfsRootfs:
+		packages = []string{"squashfs-tools"}
+	case ErofsRootfs:
+		packages = []string{"erofs-utils"}
+	default:
 	}
 
 	if p.OSTreeCommitSource != nil {
@@ -154,25 +160,91 @@ func (p *AnacondaInstallerISOTree) getBuildPackages(_ Distro) []string {
 	return packages
 }
 
-func (p *AnacondaInstallerISOTree) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+// NewSquashfsStage returns an osbuild stage configured to build
+// the squashfs root filesystem for the ISO.
+func (p *AnacondaInstallerISOTree) NewSquashfsStage() *osbuild.Stage {
+	var squashfsOptions osbuild.SquashfsStageOptions
+
+	if p.anacondaPipeline.Type == AnacondaInstallerTypePayload {
+		squashfsOptions = osbuild.SquashfsStageOptions{
+			Filename: "images/install.img",
+		}
+	} else if p.anacondaPipeline.Type == AnacondaInstallerTypeLive {
+		squashfsOptions = osbuild.SquashfsStageOptions{
+			Filename: "LiveOS/squashfs.img",
+		}
+	}
+
+	if p.RootfsCompression != "" {
+		squashfsOptions.Compression.Method = p.RootfsCompression
+	} else {
+		// default to xz if not specified
+		squashfsOptions.Compression.Method = "xz"
+	}
+
+	if squashfsOptions.Compression.Method == "xz" {
+		squashfsOptions.Compression.Options = &osbuild.FSCompressionOptions{
+			BCJ: osbuild.BCJOption(p.anacondaPipeline.platform.GetArch().String()),
+		}
+	}
+
+	// The iso's rootfs can either be an ext4 filesystem compressed with squashfs, or
+	// a squashfs of the plain directory tree
+	if p.RootfsType == SquashfsExt4Rootfs && p.rootfsPipeline != nil {
+		return osbuild.NewSquashfsStage(&squashfsOptions, p.rootfsPipeline.Name())
+	}
+	return osbuild.NewSquashfsStage(&squashfsOptions, p.anacondaPipeline.Name())
+}
+
+// NewErofsStage returns an osbuild stage configured to build
+// the erofs root filesystem for the ISO.
+func (p *AnacondaInstallerISOTree) NewErofsStage() *osbuild.Stage {
+	var erofsOptions osbuild.ErofsStageOptions
+
+	if p.anacondaPipeline.Type == AnacondaInstallerTypePayload {
+		erofsOptions = osbuild.ErofsStageOptions{
+			Filename: "images/install.img",
+		}
+	} else if p.anacondaPipeline.Type == AnacondaInstallerTypeLive {
+		erofsOptions = osbuild.ErofsStageOptions{
+			Filename: "LiveOS/squashfs.img",
+		}
+	}
+
+	var compression osbuild.ErofsCompression
+	if p.RootfsCompression != "" {
+		compression.Method = p.RootfsCompression
+	} else {
+		// default to zstd if not specified
+		compression.Method = "zstd"
+	}
+	compression.Level = common.ToPtr(8)
+	erofsOptions.Compression = &compression
+	erofsOptions.ExtendedOptions = []string{"all-fragments", "dedupe"}
+	erofsOptions.ClusterSize = common.ToPtr(131072)
+
+	return osbuild.NewErofsStage(&erofsOptions, p.anacondaPipeline.Name())
+}
+
+func (p *AnacondaInstallerISOTree) serializeStart(inputs Inputs) {
 	if p.ostreeCommitSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}
 
-	if len(commits) > 1 {
+	if len(inputs.Commits) > 1 {
 		panic("pipeline supports at most one ostree commit")
 	}
 
-	if len(containers) > 1 {
+	if len(inputs.Containers) > 1 {
 		panic("pipeline supports at most one container")
 	}
 
-	if len(commits) > 0 {
-		p.ostreeCommitSpec = &commits[0]
+	if len(inputs.Commits) > 0 {
+		p.ostreeCommitSpec = &inputs.Commits[0]
 	}
 
-	if len(containers) > 0 {
-		p.containerSpec = &containers[0]
+	if len(inputs.Containers) > 0 {
+		p.containerSpec = &inputs.Containers[0]
 	}
 }
 
@@ -261,40 +333,14 @@ func (p *AnacondaInstallerISOTree) serialize() osbuild.Pipeline {
 	copyStage := osbuild.NewCopyStageSimple(copyStageOptions, copyStageInputs)
 	pipeline.AddStage(copyStage)
 
-	var squashfsOptions osbuild.SquashfsStageOptions
-
-	if p.anacondaPipeline.Type == AnacondaInstallerTypePayload {
-		squashfsOptions = osbuild.SquashfsStageOptions{
-			Filename: "images/install.img",
-		}
-	} else if p.anacondaPipeline.Type == AnacondaInstallerTypeLive {
-		squashfsOptions = osbuild.SquashfsStageOptions{
-			Filename: "LiveOS/squashfs.img",
-		}
+	// Add the selected roofs stage
+	switch p.RootfsType {
+	case SquashfsExt4Rootfs, SquashfsRootfs:
+		pipeline.AddStage(p.NewSquashfsStage())
+	case ErofsRootfs:
+		pipeline.AddStage(p.NewErofsStage())
+	default:
 	}
-
-	if p.SquashfsCompression != "" {
-		squashfsOptions.Compression.Method = p.SquashfsCompression
-	} else {
-		// default to xz if not specified
-		squashfsOptions.Compression.Method = "xz"
-	}
-
-	if squashfsOptions.Compression.Method == "xz" {
-		squashfsOptions.Compression.Options = &osbuild.FSCompressionOptions{
-			BCJ: osbuild.BCJOption(p.anacondaPipeline.platform.GetArch().String()),
-		}
-	}
-
-	// The iso's rootfs can either be an ext4 filesystem compressed with squashfs, or
-	// a squashfs of the plain directory tree
-	var squashfsStage *osbuild.Stage
-	if p.rootfsPipeline != nil {
-		squashfsStage = osbuild.NewSquashfsStage(&squashfsOptions, p.rootfsPipeline.Name())
-	} else {
-		squashfsStage = osbuild.NewSquashfsStage(&squashfsOptions, p.anacondaPipeline.Name())
-	}
-	pipeline.AddStage(squashfsStage)
 
 	if p.ISOLinux {
 		isoLinuxOptions := &osbuild.ISOLinuxStageOptions{
@@ -526,12 +572,13 @@ reboot --eject
 `
 
 	// Workaround for lack of --target-imgref in Anaconda, xref https://github.com/osbuild/images/issues/380
-	hardcodedKickstartBits += fmt.Sprintf(`%%post
+	hardcodedKickstartBits += fmt.Sprintf(`%%post --erroronfail
 bootc switch --mutate-in-place --transport %s %s
 
 # used during automatic image testing as finished marker
 if [ -c /dev/ttyS0 ]; then
-    echo "Install finished" > /dev/ttyS0
+    # continue on errors here, because we used to omit --erroronfail
+    echo "Install finished" > /dev/ttyS0 || true
 fi
 %%end
 `, targetContainerTransport, p.containerSpec.LocalName)

--- a/vendor/github.com/osbuild/images/pkg/manifest/build.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/build.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/images/pkg/runner"
 )
@@ -99,12 +98,12 @@ func (p *BuildrootFromPackages) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *BuildrootFromPackages) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *BuildrootFromPackages) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
-	p.repos = append(p.repos, rpmRepos...)
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *BuildrootFromPackages) serializeEnd() {
@@ -199,11 +198,11 @@ func (p *BuildrootFromContainer) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *BuildrootFromContainer) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *BuildrootFromContainer) serializeStart(inputs Inputs) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.containerSpecs = containerSpecs
+	p.containerSpecs = inputs.Containers
 }
 
 func (p *BuildrootFromContainer) serializeEnd() {

--- a/vendor/github.com/osbuild/images/pkg/manifest/commit_server_tree.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/commit_server_tree.go
@@ -4,9 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/osbuild/images/internal/common"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -80,12 +78,12 @@ func (p *OSTreeCommitServer) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *OSTreeCommitServer) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *OSTreeCommitServer) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
-	p.repos = append(p.repos, rpmRepos...)
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *OSTreeCommitServer) serializeEnd() {

--- a/vendor/github.com/osbuild/images/pkg/manifest/coreos_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/coreos_installer.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/container"
 	"github.com/osbuild/images/pkg/customizations/fdo"
 	"github.com/osbuild/images/pkg/customizations/ignition"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
@@ -136,15 +134,15 @@ func (p *CoreOSInstaller) getPackageSpecs() []rpmmd.PackageSpec {
 	return p.packageSpecs
 }
 
-func (p *CoreOSInstaller) serializeStart(packages []rpmmd.PackageSpec, _ []container.Spec, _ []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *CoreOSInstaller) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = packages
+	p.packageSpecs = inputs.Depsolved.Packages
 	if p.kernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.kernelName)
 	}
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *CoreOSInstaller) getInline() []string {

--- a/vendor/github.com/osbuild/images/pkg/manifest/empty.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/empty.go
@@ -65,14 +65,14 @@ func (p *ContentTest) getOSTreeCommits() []ostree.CommitSpec {
 	return p.commitSpecs
 }
 
-func (p *ContentTest) serializeStart(pkgs []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *ContentTest) serializeStart(inputs Inputs) {
 	if p.serializing {
 		panic("double call to serializeStart()")
 	}
-	p.packageSpecs = pkgs
-	p.containerSpecs = containers
-	p.commitSpecs = commits
-	p.repos = rpmRepos
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.containerSpecs = inputs.Containers
+	p.commitSpecs = inputs.Commits
+	p.repos = inputs.Depsolved.Repos
 
 	p.serializing = true
 }

--- a/vendor/github.com/osbuild/images/pkg/manifest/os.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/os.go
@@ -376,25 +376,25 @@ func (p *OS) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *OS) serializeStart(packages []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, rpmRepos []rpmmd.RepoConfig) {
+func (p *OS) serializeStart(inputs Inputs) {
 	if len(p.packageSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
 
-	p.packageSpecs = packages
-	p.containerSpecs = containers
-	if len(commits) > 0 {
-		if len(commits) > 1 {
+	p.packageSpecs = inputs.Depsolved.Packages
+	p.containerSpecs = inputs.Containers
+	if len(inputs.Commits) > 0 {
+		if len(inputs.Commits) > 1 {
 			panic("pipeline supports at most one ostree commit")
 		}
-		p.ostreeParentSpec = &commits[0]
+		p.ostreeParentSpec = &inputs.Commits[0]
 	}
 
 	if p.KernelName != "" {
 		p.kernelVer = rpmmd.GetVerStrFromPackageSpecListPanic(p.packageSpecs, p.KernelName)
 	}
 
-	p.repos = append(p.repos, rpmRepos...)
+	p.repos = append(p.repos, inputs.Depsolved.Repos...)
 }
 
 func (p *OS) serializeEnd() {

--- a/vendor/github.com/osbuild/images/pkg/manifest/ostree_deployment.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/ostree_deployment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // OSTreeDeploymentCustomizations encapsulates all configuration applied to an
@@ -161,18 +160,18 @@ func (p *OSTreeDeployment) getContainerSources() []container.SourceSpec {
 	}
 }
 
-func (p *OSTreeDeployment) serializeStart(_ []rpmmd.PackageSpec, containers []container.Spec, commits []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *OSTreeDeployment) serializeStart(inputs Inputs) {
 	if p.ostreeSpec != nil || p.containerSpec != nil {
 		panic("double call to serializeStart()")
 	}
 
 	switch {
-	case len(commits) == 1:
-		p.ostreeSpec = &commits[0]
-	case len(containers) == 1:
-		p.containerSpec = &containers[0]
+	case len(inputs.Commits) == 1:
+		p.ostreeSpec = &inputs.Commits[0]
+	case len(inputs.Containers) == 1:
+		p.containerSpec = &inputs.Containers[0]
 	default:
-		panic(fmt.Sprintf("pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), commits, containers))
+		panic(fmt.Sprintf("pipeline %s requires exactly one ostree commit or one container (have commits: %v; containers: %v)", p.Name(), inputs.Commits, inputs.Containers))
 	}
 }
 

--- a/vendor/github.com/osbuild/images/pkg/manifest/pipeline.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/pipeline.go
@@ -53,7 +53,7 @@ type Pipeline interface {
 	// its full Spec. See the ostree package for more details.
 	getOSTreeCommitSources() []ostree.SourceSpec
 
-	serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig)
+	serializeStart(Inputs)
 	serializeEnd()
 	serialize() osbuild.Pipeline
 
@@ -166,7 +166,7 @@ func NewBase(name string, build Build) Base {
 
 // serializeStart must be called exactly once before each call
 // to serialize().
-func (p Base) serializeStart([]rpmmd.PackageSpec, []container.Spec, []ostree.CommitSpec, []rpmmd.RepoConfig) {
+func (p Base) serializeStart(inputs Inputs) {
 }
 
 // serializeEnd must be called exactly once after each call to

--- a/vendor/github.com/osbuild/images/pkg/manifest/raw_bootc.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/raw_bootc.go
@@ -10,9 +10,7 @@ import (
 	"github.com/osbuild/images/pkg/customizations/users"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/osbuild"
-	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/platform"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // A RawBootcImage represents a raw bootc image file which can be booted in a
@@ -71,11 +69,11 @@ func (p *RawBootcImage) getContainerSpecs() []container.Spec {
 	return p.containerSpecs
 }
 
-func (p *RawBootcImage) serializeStart(_ []rpmmd.PackageSpec, containerSpecs []container.Spec, _ []ostree.CommitSpec, _ []rpmmd.RepoConfig) {
+func (p *RawBootcImage) serializeStart(inputs Inputs) {
 	if len(p.containerSpecs) > 0 {
 		panic("double call to serializeStart()")
 	}
-	p.containerSpecs = containerSpecs
+	p.containerSpecs = inputs.Containers
 }
 
 func (p *RawBootcImage) serializeEnd() {

--- a/vendor/github.com/osbuild/images/pkg/osbuild/curl_source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/curl_source.go
@@ -9,6 +9,8 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
+const SourceNameCurl = "org.osbuild.curl"
+
 var curlDigestPattern = regexp.MustCompile(`(md5|sha1|sha256|sha384|sha512):[0-9a-f]{32,128}`)
 
 type CurlSource struct {

--- a/vendor/github.com/osbuild/images/pkg/osbuild/erofs_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/erofs_stage.go
@@ -1,0 +1,24 @@
+package osbuild
+
+type ErofsCompression struct {
+	Method string `json:"method"`
+	Level  *int   `json:"level,omitempty"`
+}
+
+type ErofsStageOptions struct {
+	Filename string `json:"filename"`
+
+	Compression     *ErofsCompression `json:"compression,omitempty"`
+	ExtendedOptions []string          `json:"options,omitempty"`
+	ClusterSize     *int              `json:"cluster-size,omitempty"`
+}
+
+func (ErofsStageOptions) isStageOptions() {}
+
+func NewErofsStage(options *ErofsStageOptions, inputPipeline string) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.erofs",
+		Options: options,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
+	}
+}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/inline_source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/inline_source.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const SourceNameInline = "org.osbuild.inline"
+
 type InlineSource struct {
 	Items map[string]InlineSourceItem `json:"items"`
 }

--- a/vendor/github.com/osbuild/images/pkg/osbuild/librepo_source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/librepo_source.go
@@ -1,0 +1,128 @@
+package osbuild
+
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+const SourceNameLibrepo = "org.osbuild.librepo"
+
+// LibrepoSource wraps the org.osbuild.librepo osbuild source
+type LibrepoSource struct {
+	Items   map[string]*LibrepoSourceItem `json:"items"`
+	Options *LibrepoSourceOptions         `json:"options"`
+}
+
+func NewLibrepoSource() *LibrepoSource {
+	return &LibrepoSource{
+		Items: make(map[string]*LibrepoSourceItem),
+		Options: &LibrepoSourceOptions{
+			Mirrors: make(map[string]*LibrepoSourceMirror),
+		},
+	}
+}
+
+// AddPackage adds the given *depsolved* pkg to the downloading. It
+// needs the *depsovled* repoConfig so that the repoID of the two can
+// be matched up
+func (source *LibrepoSource) AddPackage(pkg rpmmd.PackageSpec, repos []rpmmd.RepoConfig) error {
+	pkgRepo, err := findRepoById(repos, pkg.RepoID)
+	if err != nil {
+		return fmt.Errorf("cannot find repo-id for pkg %v: %v", pkg.Name, err)
+	}
+	if _, ok := source.Options.Mirrors[pkgRepo.Id]; !ok {
+		mirror, err := mirrorFromRepo(pkgRepo)
+		if err != nil {
+			return err
+		}
+		source.Options.Mirrors[pkgRepo.Id] = mirror
+	}
+	mirror := source.Options.Mirrors[pkgRepo.Id]
+	if pkg.IgnoreSSL {
+		mirror.Insecure = true
+	}
+	// this should never happen but we should still check to avoid
+	// potential security issues
+	if mirror.Insecure && !pkg.IgnoreSSL {
+		return fmt.Errorf("inconsistent SSL configuration: package %v requires SSL but mirror %v is configured to ignore SSL", pkg.Name, mirror.URL)
+	}
+	if pkg.Secrets == "org.osbuild.rhsm" {
+		mirror.Secrets = &URLSecrets{
+			Name: "org.osbuild.rhsm",
+		}
+	} else if pkg.Secrets == "org.osbuild.mtls" {
+		mirror.Secrets = &URLSecrets{
+			Name: "org.osbuild.mtls",
+		}
+	}
+
+	item := &LibrepoSourceItem{
+		Path:     pkg.Path,
+		MirrorID: pkgRepo.Id,
+	}
+	source.Items[pkg.Checksum] = item
+	return nil
+}
+
+func (LibrepoSource) isSource() {}
+
+type LibrepoSourceItem struct {
+	Path     string `json:"path"`
+	MirrorID string `json:"mirror"`
+}
+
+func findRepoById(repos []rpmmd.RepoConfig, repoID string) (*rpmmd.RepoConfig, error) {
+	type info struct {
+		ID   string
+		Name string
+	}
+	var repoInfo []info
+	for _, repo := range repos {
+		repoInfo = append(repoInfo, info{repo.Id, repo.Name})
+		if repo.Id == repoID {
+			return &repo, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot find repo-id %v in %+v", repoID, repoInfo)
+}
+
+func mirrorFromRepo(repo *rpmmd.RepoConfig) (*LibrepoSourceMirror, error) {
+	switch {
+	case repo.Metalink != "":
+		return &LibrepoSourceMirror{
+			URL:  repo.Metalink,
+			Type: "metalink",
+		}, nil
+	case repo.MirrorList != "":
+		return &LibrepoSourceMirror{
+			URL:  repo.MirrorList,
+			Type: "mirrorlist",
+		}, nil
+	case len(repo.BaseURLs) > 0:
+		return &LibrepoSourceMirror{
+			// XXX: should we pick a random one instead?
+			URL:  repo.BaseURLs[0],
+			Type: "baseurl",
+		}, nil
+	}
+
+	return nil, fmt.Errorf("cannot find metalink, mirrorlist or baseurl for %+v", repo)
+}
+
+// librepoSourceOptions are the JSON options for source org.osbuild.librepo
+type LibrepoSourceOptions struct {
+	Mirrors map[string]*LibrepoSourceMirror `json:"mirrors"`
+}
+
+type LibrepoSourceMirror struct {
+	URL  string `json:"url"`
+	Type string `json:"type"`
+
+	Insecure bool        `json:"insecure,omitempty"`
+	Secrets  *URLSecrets `json:"secrets,omitempty"`
+
+	MaxParallels  *int `json:"max-parallels,omitempty"`
+	FastestMirror bool `json:"fastest-mirror,omitempty"`
+}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/ostree_source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/ostree_source.go
@@ -2,6 +2,8 @@ package osbuild
 
 import "github.com/osbuild/images/pkg/ostree"
 
+const SourceNameOstree = "org.osbuild.ostree"
+
 // The commits to fetch indexed their checksum
 type OSTreeSource struct {
 	Items map[string]OSTreeSourceItem `json:"items"`

--- a/vendor/github.com/osbuild/images/pkg/osbuild/source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/source.go
@@ -3,11 +3,32 @@ package osbuild
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/osbuild/images/pkg/container"
+	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
+
+// RpmDownloader specifies what backend to use for rpm downloads
+// Note that the librepo backend requires a newer osbuild.
+type RpmDownloader uint64
+
+const (
+	RpmDownloaderCurl    = iota
+	RpmDownloaderLibrepo = iota
+)
+
+// SourceInputs contains the inputs to generate osbuild.Sources
+// Note that for Packages/RpmRepos the depsolve resolved results
+// must be passed
+type SourceInputs struct {
+	Depsolved  dnfjson.DepsolveResult
+	Containers []container.Spec
+	Commits    []ostree.CommitSpec
+	InlineData []string
+}
 
 // A Sources map contains all the sources made available to an osbuild run
 type Sources map[string]Source
@@ -35,11 +56,13 @@ func (sources *Sources) UnmarshalJSON(data []byte) error {
 	for name, rawSource := range rawSources {
 		var source Source
 		switch name {
-		case "org.osbuild.curl":
+		case SourceNameCurl:
 			source = new(CurlSource)
-		case "org.osbuild.inline":
+		case SourceNameLibrepo:
+			source = new(LibrepoSource)
+		case SourceNameInline:
 			source = new(InlineSource)
-		case "org.osbuild.ostree":
+		case SourceNameOstree:
 			source = new(OSTreeSource)
 		default:
 			return errors.New("unexpected source name: " + name)
@@ -54,48 +77,78 @@ func (sources *Sources) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func GenSources(packages []rpmmd.PackageSpec, ostreeCommits []ostree.CommitSpec, inlineData []string, containers []container.Spec) (Sources, error) {
+func (sources Sources) addPackagesCurl(packages []rpmmd.PackageSpec) error {
+	curl := NewCurlSource()
+	for _, pkg := range packages {
+		err := curl.AddPackage(pkg)
+		if err != nil {
+			return err
+		}
+	}
+	sources[SourceNameCurl] = curl
+	return nil
+}
+
+func (sources Sources) addPackagesLibrepo(packages []rpmmd.PackageSpec, rpmRepos []rpmmd.RepoConfig) error {
+	librepo := NewLibrepoSource()
+	for _, pkg := range packages {
+		err := librepo.AddPackage(pkg, rpmRepos)
+		if err != nil {
+			return err
+		}
+	}
+	sources[SourceNameLibrepo] = librepo
+	return nil
+}
+
+// GenSources generates the Sources from the given inputs. Note that
+// the packages and rpmRepos need to come from the *resolved* set.
+func GenSources(inputs SourceInputs, rpmDownloader RpmDownloader) (Sources, error) {
 	sources := Sources{}
 
 	// collect rpm package sources
-	if len(packages) > 0 {
-		curl := NewCurlSource()
-		for _, pkg := range packages {
-			err := curl.AddPackage(pkg)
-			if err != nil {
-				return nil, err
-			}
+	if len(inputs.Depsolved.Packages) > 0 {
+		var err error
+		switch rpmDownloader {
+		case RpmDownloaderCurl:
+			err = sources.addPackagesCurl(inputs.Depsolved.Packages)
+		case RpmDownloaderLibrepo:
+			err = sources.addPackagesLibrepo(inputs.Depsolved.Packages, inputs.Depsolved.Repos)
+		default:
+			err = fmt.Errorf("unknown rpm downloader %v", rpmDownloader)
 		}
-		sources["org.osbuild.curl"] = curl
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// collect ostree commit sources
-	if len(ostreeCommits) > 0 {
+	if len(inputs.Commits) > 0 {
 		ostree := NewOSTreeSource()
-		for _, commit := range ostreeCommits {
+		for _, commit := range inputs.Commits {
 			ostree.AddItem(commit)
 		}
 		if len(ostree.Items) > 0 {
-			sources["org.osbuild.ostree"] = ostree
+			sources[SourceNameOstree] = ostree
 		}
 	}
 
 	// collect inline data sources
-	if len(inlineData) > 0 {
+	if len(inputs.InlineData) > 0 {
 		ils := NewInlineSource()
-		for _, data := range inlineData {
+		for _, data := range inputs.InlineData {
 			ils.AddItem(data)
 		}
 
-		sources["org.osbuild.inline"] = ils
+		sources[SourceNameInline] = ils
 	}
 
 	// collect skopeo and local container sources
-	if len(containers) > 0 {
+	if len(inputs.Containers) > 0 {
 		skopeo := NewSkopeoSource()
 		skopeoIndex := NewSkopeoIndexSource()
 		localContainers := NewContainersStorageSource()
-		for _, c := range containers {
+		for _, c := range inputs.Containers {
 			if c.LocalStorage {
 				localContainers.AddItem(c.ImageID)
 			} else {

--- a/vendor/github.com/osbuild/images/pkg/rpmmd/repository.go
+++ b/vendor/github.com/osbuild/images/pkg/rpmmd/repository.go
@@ -165,6 +165,9 @@ type PackageSpec struct {
 	Secrets        string `json:"secrets,omitempty"`
 	CheckGPG       bool   `json:"check_gpg,omitempty"`
 	IgnoreSSL      bool   `json:"ignore_ssl,omitempty"`
+
+	Path   string `json:"path,omitempty"`
+	RepoID string `json:"repo_id,omitempty"`
 }
 
 type PackageSource struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1021,7 +1021,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.109.0
+# github.com/osbuild/images v0.111.0
 ## explicit; go 1.21.0
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
~~edit: draft as I'm stuggeling right now with the weldr tests and the repo_id integration there~~

This is a WIP branch to port osbuild-composer to the latest version of images. The notable change is the inclusion of the librepo support which changes the manifest.Serialize() API but it also adds extra fields like "repo_id" into the package spec.

EDIT (akoutsou): Fixed up the tests.  Had to add repo IDs to a lot of mock responses.  Some of them needed to be added by the test function separately because they change based on the repo config.
