### PR TITLE
composer: use `reporegistry.New()` again (see PR#4378)

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -77,8 +77,10 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 		return nil, fmt.Errorf("failed to configure distro aliases: %v", err)
 	}
 
-	repoConfigs, err := reporegistry.LoadAllRepositories(repositoryConfigs)
+	c.repos, err = reporegistry.New(repositoryConfigs)
 	switch err.(type) {
+	case nil:
+		// fine
 	case *reporegistry.NoReposLoadedError:
 		if !c.config.IgnoreMissingRepos {
 			return nil, fmt.Errorf("error loading repository definitions: %w", err)
@@ -86,8 +88,6 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 		// running without repositories is allowed: log message and continue
 		logrus.Info(err.Error())
 		logrus.Info("ignore_missing_repos enabled: continuing")
-	case nil:
-		c.repos = reporegistry.NewFromDistrosRepoConfigs(repoConfigs)
 	default:
 		return nil, fmt.Errorf("error loading repository definitions: %w", err)
 	}


### PR DESCRIPTION
This commit changes cmd/composer to use the `reporegistry.New` call again. This is a preparation for
https://github.com/osbuild/images/pull/1179

And undoes parts of https://github.com/osbuild/osbuild-composer/pull/4378 but that is no longer necessary because in
https://github.com/osbuild/images/pull/946 the error is now passed on from `reporegistry.New()` in the same way as from `LoadRepositories()`.
