### PR TITLE
go.mod: upgrade glog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-	github.com/golang/glog v1.2.2 // indirect
+	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-containerregistry v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
-github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/vendor/github.com/golang/glog/glog.go
+++ b/vendor/github.com/golang/glog/glog.go
@@ -76,7 +76,7 @@
 //			-log_backtrace_at=gopherflakes.go:234
 //		A stack trace will be written to the Info log whenever execution
 //		hits one of these statements. (Unlike with -vmodule, the ".go"
-//		must bepresent.)
+//		must be present.)
 //	-v=0
 //		Enable V-leveled logging at the specified level.
 //	-vmodule=""

--- a/vendor/github.com/golang/glog/glog_file_nonwindows.go
+++ b/vendor/github.com/golang/glog/glog_file_nonwindows.go
@@ -4,6 +4,13 @@ package glog
 
 import "os/user"
 
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this always returns true on non-Windows platforms, as it specifically checks for a
+// condition that is only present on Windows.
+func shouldRegisterStderrSink() bool {
+	return true
+}
+
 func lookupUser() string {
 	if current, err := user.Current(); err == nil {
 		return current.Username

--- a/vendor/github.com/golang/glog/glog_file_windows.go
+++ b/vendor/github.com/golang/glog/glog_file_windows.go
@@ -3,8 +3,21 @@
 package glog
 
 import (
+	"os"
 	"syscall"
 )
+
+// shouldRegisterStderrSink determines whether we should register a log sink that writes to stderr.
+// Today, this checks if stderr is "valid", in that it maps to a non-NULL Handle.
+// Windows Services are spawned without Stdout and Stderr, so any attempt to use them equates to
+// referencing an invalid file Handle.
+// os.Stderr's FD is derived from a call to `syscall.GetStdHandle(syscall.STD_ERROR_HANDLE)`.
+// Documentation[1] for the GetStdHandle function indicates the return value may be NULL if the
+// application lacks the standard handle, so consider Stderr valid if its FD is non-NULL.
+// [1]: https://learn.microsoft.com/en-us/windows/console/getstdhandle
+func shouldRegisterStderrSink() bool {
+	return os.Stderr.Fd() != 0
+}
 
 // This follows the logic in the standard library's user.Current() function, except
 // that it leaves out the potentially expensive calls required to look up the user's

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -749,7 +749,7 @@ github.com/golang-jwt/jwt/v4
 # github.com/golang-jwt/jwt/v5 v5.2.1
 ## explicit; go 1.18
 github.com/golang-jwt/jwt/v5
-# github.com/golang/glog v1.2.2
+# github.com/golang/glog v1.2.4
 ## explicit; go 1.19
 github.com/golang/glog
 github.com/golang/glog/internal/logsink


### PR DESCRIPTION
github.com/golang/glog 1.2.2 is reported to be potentially vulnerable, so we'll upgrade to 1.2.4.
