### PR TITLE
internal/cloud/gcp/compute: Add TDX_CAPABLE guest OS feature

### DIFF
--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -29,6 +29,18 @@ var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeatu
 	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
 	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE_V2.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_TDX_CAPABLE.String())},
+}
+
+// Guest OS Features for RHEL images up to RHEL9.5.
+// The TDX support was added since RHEL-9.6.
+var GuestOsFeaturesRHEL95 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
+	{Type: common.ToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_GVNIC.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_SNP_CAPABLE.String())},
+	{Type: common.ToPtr(computepb.GuestOsFeature_SEV_LIVE_MIGRATABLE_V2.String())},
 }
 
 // Guest OS Features for RHEL9.1 images.
@@ -71,6 +83,14 @@ func GuestOsFeaturesByDistro(distroName string) []*computepb.GuestOsFeature {
 	// TODO: this should be updated for the dot-notation
 	case distroName == "rhel-91":
 		return GuestOsFeaturesRHEL91
+	case distroName == "rhel-92":
+		fallthrough
+	case distroName == "rhel-93":
+		fallthrough
+	case distroName == "rhel-94":
+		fallthrough
+	case distroName == "rhel-95":
+		return GuestOsFeaturesRHEL95
 	case strings.HasPrefix(distroName, "centos-9"):
 		fallthrough
 	case strings.HasPrefix(distroName, "rhel-9"):


### PR DESCRIPTION
Latest RHEL images (from 9.6 on) should fully support running as TDX guests, as well as latest CentOS images.

See: https://issues.redhat.com/browse/COS-3111
See: https://github.com/coreos/coreos-assembler/pull/4006
See: https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/5979


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

I couldn't find anything relevant to be changed to address the points above.


<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->