### PR TITLE
tools: use go toolbox instead of installing a binary

### DIFF
--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -1,9 +1,20 @@
 #!/bin/sh
 
-set -eux
+set -eu
 
-# Pin Go and toolbox versions at a reasonable version
-go get go@1.22.6 toolchain@1.22.6
+GO_MINOR_VERSION="1.22"
+GO_VERSION="${GO_MINOR_VERSION}.6"
+
+# Check latest Go version for the minor we're using
+LATEST=$(curl -s https://endoflife.date/api/go/"${GO_MINOR_VERSION}".json  | jq -r .latest)
+if test "$LATEST" != "$GO_VERSION"; then
+    echo "NOTE: A new minor release is available (${LATEST}), consider bumping the project version (${GO_VERSION})"
+fi
+
+set -x
+
+# Pin Go and toolbox versions
+go get "go@${GO_VERSION}" "toolchain@${GO_VERSION}"
 
 # Update go.mod and go.sum:
 go mod tidy

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,20 +2,15 @@
 
 set -eux
 
-GO_VERSION=1.22.6
-GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
+# Pin Go and toolbox versions at a reasonable version
+go get go@1.22.6 toolchain@1.22.6
 
-# this is the official way to get a different version of golang
-# see https://go.dev/doc/manage-install
-go install golang.org/dl/go$GO_VERSION@latest
-$GO_BINARY download
+# Update go.mod and go.sum:
+go mod tidy
+go mod vendor
 
-# ensure that go.mod and go.sum are up to date, ...
-$GO_BINARY mod tidy
-$GO_BINARY mod vendor
+# Generate all sources (skip vendor/):
+go generate ./cmd/... ./internal/... ./pkg/...
 
-# ... and all code has been regenerated from its sources.
-$GO_BINARY generate ./...
-
-# ... the code is formatted correctly, ...
-$GO_BINARY fmt ./...
+# Format all sources (skip vendor/):
+go fmt ./cmd/... ./internal/... ./pkg/...


### PR DESCRIPTION
Repeat of 8554d6202dff0f887d0f8bec838f15c24af02e8d.

This is a much nicer (and newer) way of handling the Go version for the
project.  The issue that caused the previous revert was that the toolbox
version was being set to 1.22.0, which is older than what some
dependencies require, specifically osbuild/images, so the 'go mod tidy'
would downgrade images to match the required toolbox version.

Setting the go and toolbox version to 1.22.6 should make it all work as
expected.

This reverts commit 7e87d1e124c1bbd49f7a0afcd732fd83357f4e57.

Co-authored-by: Lukáš Zapletal <lukas@zapletalovi.com>
