### PR TITLE
ITM26 last-minute fixes

### DIFF
--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -127,7 +127,7 @@ func GetDefaultConfig() *ComposerConfigFile {
 		DistroAliases: map[string]string{
 			"rhel-7":  "rhel-7.9",
 			"rhel-8":  "rhel-8.10",
-			"rhel-9":  "rhel-9.5",
+			"rhel-9":  "rhel-9.6",
 			"rhel-10": "rhel-10.0",
 		},
 		LogLevel:           "info",

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -73,7 +73,7 @@ func TestDefaultConfig(t *testing.T) {
 		"rhel-10": "rhel-10.0",
 		"rhel-7":  "rhel-7.9",
 		"rhel-8":  "rhel-8.10",
-		"rhel-9":  "rhel-9.5",
+		"rhel-9":  "rhel-9.6",
 	}
 	require.Equal(t, expectedDistroAliases, defaultConfig.DistroAliases)
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -85,11 +85,10 @@ export PATH=$PWD/_bin${PATH:+:$PATH}
 export GOPATH=$GO_BUILD_PATH:%{gopath}
 export GOFLAGS+=" -mod=vendor"
 %endif
-%if 0%{?fedora}
-# Fedora disables Go modules by default, but we want to use them.
-# Undefine the macro which disables it to use the default behavior.
+
+# Fedora and RHEL versions disable Go modules by default, but we want to use them.
+# Unconditionally undefine the macro which disables it to use the default behavior.
 %undefine gomodulesmode
-%endif
 
 # btrfs-progs-devel is not available on RHEL
 %if 0%{?rhel}


### PR DESCRIPTION
I noticed a few issues that should land in RHEL-9.6 and RHEL-10:

- SPEC: unconditionally undefine gomodulesmode
- osbuild-composer: bump rhel-9 distro alias to rhel-9.6