### PR TITLE
test/README: image-builder repo was renamed to image-builder-crc

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -363,10 +363,10 @@ is is missing lots of details!
 ## QE associates/responsibilities matrix
 
 - [@atodorov](https://github.com/atodorov) - QE lead;
-  osbuild, osbuild-composer, weldr-client, composer-cli, image-builder, image-builder-frontend,
+  osbuild, osbuild-composer, weldr-client, composer-cli, image-builder-crc, image-builder-frontend,
   bug testing & verification, anything else
 - [@jrusz](https://github.com/jrusz) - testing across the board; backup for @atodorov;
-  osbuild, osbuild-composer, weldr-client, composer-cli, image-builder, image-builder-frontend,
+  osbuild, osbuild-composer, weldr-client, composer-cli, image-builder-crc, image-builder-frontend,
   bug testing & verification, anything else
 - [@henrywang](https://github.com/henrywang) - everything related to testing RHEL for Edge images
 - [@yih-redhat](https://github.com/yih-redhat) - everything related to testing RHEL for Edge images;


### PR DESCRIPTION
The repository of the "backend" aka "middleware" was renamed
from `image-builder` to `image-builder-crc`.