### PR TITLE
Use golangci-lint v1.60 and cleanup the errors it returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-exclude-dirs:
-  - vendor
-
 linters-settings:
   govet:
     disable:
@@ -23,6 +20,9 @@ run:
   timeout: 5m
 
 issues:
+  exclude-dirs:
+    - vendor
+
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,13 @@ RST2MAN ?= rst2man
 SHELL := /bin/bash
 .SHELLFLAGS := -ec -o pipefail
 
-# see https://hub.docker.com/r/docker/golangci-lint/tags
-# v1.56 to get golang 1.22 (1.22.1)
+# see https://hub.docker.com/r/golangci/golangci-lint/tags
+# This is also used in Containerfile_golangci_lint FROM line
+# v1.60 to get golang 1.23 (1.23.0)
+# v1.56 to get golang 1.22 (1.22.0)
 # v1.55 to get golang 1.21 (1.21.3)
 # v1.53 to get golang 1.20 (1.20.5)
-GOLANGCI_LINT_VERSION=v1.56
+GOLANGCI_LINT_VERSION=v1.60
 GOLANGCI_LINT_CACHE_DIR=$(HOME)/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION)
 GOLANGCI_COMPOSER_IMAGE=composer_golangci
 #

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ SHELLCHECK_FILES=$(shell find . -name "*.sh" -not -regex "./vendor/.*")
 .PHONY: lint
 lint: $(GOLANGCI_LINT_CACHE_DIR) container_composer_golangci_built.info
 	./tools/prepare-source.sh
+	podman run -t --rm -v $(SRCDIR):/app:z -v $(GOLANGCI_LINT_CACHE_DIR):/root/.cache:z -w /app $(GOLANGCI_COMPOSER_IMAGE) golangci-lint config verify -v
 	podman run -t --rm -v $(SRCDIR):/app:z -v $(GOLANGCI_LINT_CACHE_DIR):/root/.cache:z -w /app $(GOLANGCI_COMPOSER_IMAGE) golangci-lint run -v
 	echo "$(SHELLCHECK_FILES)" | xargs shellcheck --shell bash -e SC1091 -e SC2002 -e SC2317
 

--- a/cmd/gen-manifests/workerqueue.go
+++ b/cmd/gen-manifests/workerqueue.go
@@ -94,7 +94,7 @@ func (wq *workerQueue) startMessagePrinter() {
 		var msglen int
 		for msg := range wq.msgQueue {
 			// clear previous line (avoids leftover trailing characters from progress)
-			fmt.Printf(strings.Repeat(" ", msglen) + "\r")
+			fmt.Print(strings.Repeat(" ", msglen) + "\r")
 			fmt.Println(msg)
 			msglen, _ = fmt.Printf(" == Jobs == Queue: %4d  Active: %4d  Total: %4d\r", len(wq.jobQueue), wq.activeWorkers, wq.njobs)
 		}

--- a/cmd/osbuild-worker-executor/handler_build.go
+++ b/cmd/osbuild-worker-executor/handler_build.go
@@ -202,7 +202,7 @@ func handleIncludedSources(atar *tar.Reader, buildDir string) error {
 
 		// this assume "well" behaving tars, i.e. all dirs that lead
 		// up to the tar are included etc
-		mode := os.FileMode(hdr.Mode)
+		mode := hdr.FileInfo().Mode()
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.Mkdir(target, mode); err != nil {

--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/osbuild/osbuild-composer/internal/upload/azure"
@@ -20,7 +21,7 @@ type kerberosConfig struct {
 
 type kojiServerConfig struct {
 	Kerberos           *kerberosConfig `toml:"kerberos,omitempty"`
-	RelaxTimeoutFactor uint            `toml:"relax_timeout_factor"`
+	RelaxTimeoutFactor time.Duration   `toml:"relax_timeout_factor"`
 }
 
 type gcpConfig struct {

--- a/cmd/osbuild-worker/jobimpl-file-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-file-resolve.go
@@ -28,7 +28,7 @@ func (impl *FileResolveJobImpl) Run(job worker.Job) error {
 			}
 		}
 
-		if result.Results == nil || len(result.Results) == 0 {
+		if len(result.Results) == 0 {
 			logWithId.Infof("Resolving file contents failed: %v", err)
 			result.JobError = clienterrors.New(
 				clienterrors.ErrorRemoteFileResolution,

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -39,7 +39,7 @@ type connectionConfig struct {
 
 type kojiServer struct {
 	creds              koji.GSSAPICredentials
-	relaxTimeoutFactor uint
+	relaxTimeoutFactor time.Duration
 }
 
 // Represents the implementation of a job type as defined by the worker API.

--- a/internal/blueprint/fsnode_customizations.go
+++ b/internal/blueprint/fsnode_customizations.go
@@ -144,6 +144,8 @@ func (d DirectoryCustomization) ToFsNodeDirectory() (*fsnode.Directory, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid mode %s: %v", d.Mode, err)
 		}
+		// modeNum is parsed as an unsigned 32 bit int
+		/* #nosec G115 */
 		mode = common.ToPtr(os.FileMode(modeNum))
 	}
 
@@ -302,6 +304,8 @@ func (f FileCustomization) ToFsNodeFile() (*fsnode.File, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid mode %s: %v", f.Mode, err)
 		}
+		// modeNum is parsed as an unsigned 32 bit int
+		/* #nosec G115 */
 		mode = common.ToPtr(os.FileMode(modeNum))
 	}
 

--- a/internal/boot/netns.go
+++ b/internal/boot/netns.go
@@ -73,6 +73,8 @@ func newNetworkNamespace() (NetNS, error) {
 		return "", fmt.Errorf("cannot unshare the network namespace")
 	}
 	defer func() {
+		// The Fd() is actually an int cast into a uintptr, so casting back to an int is fine
+		/* #nosec G115 */
 		err = unix.Setns(int(oldNS.Fd()), syscall.CLONE_NEWNET)
 		if err != nil {
 			// We cannot return to the original namespace.

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -464,7 +464,13 @@ func (h *apiHandlers) getJobIDComposeStatus(jobId uuid.UUID) (ComposeStatus, err
 			ImageStatuses: &buildJobStatuses,
 			KojiStatus:    &KojiStatus{},
 		}
+		/* #nosec G115 */
 		buildID := int(initResult.BuildID)
+		// Make sure signed integer conversion didn't underflow
+		if buildID < 0 {
+			err := fmt.Errorf("BuildID integer underflow: %d", initResult.BuildID)
+			return ComposeStatus{}, HTTPErrorWithInternal(ErrorMalformedOSBuildJobResult, err)
+		}
 		if buildID != 0 {
 			response.KojiStatus.BuildId = &buildID
 		}

--- a/internal/upload/koji/koji.go
+++ b/internal/upload/koji/koji.go
@@ -574,7 +574,7 @@ func GSSAPICredentialsFromEnv() (*GSSAPICredentials, error) {
 	}, nil
 }
 
-func CreateKojiTransport(relaxTimeout uint) http.RoundTripper {
+func CreateKojiTransport(relaxTimeout time.Duration) http.RoundTripper {
 	// Koji for some reason needs TLS renegotiation enabled.
 	// Clone the default http rt and enable renegotiation.
 	rt := CreateRetryableTransport()
@@ -588,9 +588,9 @@ func CreateKojiTransport(relaxTimeout uint) http.RoundTripper {
 
 	// Relax timeouts a bit
 	if relaxTimeout > 0 {
-		transport.TLSHandshakeTimeout *= time.Duration(relaxTimeout)
+		transport.TLSHandshakeTimeout *= relaxTimeout
 		transport.DialContext = (&net.Dialer{
-			Timeout:   30 * time.Second * time.Duration(relaxTimeout),
+			Timeout:   30 * time.Second * relaxTimeout,
 			KeepAlive: 30 * time.Second,
 		}).DialContext
 	}


### PR DESCRIPTION
Currently a draft because I am not sure how to handle:
```
internal/cloudapi/v2/handler.go:467:17: G115: integer overflow conversion uint64 -> int (gosec)
                buildID := int(initResult.BuildID)
                              ^
cmd/osbuild-worker/jobimpl-koji-finalize.go:314:19: G115: integer overflow conversion uint64 -> int64 (gosec)
                StartTime: int64(args.StartTime),
                                ^
cmd/osbuild-worker/jobimpl-koji-finalize.go:105:40: G115: integer overflow conversion uint64 -> int (gosec)
                        err = impl.kojiFail(args.Server, int(initArgs.BuildID), initArgs.Token)
```

Ideally these would just use the proper type from the start, but I don't know exactly how this interacts with koji, what values it expects or returns.

