### PR TITLE
remove workaround for CLOUDX-994

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -259,26 +259,20 @@ cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 # temporary workaround for
 # https://issues.redhat.com/browse/CLOUDX-488
 if nvrGreaterOrEqual "osbuild-composer" "83"; then
-    # TODO: Remove this workaround, once CLOUDX-994 is resolved
-    if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} == 10 ]]; then
-        RESULTS=1
-        yellowprint "WARNING: cloud-image-val currently skipped until CLOUDX-994 is resolved!"
-    else
-        sudo "${CONTAINER_RUNTIME}" run \
-            --net=host \
-            -a stdout -a stderr \
-            -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
-            -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
-            -e AWS_REGION="${AWS_REGION}" \
-            -e JIRA_PAT="${JIRA_PAT}" \
-            -v "${TEMPDIR}":/tmp:Z \
-            "${CONTAINER_CLOUD_IMAGE_VAL}" \
-            python cloud-image-val.py \
-            -c /tmp/civ_config.yml \
-            && RESULTS=1 || RESULTS=0
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
+        -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
+        -e AWS_REGION="${AWS_REGION}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-        mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-    fi
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
 else
     RESULTS=1
 fi

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -240,27 +240,21 @@ cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 # temporary workaround for
 # https://issues.redhat.com/browse/CLOUDX-488
 if nvrGreaterOrEqual "osbuild-composer" "83"; then
-    # TODO: Remove this workaround, once CLOUDX-994 is resolved
-    if [[ ($ID == rhel || $ID == centos) && ${VERSION_ID%.*} == 10 ]]; then
-        RESULTS=1
-        yellowprint "WARNING: cloud-image-val currently skipped until CLOUDX-994 is resolved!"
-    else
-        sudo "${CONTAINER_RUNTIME}" run \
-            --net=host \
-            -a stdout -a stderr \
-            -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
-            -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
-            -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
-            -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
-            -e JIRA_PAT="${JIRA_PAT}" \
-            -v "${TEMPDIR}":/tmp:Z \
-            "${CONTAINER_CLOUD_IMAGE_VAL}" \
-            python cloud-image-val.py \
-            -c /tmp/civ_config.yml \
-            && RESULTS=1 || RESULTS=0
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
+        -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
+        -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+        -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-        mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-    fi
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
 else
     RESULTS=1
 fi


### PR DESCRIPTION
In CloudX, we'd like to start testing on RHEL10 and CentOS10. Therefore, we'd like to see what tests are applicable and failing for these runners if any. For the start, please see the fix for [CLOUDX-994](https://issues.redhat.com/browse/CLOUDX-994) as [PR364](https://github.com/osbuild/cloud-image-val/pull/364). Thus, this PR removes a workaround for [CLOUDX-994](https://issues.redhat.com/browse/CLOUDX-994) which skips RHEL10/CentOS10 runners.



This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
