### PR TITLE
cloudapi: silence logrus in tests

### DIFF
--- a/internal/cloudapi/v2/v2_internal_test.go
+++ b/internal/cloudapi/v2/v2_internal_test.go
@@ -1,8 +1,10 @@
 package v2
 
 import (
+	"io"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -10,6 +12,13 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 )
+
+func init() {
+	// logrus is creating so much output that it drowns the useful
+	// test output and we don't get test anything logrus related
+	// anyway so silence it by default
+	logrus.SetOutput(io.Discard)
+}
 
 func TestSplitExtension(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This commit discards the logrus output when the tests are run. That might be a controversial change but the amount of redundant output that drowns the actual failures makes it very hard to work with these tests.

I want to paste the output here in full but github won't let me because it's too long for the limits that the body can have!
It is 1135 lines and exceeds the 65536 bytes limit of GH.

