### PR TITLE
cloudapi: Use constants for distro in compose_test.go

### DIFF
--- a/internal/cloudapi/v2/compose_test.go
+++ b/internal/cloudapi/v2/compose_test.go
@@ -4,7 +4,7 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/osbuild/images/data/repositories"
+	repos "github.com/osbuild/images/data/repositories"
 	"github.com/osbuild/images/pkg/customizations/subscription"
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distrofactory"
@@ -15,6 +15,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// Change these when moving to a new release
+const (
+	TEST_DISTRO_NAME    = "fedora-42"
+	TEST_DISTRO_VERSION = "42"
 )
 
 // GetTestBlueprint returns a populated blueprint
@@ -805,7 +811,7 @@ func TestGetImageRequests_ImageTypeConversion(t *testing.T) {
 func TestGetImageRequests_NoRepositories(t *testing.T) {
 	uo := UploadOptions(struct{}{})
 	request := &ComposeRequest{
-		Distribution: "fedora-42",
+		Distribution: TEST_DISTRO_NAME,
 		ImageRequest: &ImageRequest{
 			Architecture:  "x86_64",
 			ImageType:     ImageTypesAws,
@@ -819,14 +825,14 @@ func TestGetImageRequests_NoRepositories(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Greater(t, len(got[0].repositories), 0)
-	assert.Contains(t, got[0].repositories[0].Metalink, "42")
+	assert.Contains(t, got[0].repositories[0].Metalink, TEST_DISTRO_VERSION)
 }
 
 // TestGetImageRequests_BlueprintDistro test to make sure blueprint distro overrides request distro
 func TestGetImageRequests_BlueprintDistro(t *testing.T) {
 	uo := UploadOptions(struct{}{})
 	request := &ComposeRequest{
-		Distribution: "fedora-42",
+		Distribution: TEST_DISTRO_NAME,
 		ImageRequest: &ImageRequest{
 			Architecture:  "x86_64",
 			ImageType:     ImageTypesAws,
@@ -835,7 +841,7 @@ func TestGetImageRequests_BlueprintDistro(t *testing.T) {
 		},
 		Blueprint: &Blueprint{
 			Name:   "distro-test",
-			Distro: common.ToPtr("fedora-42"),
+			Distro: common.ToPtr(TEST_DISTRO_NAME),
 		},
 	}
 	rr, err := reporegistry.New(nil, []fs.FS{repos.FS})
@@ -844,8 +850,8 @@ func TestGetImageRequests_BlueprintDistro(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Greater(t, len(got[0].repositories), 0)
-	assert.Contains(t, got[0].repositories[0].Metalink, "42")
-	assert.Equal(t, got[0].blueprint.Distro, "fedora-42")
+	assert.Contains(t, got[0].repositories[0].Metalink, TEST_DISTRO_VERSION)
+	assert.Equal(t, got[0].blueprint.Distro, TEST_DISTRO_NAME)
 }
 
 func TestOpenSCAPTailoringOptions(t *testing.T) {


### PR DESCRIPTION
This will make it easier to update next time the distribution version needs to be bumped.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
