### PR TITLE
tests/CI: Disable installer test for RHEL 10.0 nightly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -811,7 +811,10 @@ Installer:
   extends: .terraform/openstack
   rules:
     - !reference [.upstream_rules_all, rules]
-    - !reference [.nightly_rules_all, rules]
+    # Disable Installer test for RHEL 10.0 nightly pipeline because fix for dracut issue won't make to nightly composes
+    # For more info see: https://issues.redhat.com/browse/RHEL-80160
+    # - !reference [.nightly_rules_all, rules]
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUNNER =~ /[\S]+rhel-9.6-[^ga][\S]+/ && $NIGHTLY == "true" && $RHEL_MAJOR == "9"'
     - !reference [.ga_rules_all, rules]
   script:
     - schutzbot/deploy.sh


### PR DESCRIPTION
Disable installer test because it will keep failing due to the fix for dracut missing ifcfg won't make RHEL 10 nightly composes.

