### PR TITLE
CODEOWNERS: set people for `/templates`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,9 @@
 # Worker code
 /internal/worker/       @thozza
 /cmd/osbuild-worker/    @thozza
+
+# Service deployment
+# (note: last match wins)
+/templates/ @croissanne @kingsleyzissou @schuellerf @thozza
+/templates/dashboards/ @croissanne @kingsleyzissou @schuellerf @thozza
+


### PR DESCRIPTION
Setting people for `/templates` codeowners: @croissanne @kingsleyzissou @thozza (and myself)

@kingsleyzissou do you want to be part of `/templates` or only `/templates/dashboards`
Did I miss someone?