### PR TITLE
test: migrate the openshift virt test to a new cluster (COMPOSER-2458)

### DIFF
--- a/test/cases/openshift_virtualization.sh
+++ b/test/cases/openshift_virtualization.sh
@@ -167,12 +167,12 @@ sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null
 
 
 # install the OpenShift cli & virtctl binary
-sudo dnf -y install wget
-# https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html
-wget --no-check-certificate https://downloads-openshift-console.apps.prod-scale-spoke1-aws-us-east-1.itup.redhat.com/amd64/linux/oc.tar --directory-prefix "$TEMPDIR"
-# https://docs.openshift.com/container-platform/4.13/virt/virt-using-the-cli-tools.html
-wget --no-check-certificate https://hyperconverged-cluster-cli-download-openshift-cnv.apps.prod-scale-spoke1-aws-us-east-1.itup.redhat.com/amd64/linux/virtctl.tar.gz --directory-prefix "$TEMPDIR"
 pushd "$TEMPDIR"
+# https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html
+curl -kLO https://downloads-openshift-console.apps.prod-scale-spoke1-aws-us-east-1.itup.redhat.com/amd64/linux/oc.tar
+# https://docs.openshift.com/container-platform/4.13/virt/virt-using-the-cli-tools.html
+curl -kLO https://hyperconverged-cluster-cli-download-openshift-cnv.apps.prod-scale-spoke1-aws-us-east-1.itup.redhat.com/amd64/linux/virtctl.tar.gz
+
 tar -xvf oc.tar
 tar -xzvf virtctl.tar.gz
 popd


### PR DESCRIPTION
The old one is going to be decommissioned. I only changed:
- extracted the storage class to a variable
- adjusted the openshift yaml file to what I was given in the UI
  - most importantly, we now use an instancetype to specify the
    resource requirements instead of doing it manually
  - the network is called default, instead of nic0 on this cluster
- we are downloading the oc and virtctl clients from the new cluster
  so the versions match

+ I removed wget, and introduced retries to help with flakiness.