### PR TITLE
GH Action/create-tag: allow passing the version when run manually

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -3,6 +3,11 @@ name: "Create and push release tag"
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag. Useful for making the first "dot" release from a rhel-x.y branch.'
+        required: false
+        default: ""
   schedule:
     - cron: "0 8 * * 3"
 
@@ -22,3 +27,4 @@ jobs:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
           username: "imagebuilder-bot"
           email: "imagebuilder-bots+imagebuilder-bot@redhat.com"
+          version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Modify the action to allow passing the version when run manually. This will be useful in the future once we branch-off a `rhel-x.y` branch to backport a fix and will be doing the first "dot" release from such branch.

Depends on https://github.com/osbuild/release-action/pull/29