### PR TITLE
[RHEL-9.5.0] SPEC: bump the version to the next to release

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -3,6 +3,11 @@ name: "Create and push release tag"
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag. Useful for making the first "dot" release from a rhel-x.y branch.'
+        required: false
+        default: ""
   schedule:
     - cron: "0 8 * * 3"
 
@@ -22,3 +27,4 @@ jobs:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
           username: "imagebuilder-bot"
           email: "imagebuilder-bots+imagebuilder-bot@redhat.com"
+          version: ${{ github.event.inputs.version }}

--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -11,10 +11,7 @@
 package client
 
 import (
-	"fmt"
-	"os/exec"
 	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -1060,22 +1057,6 @@ func TestBlueprintFreezeV0(t *testing.T) {
 func TestBlueprintFreezeGlobsV0(t *testing.T) {
 	// Test needs real packages, skip it for unit testing
 	if testState.unitTest {
-		t.Skip()
-	}
-
-	// works with osbuild-composer v83 and later
-	rpm_q := exec.Command("rpm", "-q", "--qf", "%{version}", "osbuild-composer")
-	out, err := rpm_q.CombinedOutput()
-	if err != nil {
-		assert.Fail(t, fmt.Sprintf("Error during rpm -q: %s", err))
-	}
-
-	rpm_version, err := strconv.Atoi(string(out))
-	if err != nil {
-		assert.Fail(t, "Error during str-int conversion", err)
-	}
-
-	if rpm_version < 83 {
 		t.Skip()
 	}
 

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -12,7 +12,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        118
+Version:        118.1
 
 %gometa
 


### PR DESCRIPTION
Also add the option to specify version for the "create tag" action for the first "dot" release on the branch.