### PR TITLE
client/blueprints_test.go: delete condition for composer version < 83

### DIFF
--- a/internal/client/blueprints_test.go
+++ b/internal/client/blueprints_test.go
@@ -11,10 +11,7 @@
 package client
 
 import (
-	"fmt"
-	"os/exec"
 	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -1060,22 +1057,6 @@ func TestBlueprintFreezeV0(t *testing.T) {
 func TestBlueprintFreezeGlobsV0(t *testing.T) {
 	// Test needs real packages, skip it for unit testing
 	if testState.unitTest {
-		t.Skip()
-	}
-
-	// works with osbuild-composer v83 and later
-	rpm_q := exec.Command("rpm", "-q", "--qf", "%{version}", "osbuild-composer")
-	out, err := rpm_q.CombinedOutput()
-	if err != nil {
-		assert.Fail(t, fmt.Sprintf("Error during rpm -q: %s", err))
-	}
-
-	rpm_version, err := strconv.Atoi(string(out))
-	if err != nil {
-		assert.Fail(t, "Error during str-int conversion", err)
-	}
-
-	if rpm_version < 83 {
 		t.Skip()
 	}
 


### PR DESCRIPTION
The version check is failing on the "dot" version, while trying to convert "118.1" to an integer. Delete the condition for skipping the test, because it will never be running on anything older than v83 anyway.