### PR TITLE
Disable vmware tests and verification step in vsphere builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -489,25 +489,34 @@ gcp.sh:
   variables:
     SCRIPT: gcp.sh
 
-vmware.sh_vmdk:
-  extends: .integration_rhel
-  rules:
-    # Run only on x86_64
-    - !reference [.upstream_rules_x86_64, rules]
-    - !reference [.nightly_rules_x86_64, rules]
-    - !reference [.ga_rules_x86_64, rules]
-  variables:
-    SCRIPT: vmware.sh vmdk
+# NOTE(akoutsou): The vmware tests are consistently failing. While the
+# build succeeds, the upload fails with:
+#   Unable to protect host, if the host isn't running as part of an
+#   autoscaling group, this can safely be ignored: operation error Auto
+#   Scaling: DescribeAutoScalingInstances, get identity: get credentials:
+#   failed to refresh cached credentials, no EC2 IMDS role found, operation
+#   error ec2imds: GetMetadata, http response error StatusCode: 404, request
+#   to EC2 IMDS failed
+# Disabling the test until we have time to look into it furhter.
+# vmware.sh_vmdk:
+#   extends: .integration_rhel
+#   rules:
+#     # Run only on x86_64
+#     - !reference [.upstream_rules_x86_64, rules]
+#     - !reference [.nightly_rules_x86_64, rules]
+#     - !reference [.ga_rules_x86_64, rules]
+#   variables:
+#     SCRIPT: vmware.sh vmdk
 
-vmware.sh_ova:
-  extends: .integration_rhel
-  rules:
-    # Run only on x86_64
-    - !reference [.upstream_rules_x86_64, rules]
-    - !reference [.nightly_rules_x86_64, rules]
-    - !reference [.ga_rules_x86_64, rules]
-  variables:
-    SCRIPT: vmware.sh ova
+# vmware.sh_ova:
+#   extends: .integration_rhel
+#   rules:
+#     # Run only on x86_64
+#     - !reference [.upstream_rules_x86_64, rules]
+#     - !reference [.nightly_rules_x86_64, rules]
+#     - !reference [.ga_rules_x86_64, rules]
+#   variables:
+#     SCRIPT: vmware.sh ova
 
 filesystem.sh:
   extends: .integration

--- a/test/cases/api/aws.s3.sh
+++ b/test/cases/api/aws.s3.sh
@@ -108,11 +108,13 @@ function verify() {
             verifyDisk "${WORKDIR}/disk.qcow2"
             ;;
 
-        "${IMAGE_TYPE_VSPHERE}")
-
-            curl "${S3_URL}" --output "${WORKDIR}/disk.vmdk"
-            verifyInVSphere "${WORKDIR}/disk.vmdk"
-            ;;
+        # NOTE(akoutsou): The vsphere verification is failing very
+        # consistently. Disabling it until we have time to look into it
+        # further.
+        # "${IMAGE_TYPE_VSPHERE}")
+        #     curl "${S3_URL}" --output "${WORKDIR}/disk.vmdk"
+        #     verifyInVSphere "${WORKDIR}/disk.vmdk"
+        #     ;;
         *)
             greenprint "No validation method for image type ${IMAGE_TYPE}"
             ;;

--- a/test/cases/api/generic.s3.sh
+++ b/test/cases/api/generic.s3.sh
@@ -147,10 +147,13 @@ function verify() {
             verifyDisk "${WORKDIR}/disk.qcow2"
             ;;
 
-        "${IMAGE_TYPE_VSPHERE}")
-            curl "${S3_URL}" --output "${WORKDIR}/disk.vmdk"
-            verifyInVSphere "${WORKDIR}/disk.vmdk"
-            ;;
+        # NOTE(akoutsou): The vsphere verification is failing very
+        # consistently. Disabling it until we have time to look into it
+        # further.
+        # "${IMAGE_TYPE_VSPHERE}")
+        #     curl "${S3_URL}" --output "${WORKDIR}/disk.vmdk"
+        #     verifyInVSphere "${WORKDIR}/disk.vmdk"
+        #     ;;
         *)
             greenprint "No validation method for image type ${IMAGE_TYPE}"
             ;;


### PR DESCRIPTION
**test: disable verification step for vsphere builds**

The vsphere verification is failing consistently with the following
error message from govc:

    A component of the virtual machine is not accessible on the host.

Disabling it until we have time to look into it further.

---

**gitlab: disable vmware tests**

 The vmware tests are consistently failing.  While the build succeeds,
 the upload step fails with:

    Unable to protect host, if the host isn't running as part of an
    autoscaling group, this can safely be ignored: operation error Auto
    Scaling: DescribeAutoScalingInstances, get identity: get credentials:
    failed to refresh cached credentials, no EC2 IMDS role found,
    operation error ec2imds: GetMetadata, http response error StatusCode:
    404, request to EC2 IMDS failed

Disabling the test until we have time to look into it furhter.

---
