### PR TITLE
go.mod: update osbuild/images to v0.137.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
 	github.com/osbuild/blueprint v1.6.0
-	github.com/osbuild/images v0.134.1-0.20250416092909-a1ca7f34c770
+	github.com/osbuild/images v0.137.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXch
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/osbuild/blueprint v1.6.0 h1:HUV1w/dMxpgqOgVtHhfTZE3zRmWQkuW/qTfx9smKImI=
 github.com/osbuild/blueprint v1.6.0/go.mod h1:0d3dlY8aSJ6jM6NHwBmJFF1VIySsp/GsDpcJQ0yrOqM=
-github.com/osbuild/images v0.134.1-0.20250416092909-a1ca7f34c770 h1:w9h0KIV2p9QLCl6kMPlzJfb1kBV4QS672QSOKWOh50w=
-github.com/osbuild/images v0.134.1-0.20250416092909-a1ca7f34c770/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
+github.com/osbuild/images v0.137.0 h1:ypC/0BIkyoPbX8tSfobwoVcc4ExlEZVowgu7HbPCNfk=
+github.com/osbuild/images v0.137.0/go.mod h1:Ag87vmyxooiPQBJEDILbypG8/SRIear75YA78NwLix0=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/vendor/github.com/osbuild/images/pkg/distro/defs/rhel-10/distro.yaml
+++ b/vendor/github.com/osbuild/images/pkg/distro/defs/rhel-10/distro.yaml
@@ -395,6 +395,7 @@ image_types:
           - "patch"
           - "rng-tools"
           - "selinux-policy-targeted"
+          - "system-reinstall-bootc"
           - "uuid"
           - "WALinuxAgent"
           - "yum-utils"
@@ -503,6 +504,7 @@ image_types:
           - "redhat-release"
           - "redhat-release-eula"
           - "rsync"
+          - "system-reinstall-bootc"
           - "tuned"
           - "tar"
         exclude:

--- a/vendor/github.com/osbuild/images/pkg/distro/defs/rhel-9/distro.yaml
+++ b/vendor/github.com/osbuild/images/pkg/distro/defs/rhel-9/distro.yaml
@@ -83,6 +83,10 @@
         rhel:
           include:
             - "insights-client"
+      version_greater_or_equal:
+        "9.6":
+          include:
+            - "system-reinstall-bootc"
 
   sap_pkgset: &sap_pkgset
     include:
@@ -579,6 +583,8 @@ image_types:
                 - "insights-client"
           version_greater_or_equal:
             "9.6":
+              include:
+                - "system-reinstall-bootc"
               exclude:
                 - "microcode_ctl"
 

--- a/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/fedora/images.go
@@ -232,6 +232,7 @@ func osCustomizations(
 	osc.AuthConfig = imageConfig.Authconfig
 	osc.PwQuality = imageConfig.PwQuality
 	osc.WSLConfig = imageConfig.WSLConfStageOptions()
+	osc.NetworkManager = imageConfig.NetworkManager
 
 	osc.Files = append(osc.Files, imageConfig.Files...)
 	osc.Directories = append(osc.Directories, imageConfig.Directories...)

--- a/vendor/github.com/osbuild/images/pkg/distro/image_config.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/image_config.go
@@ -69,6 +69,7 @@ type ImageConfig struct {
 	Firewall            *osbuild.FirewallStageOptions
 	UdevRules           *osbuild.UdevRulesStageOptions
 	GCPGuestAgentConfig *osbuild.GcpGuestAgentConfigOptions
+	NetworkManager      *osbuild.NMConfStageOptions
 
 	WSLConfig *WSLConfig
 

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
@@ -271,6 +271,7 @@ func osCustomizations(
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
 	osc.WSLConfig = imageConfig.WSLConfStageOptions()
+	osc.NetworkManager = imageConfig.NetworkManager
 
 	osc.Files = append(osc.Files, imageConfig.Files...)
 	osc.Directories = append(osc.Directories, imageConfig.Directories...)

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/azure.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel9/azure.go
@@ -523,6 +523,18 @@ func defaultAzureImageConfig(rd *rhel.Distribution) *distro.ImageConfig {
 			}
 			ic.Files = append(ic.Files, datalossWarningScript)
 			ic.SystemdUnit = append(ic.SystemdUnit, datalossSystemdUnit)
+			ic.EnabledServices = append(ic.EnabledServices, datalossSystemdUnit.Filename)
+			ic.NetworkManager = &osbuild.NMConfStageOptions{
+				Path: "/etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf",
+				Settings: osbuild.NMConfStageSettings{
+					Keyfile: &osbuild.NMConfSettingsKeyfile{
+						UnmanagedDevices: []string{
+							"driver:mlx4_core",
+							"driver:mlx5_core",
+						},
+					},
+				},
+			}
 		}
 	}
 

--- a/vendor/github.com/osbuild/images/pkg/manifest/os.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/os.go
@@ -127,6 +127,7 @@ type OSCustomizations struct {
 	UdevRules            *osbuild.UdevRulesStageOptions
 	WSLConfig            *osbuild.WSLConfStageOptions
 	InsightsClientConfig *osbuild.InsightsClientConfigStageOptions
+	NetworkManager       *osbuild.NMConfStageOptions
 	Presets              []osbuild.Preset
 	ContainersStorage    *string
 
@@ -648,6 +649,10 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 	if p.OSCustomizations.InsightsClientConfig != nil {
 		pipeline.AddStage(osbuild.NewInsightsClientConfigStage(p.OSCustomizations.InsightsClientConfig))
+	}
+
+	if p.OSCustomizations.NetworkManager != nil {
+		pipeline.AddStage(osbuild.NewNMConfStage(p.OSCustomizations.NetworkManager))
 	}
 
 	if p.OSCustomizations.AuthConfig != nil {

--- a/vendor/github.com/osbuild/images/pkg/osbuild/nm_conf_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/nm_conf_stage.go
@@ -1,0 +1,117 @@
+package osbuild
+
+import "fmt"
+
+const nmConfStageType = "org.osbuild.nm.conf"
+
+type NMConfStageOptions struct {
+	Path     string              `json:"path"`
+	Settings NMConfStageSettings `json:"settings"`
+}
+
+func (*NMConfStageOptions) isStageOptions() {}
+
+type NMConfStageSettings struct {
+	Main            *NMConfSettingsMain             `json:"main,omitempty"`
+	Device          []NMConfSettingsDevice          `json:"device,omitempty"`
+	GlobalDNSDomain []NMConfSettingsGlobalDNSDomain `json:"global-dns-domain,omitempty"`
+	Keyfile         *NMConfSettingsKeyfile          `json:"keyfile,omitempty"`
+}
+
+type NMConfSettingsMain struct {
+	NoAutoDefault []string `json:"no-auto-default,omitempty"`
+	Plugins       []string `json:"plugins,omitempty"`
+}
+
+type NMConfSettingsDevice struct {
+	Name   string             `json:"name,omitempty"`
+	Config NMConfDeviceConfig `json:"config"`
+}
+
+type NMConfSettingsGlobalDNSDomain struct {
+	Name   string                              `json:"name"`
+	Config NMConfSettingsGlobalDNSDomainConfig `json:"config"`
+}
+
+type NMConfSettingsGlobalDNSDomainConfig struct {
+	Servers []string `json:"servers"`
+}
+
+type NMConfSettingsKeyfile struct {
+	UnmanagedDevices []string `json:"unmanaged-devices,omitempty"`
+}
+
+type NMConfDeviceConfig struct {
+	Managed                bool `json:"managed"`
+	WifiScanRandMacAddress bool `json:"wifi.scan-rand-mac-address"`
+}
+
+func (o NMConfStageOptions) validate() error {
+	if o.Path == "" {
+		return fmt.Errorf("%s: path is a required property", nmConfStageType)
+	}
+
+	if err := validatePath(o.Path); err != nil {
+		return fmt.Errorf("%s: %s", nmConfStageType, err)
+	}
+
+	settings := o.Settings
+	// at least one of the settings must be defined
+	if settings.Main == nil &&
+		settings.Device == nil &&
+		settings.GlobalDNSDomain == nil &&
+		settings.Keyfile == nil {
+		return fmt.Errorf("%s: at least one setting must be set", nmConfStageType)
+	}
+
+	if main := settings.Main; main != nil {
+		if err := validateArrayHasItems(main.NoAutoDefault); err != nil {
+			return fmt.Errorf("%s: main.no-auto-default %s", nmConfStageType, err)
+		}
+		if err := validateArrayHasItems(main.Plugins); err != nil {
+			return fmt.Errorf("%s: main.plugins %s", nmConfStageType, err)
+		}
+	}
+
+	if err := validateArrayHasItems(settings.Device); err != nil {
+		return fmt.Errorf("%s: device %s", nmConfStageType, err)
+	}
+
+	if err := validateArrayHasItems(settings.GlobalDNSDomain); err != nil {
+		return fmt.Errorf("%s: global-dns-domain %s", nmConfStageType, err)
+	}
+
+	for _, gdd := range settings.GlobalDNSDomain {
+		if gdd.Name == "" {
+			return fmt.Errorf("%s: global-dns-domain name is a required property", nmConfStageType)
+		}
+
+		if err := validateArrayHasItems(gdd.Config.Servers); err != nil {
+			return fmt.Errorf("%s: global-dns-domain.config.servers %s", nmConfStageType, err)
+		}
+	}
+
+	if keyfile := settings.Keyfile; keyfile != nil {
+		if err := validateArrayHasItems(keyfile.UnmanagedDevices); err != nil {
+			return fmt.Errorf("%s: keyfile.unmanaged-devices %s", nmConfStageType, err)
+		}
+	}
+
+	return nil
+}
+
+// validateArrayHasItems returns an error if an array is non-nil but also
+// contains no items.
+func validateArrayHasItems[T any](arr []T) error {
+	if arr != nil && len(arr) == 0 {
+		return fmt.Errorf("requires at least one element when defined")
+	}
+	return nil
+}
+
+func NewNMConfStage(options *NMConfStageOptions) *Stage {
+	return &Stage{
+		Type:    nmConfStageType,
+		Options: options,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1049,7 +1049,7 @@ github.com/oracle/oci-go-sdk/v54/workrequests
 ## explicit; go 1.22.8
 github.com/osbuild/blueprint/internal/common
 github.com/osbuild/blueprint/pkg/blueprint
-# github.com/osbuild/images v0.134.1-0.20250416092909-a1ca7f34c770
+# github.com/osbuild/images v0.137.0
 ## explicit; go 1.22.8
 github.com/osbuild/images/data/dependencies
 github.com/osbuild/images/data/repositories


### PR DESCRIPTION
Includes

tag v0.134.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.134.0

----------------
  * Distro/el10/ec2/modprobe: blacklist 'i2c_piix4' (RHEL-71926) (osbuild/images#1395)
    * Author: Tomáš Hozza, Reviewers: Achilleas Koutsou, Michael Vogt
  * Update osbuild dependency commit ID to latest (osbuild/images#1391)
    * Author: SchutzBot, Reviewers: Achilleas Koutsou, Tomáš Hozza
  * distro/rhel9/azure: blacklist more modules on 9.6+ (RHEL-79065) (osbuild/images#1394)
    * Author: Achilleas Koutsou, Reviewers: Michael Vogt, Simon de Vlieger
  * distro/rhel9/azure: exclude microcode_ctl on 9.6+ (RHEL-79065) (osbuild/images#1405)
    * Author: Achilleas Koutsou, Reviewers: Michael Vogt, Tomáš Hozza
  * test: add configs for Azure that match official builds (osbuild/images#1411)
    * Author: Achilleas Koutsou, Reviewers: Michael Vogt, Tomáš Hozza
  * test: fix description of `build-image` (osbuild/images#1420)
    * Author: Michael Vogt, Reviewers: Achilleas Koutsou, Simon de Vlieger
  * tools/gen-manifest-checksums: sort by image name (osbuild/images#1406)
    * Author: Achilleas Koutsou, Reviewers: Michael Vogt, Simon de Vlieger

— Somewhere on the Internet, 2025-04-14

---

tag v0.135.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.135.0

----------------
  * RHEL 9.6+ & 10.0+: install system-reinstall-bootc AWS and Azure [COMPOSER-2502] (osbuild/images#1435)
    * Author: Achilleas Koutsou, Reviewers: Ondřej Budai
  * RHEL 9.6+/Azure: systemd service and script for dataloss warning on temporary resource disk (osbuild/images#1434)
    * Author: Achilleas Koutsou, Reviewers: Tomáš Hozza
  * Set refclock in chrony config for Azure images on RHEL 9.6+ (RHEL-79065) (osbuild/images#1400)
    * Author: Achilleas Koutsou, Reviewers: Tomáš Hozza
  * Update snapshots to 20250415 (osbuild/images#1431)
    * Author: SchutzBot, Reviewers: Achilleas Koutsou
  * WSL: add packages for podman and proc utilities (COMPOSER-2455) (osbuild/images#1425)
    * Author: Sanne Raymaekers, Reviewers: Tomáš Hozza
  * [RHEL-9.6+/Azure]: update waagent.conf and add nvme_core.io_timeout kernel arg (osbuild/images#1430)
    * Author: Achilleas Koutsou, Reviewers: Ondřej Budai, Sanne Raymaekers
  * [RHEL/Azure RHUI] Disable `auto_enable_yum_plugins` in the RHSM config as a BP customization (osbuild/images#1415)
    * Author: Tomáš Hozza, Reviewers: Achilleas Koutsou
  * ci: dependency updater gobump golang fix (osbuild/images#1441)
    * Author: Lukáš Zapletal, Reviewers: Ondřej Budai
  * ci: dependency updater gobump typo (osbuild/images#1439)
    * Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou
  * ci: dependency updater via gobump (osbuild/images#1385)
    * Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou
  * distro: almalinux and almalinux_kitten (osbuild/images#1375)
    * Author: Simon de Vlieger, Reviewers: Neal Gompa (ニール・ゴンパ), Ondřej Budai
  * fedora: bump branched and rawhide (osbuild/images#1440)
    * Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Ondřej Budai
  * github: don't run manifest checksum validation on main (osbuild/images#1437)
    * Author: Achilleas Koutsou, Reviewers: Ondřej Budai, Simon de Vlieger
  * manifesttest: add helper to find stages in a pipeline (osbuild/images#1418)
    * Author: Michael Vogt, Reviewers: Lukáš Zapletal, Simon de Vlieger
  * rhsm: support for podman secrets (osbuild/images#1414)
    * Author: Lukáš Zapletal, Reviewers: Simon de Vlieger

— Somewhere on the Internet, 2025-04-16

---

tag v0.136.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.136.0

----------------
  * ci: dependency updater gobump git fix (osbuild/images#1442)
    * Author: Lukáš Zapletal, Reviewers: Achilleas Koutsou

— Somewhere on the Internet, 2025-04-21

---

tag v0.137.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.137.0

----------------
  * RHEL 9.6+ Azure: enable the dataloss warning service and add unmanaged devices to the NetworkManager config (osbuild/images#1447)
    * Author: Achilleas Koutsou, Reviewers: Ondřej Budai, Tomáš Hozza

— Somewhere on the Internet, 2025-04-22

---

