### PR TITLE
Test/cross-distro: fix one issue and make the test more robust on "ZStream" branches

### DIFF
--- a/test/cases/cross-distro.sh
+++ b/test/cases/cross-distro.sh
@@ -86,7 +86,7 @@ fi
 
 # Get a list of all installed distros and compare it with a pattern matching host distribution
 # Filter out beta and centos-stream, see GH issue #2257
-INSTALLED_DISTROS=$(find "/usr/share/osbuild-composer/repositories" -name '*.json' -printf '%P\n' | awk -F "." '{ print $1 }' | grep -Ev 'beta|stream' | sort)
+INSTALLED_DISTROS=$(find "/usr/share/osbuild-composer/repositories" -name '*.json' -printf '%P\n' | sed 's/\.[^.]*$//' | grep -Ev 'beta|stream' | sort)
 INSTALLED_REMAINDER=$(echo "$INSTALLED_DISTROS" | grep -v -E "$PATTERN")
 # Check if there are any extra distros that match the host pattern but are not recognized
 UNRECOGNIZED_DISTROS=$(echo "${INSTALLED_DISTROS}" | grep -v "${RECOGNIZED_DISTROS}")
@@ -111,7 +111,7 @@ REPO_PATH="images/data/repositories/"
 # ALL_EXPECTED_DISTROS - all distros matching host pattern
 # ALL_REMAINDERS - all the unrecognized distros
 # Filter out beta and centos-stream, see GH issue #2257
-ALL_DISTROS=$(find "$REPO_PATH" -name '*.json' -printf '%P\n' | grep -v 'no-aux-key' | awk -F "." '{ print $1 }')
+ALL_DISTROS=$(find "$REPO_PATH" -name '*.json' -printf '%P\n' | grep -v 'no-aux-key' | sed 's/\.[^.]*$//')
 ALL_EXPECTED_DISTROS=$(echo "$ALL_DISTROS" | grep -E "$PATTERN" | grep -Ev 'beta|stream' | sort)
 # Warning: filter out the remaining distros by matching whole words to avoid matching
 # the value rhel-9X by the pattern rhel-9!


### PR DESCRIPTION
Test/cross-distro: fix processing of repo configs 

Previously, the code would remove everything after the first dot in the
repo config filename. So 'rhel-10.0.json' -> 'rhel-10'. This means that
there was just a bunch of 'rhel-X' repo config names to compare. This is
probably a leftover from the days before we introduced dot-notation for
distro names.

Modify the test to effectivelly strip only the filename extension (the
part after the last dot, including the dot).

-----------------------------------------------------------------------------

Test/cross-distro: take the images version used to compile composer 

After the move of the repo configs to `osbuild/images`, we changed the
way to determine the all available distro repo configs by taking the
last release of 'images'. This turns out to be fragile, especially when
the test case is being run on a "rhel-x.y.0" branch or basically with
any old osbuild-composer binary. It could happen also in Nightly test
pipelines after the devel freeze.

We always compile osbuild-composer binary with debug information, so we
can determine the vendored 'images' version from the binary. We also
always ship repo configs from the same 'images' version in the RPMs.

Therefore modify the test case to check out the 'images' version that
osbuild-composer was compiled with and use repo configs from that
version.