### PR TITLE
GH actions: move from soon to be EOL F40 to F42

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: "🛃 Unit tests"
     runs-on: ubuntu-22.04
     container:
-      image: registry.fedoraproject.org/fedora:40
+      image: registry.fedoraproject.org/fedora:42
 
     steps:
         # krb5-devel is needed to test internal/upload/koji package
@@ -87,7 +87,7 @@ jobs:
     name: "🐍 Lint python scripts"
     runs-on: ubuntu-22.04
     container:
-      image: registry.fedoraproject.org/fedora:40
+      image: registry.fedoraproject.org/fedora:42
     steps:
 
       - name: Install build and test dependencies
@@ -233,7 +233,7 @@ jobs:
   rpmlint:
     name: "📦 RPMlint"
     runs-on: ubuntu-22.04
-    container: registry.fedoraproject.org/fedora:40
+    container: registry.fedoraproject.org/fedora:42
     steps:
       - name: Install dependencies
         run: sudo dnf install -y rpmlint rpm-build make git-core


### PR DESCRIPTION
This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the READMEs [listed here](https://github.com/osbuild/osbuild.github.io/blob/main/readme-list)
  - [ ] submit a PR for the [osbuild.org website](https://github.com/osbuild/osbuild.github.io/) repository if this PR changed any behavior not covered by the automatically updated READMEs

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
