### PR TITLE
Test/cross-distro: add version check for cross-building el8 on el9

### DIFF
--- a/test/cases/cross-distro.sh
+++ b/test/cases/cross-distro.sh
@@ -331,6 +331,10 @@ case $ID in
         ensure_subscription
         case $MAJOR in
             9)
+                if ! nvrGreaterOrEqual "osbuild-composer" "132.1"; then
+                    yellowprint "WARNING: osbuild-composer version lower than 132.1 is known to have issues with el8 on el9 cross-distro builds. Skipping test."
+                    exit 0
+                fi
                 # There are no new RHEL-8 releases, so just use the distro alias
                 test_cross_build_distro "rhel-8"
                 ;;


### PR DESCRIPTION
The issue has been fixed in 9.6 0day ZStream in v132.1, so running the test against anything older will make the test fail. This is currently the case for RHEL-9-nightly pipeline.

Let's solve this annoyance.

