### PR TITLE
CI: trigger EDGE CI from GH action, not GitLab

### DIFF
--- a/.github/workflows/trigger-edge-ci.yml
+++ b/.github/workflows/trigger-edge-ci.yml
@@ -1,0 +1,40 @@
+name: Trigger EDGE CI
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+
+jobs:
+  trigger-edge-ci:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_USER: ${{ secrets.SCHUTZBOT_GITHUB_USERNAME }}
+      GITHUB_ACCESS_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+    steps:
+      - name: Install Dependencies
+        run: |
+          sudo apt install -y jq
+
+      - name: Extract Pull Request Number from Event
+        id: pr_data
+        run: |
+          # Debug the event data
+          cat "$GITHUB_EVENT_PATH"
+          PR_NUMBER=$(jq -r '.pull_requests[0].number // ""' "$GITHUB_EVENT_PATH")
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Trigger EDGE CI
+        # Tests are triggered only for Pull Requests to the main branch
+        if: ${{ env.GITHUB_BASE_REF == 'main' && env.PR_NUMBER != '' }}
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          curl \
+            -u "${GITHUB_USER}:${GITHUB_ACCESS_TOKEN}" \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/osbuild/rhel-edge-ci/dispatches \
+            # Note: The 'pr_number' is currently prefixed with 'PR-' due to a limitation in the 'rhel-edge-ci' repository.
+            -d '{"event_type":"osbuild-composer-ci","client_payload":{"pr_number":"PR-${PR_NUMBER}"}}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,16 +332,6 @@ Image Tests:
           - aws/rhel-10.0-nightly-aarch64
         INTERNAL_NETWORK: ["true"]
 
-Trigger-rhel-edge-ci:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  stage: test
-  interruptible: true
-  tags:
-    - shell
-  script:
-    - 'curl -u "${SCHUTZBOT_LOGIN}" -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/osbuild/rhel-edge-ci/dispatches -d "{\"event_type\":\"osbuild-composer-ci\",\"client_payload\":{\"pr_number\":\"${CI_COMMIT_BRANCH}\"}}"'
-
 .integration_base:
   stage: test
   extends: .terraform


### PR DESCRIPTION
The way we trigger EDGE CI is silly. We boot a runner in GitLab just to use CURL to trigger EDGE CI pipeline on GitHub. None of this is really needed and we should be triggering EDGE CI from GH Action.

Subsequently, the EDGE CI pipeline expects a PR number to be triggered, but we have been triggering also for merges to `main`. It does not show up in osbuild-composer runs on `main`, but in reality, the pipeline gets triggered and always fails. This rework tries to mitigate the situation by not triggering the pipeline if the workflow is not run as part of PR to the `main` branch.