### PR TITLE
cloudapi: Fix missing specs for koji ContainerResolve

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -339,7 +339,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 
 			job := worker.ContainerResolveJob{
 				Arch:  arch.Name(),
-				Specs: make([]worker.ContainerSpec, len(ir.blueprint.Containers)),
+				Specs: workerResolveSpecs,
 			}
 
 			jobId, err := s.workers.EnqueueContainerResolveJob(&job, channel)


### PR DESCRIPTION
It looks like this got lost in a refactor back in commit 6e4efabf246561673fc7334c0e4fcb6157c48d1b when it used to populate the Specs list in a loop.
