### PR TITLE
Replace logrus with log

### DIFF
--- a/cmd/README
+++ b/cmd/README
@@ -1,0 +1,36 @@
+Binaries
+========
+
+osbuild-composer: The main binary, the service that maintains the queue and schedules all
+jobs. This is started as the main process by systemd or container runtime.
+
+osbuild-worker: The worker binary that handles jobs from the job queue locally.
+
+osbuild-worker-executor: The binary that runs osbuild to build an image on an isolated VM.
+
+osbuild-koji: Submits builds to Koji.
+
+osbuild-jobsite-*: Provides an isolated set of services to run builds in. They can be separated
+from the rest of the system through network segmentation or other means. The jobsite and what's
+in it are only available to things inside it.
+
+Service binaries
+================
+
+osbuild-service-maintenance: Vacuum the database and remove old jobs. Also used to cleanup
+cloud instances.
+
+Development and test tools
+==========================
+
+gen-manifests
+mock-dnf-json
+osbuild-auth-tests
+osbuild-composer-cli-tests
+osbuild-composer-dbjobqueue-tests
+osbuild-dnf-json-tests
+osbuild-image-tests
+osbuild-koji-tests
+osbuild-mock-openid-provider
+osbuild-store-dump
+osbuild-upload-*

--- a/cmd/osbuild-koji/main.go
+++ b/cmd/osbuild-koji/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/osbuild/images/pkg/platform"
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -51,7 +51,7 @@ func main() {
 	defer func() {
 		err := k.Logout()
 		if err != nil {
-			logrus.Warn("logging out of koji failed ", err)
+			log.Printf("logging out of koji failed: %s ", err)
 		}
 	}()
 

--- a/cmd/osbuild-service-maintenance/db.go
+++ b/cmd/osbuild-service-maintenance/db.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -94,31 +94,30 @@ func (d *db) LogVacuumStats() error {
 			return err
 		}
 
-		logrus.Infof("Stats for table %s", relName)
-		logrus.Infof("  Total table size: %s", relSize)
-		logrus.Info("  Tuples:")
-		logrus.Infof("    Inserted: %d", ins)
-		logrus.Infof("    Updated: %d", upd)
-		logrus.Infof("    Deleted: %d", del)
-		logrus.Infof("    Live: %d", live)
-		logrus.Infof("    Dead: %d", dead)
-		logrus.Info("  Vacuum stats:")
-		logrus.Infof("    Vacuum count: %d", vc)
-		logrus.Infof("    AutoVacuum count: %d", avc)
-		logrus.Infof("    Last vacuum: %v", lvc)
-		logrus.Infof("    Last autovacuum: %v", lavc)
-		logrus.Info("  Analyze stats:")
-		logrus.Infof("    Analyze count: %d", ac)
-		logrus.Infof("    AutoAnalyze count: %d", aac)
-		logrus.Infof("    Last analyze: %v", lan)
-		logrus.Infof("    Last autoanalyze: %v", laan)
-		logrus.Info("---")
+		log.Printf("Stats for table %s", relName)
+		log.Printf("  Total table size: %s", relSize)
+		log.Println("  Tuples:")
+		log.Printf("    Inserted: %d", ins)
+		log.Printf("    Updated: %d", upd)
+		log.Printf("    Deleted: %d", del)
+		log.Printf("    Live: %d", live)
+		log.Printf("    Dead: %d", dead)
+		log.Println("  Vacuum stats:")
+		log.Printf("    Vacuum count: %d", vc)
+		log.Printf("    AutoVacuum count: %d", avc)
+		log.Printf("    Last vacuum: %v", lvc)
+		log.Printf("    Last autovacuum: %v", lavc)
+		log.Println("  Analyze stats:")
+		log.Printf("    Analyze count: %d", ac)
+		log.Printf("    AutoAnalyze count: %d", aac)
+		log.Printf("    Last analyze: %v", lan)
+		log.Printf("    Last autoanalyze: %v", laan)
+		log.Println("---")
 	}
 	if rows.Err() != nil {
 		return rows.Err()
 	}
 	return nil
-
 }
 
 func DBCleanup(dbURL string, dryRun bool, cutoff time.Time) error {
@@ -129,7 +128,7 @@ func DBCleanup(dbURL string, dryRun bool, cutoff time.Time) error {
 
 	err = db.LogVacuumStats()
 	if err != nil {
-		logrus.Errorf("Error running vacuum stats: %v", err)
+		log.Printf("Error running vacuum stats: %v", err)
 	}
 
 	var rows int64
@@ -138,21 +137,21 @@ func DBCleanup(dbURL string, dryRun bool, cutoff time.Time) error {
 		if dryRun {
 			rows, err = db.ExpiredJobCount()
 			if err != nil {
-				logrus.Warningf("Error querying expired jobs: %v", err)
+				log.Printf("Error querying expired jobs: %v", err)
 			}
-			logrus.Infof("Dryrun, expired job count: %d", rows)
+			log.Printf("Dryrun, expired job count: %d", rows)
 			break
 		}
 
 		rows, err = db.DeleteJobs()
 		if err != nil {
-			logrus.Errorf("Error deleting jobs: %v, %d rows affected", rows, err)
+			log.Printf("Error deleting jobs: %v, %d rows affected", err, rows)
 			return err
 		}
 
 		err = db.VacuumAnalyze()
 		if err != nil {
-			logrus.Errorf("Error running vacuum analyze: %v", err)
+			log.Printf("Error running vacuum analyze: %v", err)
 			return err
 		}
 
@@ -160,12 +159,12 @@ func DBCleanup(dbURL string, dryRun bool, cutoff time.Time) error {
 			break
 		}
 
-		logrus.Infof("Deleted results for %d", rows)
+		log.Printf("Deleted results for %d", rows)
 	}
 
 	err = db.LogVacuumStats()
 	if err != nil {
-		logrus.Errorf("Error running vacuum stats: %v", err)
+		log.Printf("Error running vacuum stats: %v", err)
 	}
 
 	return nil

--- a/cmd/osbuild-service-maintenance/main.go
+++ b/cmd/osbuild-service-maintenance/main.go
@@ -3,18 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"sync"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	logrus.SetReportCaller(true)
-
 	// 14 days
 	cutoff := time.Now().Add(-(time.Hour * 24 * 14))
-	logrus.Infof("Cutoff date: %v", cutoff)
+	log.Printf("Cutoff date: %v", cutoff)
 
 	conf := Config{
 		MaxConcurrentRequests: 20,
@@ -24,15 +21,15 @@ func main() {
 	}
 	err := LoadConfigFromEnv(&conf)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 
 	if conf.DryRun {
-		logrus.Info("Dry run, no state will be changed")
+		log.Println("Dry run, no state will be changed")
 	}
 
 	if conf.MaxConcurrentRequests == 0 {
-		logrus.Fatal("Max concurrent requests is 0")
+		log.Fatal("Max concurrent requests is 0")
 	}
 
 	var wg sync.WaitGroup
@@ -40,14 +37,14 @@ func main() {
 	go func() {
 		defer wg.Done()
 		if !conf.EnableAWSMaintenance {
-			logrus.Info("AWS maintenance not enabled, skipping")
+			log.Println("AWS maintenance not enabled, skipping")
 			return
 		}
 
-		logrus.Info("Cleaning up AWS")
+		log.Println("Cleaning up AWS")
 		err := AWSCleanup(conf.MaxConcurrentRequests, conf.DryRun, conf.AWSAccessKeyID, conf.AWSSecretAccessKey, cutoff)
 		if err != nil {
-			logrus.Errorf("AWS cleanup failed: %v", err)
+			log.Printf("AWS cleanup failed: %v", err)
 		}
 	}()
 
@@ -55,40 +52,40 @@ func main() {
 	go func() {
 		defer wg.Done()
 		if !conf.EnableGCPMaintenance {
-			logrus.Info("GCP maintenance not enabled, skipping")
+			log.Println("GCP maintenance not enabled, skipping")
 			return
 		}
 
-		logrus.Info("Cleaning up GCP")
+		log.Println("Cleaning up GCP")
 		var gcpConf GCPCredentialsConfig
 		err := LoadConfigFromEnv(&gcpConf)
 		if err != nil {
-			logrus.Error("Unable to load GCP config from environment")
+			log.Println("Unable to load GCP config from environment")
 			return
 		}
 
 		if !gcpConf.valid() {
-			logrus.Error("GCP credentials invalid, fields missing")
+			log.Println("GCP credentials invalid, fields missing")
 			return
 		}
 
 		creds, err := json.Marshal(&gcpConf)
 		if err != nil {
-			logrus.Errorf("Unable to marshal gcp conf: %v", err)
+			log.Printf("Unable to marshal gcp conf: %v", err)
 			return
 		}
 
 		err = GCPCleanup(creds, conf.MaxConcurrentRequests, conf.DryRun, cutoff)
 		if err != nil {
-			logrus.Errorf("GCP Cleanup failed: %v", err)
+			log.Printf("GCP Cleanup failed: %v", err)
 		}
 	}()
 
 	wg.Wait()
-	logrus.Info("🦀🦀🦀 cloud cleanup done 🦀🦀🦀")
+	log.Println("🦀🦀🦀 cloud cleanup done 🦀🦀🦀")
 
 	if !conf.EnableDBMaintenance {
-		logrus.Info("🦀🦀🦀 DB maintenance not enabled, skipping  🦀🦀🦀")
+		log.Println("🦀🦀🦀 DB maintenance not enabled, skipping  🦀🦀🦀")
 		return
 	}
 	dbURL := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
@@ -101,7 +98,7 @@ func main() {
 	)
 	err = DBCleanup(dbURL, conf.DryRun, cutoff)
 	if err != nil {
-		logrus.Fatalf("Error during DBCleanup: %v", err)
+		log.Fatalf("Error during DBCleanup: %v", err)
 	}
-	logrus.Info("🦀🦀🦀 dbqueue cleanup done 🦀🦀🦀")
+	log.Println("🦀🦀🦀 dbqueue cleanup done 🦀🦀🦀")
 }

--- a/cmd/osbuild-upload-gcp/main.go
+++ b/cmd/osbuild-upload-gcp/main.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/osbuild/osbuild-composer/internal/cloud/gcp"
-	"github.com/sirupsen/logrus"
 )
 
 type strArrayFlag []string
@@ -56,7 +56,7 @@ func main() {
 	case "rhel-9":
 		guestOSFeatures = gcp.GuestOsFeaturesRHEL9
 	default:
-		logrus.Fatalf("[GCP] Unknown OS Family %q. Use one of: 'rhel-8', 'rhel-9'.", osFamily)
+		log.Fatalf("[GCP] Unknown OS Family %q. Use one of: 'rhel-8', 'rhel-9'.", osFamily)
 	}
 
 	var credentials []byte
@@ -64,51 +64,51 @@ func main() {
 		var err error
 		credentials, err = os.ReadFile(credentialsPath)
 		if err != nil {
-			logrus.Fatalf("[GCP] Error while reading credentials: %v", err)
+			log.Fatalf("[GCP] Error while reading credentials: %v", err)
 		}
 	}
 
 	g, err := gcp.New(credentials)
 	if err != nil {
-		logrus.Fatalf("[GCP] Failed to create new GCP object: %v", err)
+		log.Fatalf("[GCP] Failed to create new GCP object: %v", err)
 	}
 
 	ctx := context.Background()
 
 	// Upload image to the Storage
 	if !skipUpload {
-		logrus.Infof("[GCP] 🚀 Uploading image to: %s/%s", bucketName, objectName)
+		log.Printf("[GCP] 🚀 Uploading image to: %s/%s", bucketName, objectName)
 		_, err := g.StorageObjectUpload(ctx, imageFile, bucketName, objectName,
 			map[string]string{gcp.MetadataKeyImageName: imageName})
 		if err != nil {
-			logrus.Fatalf("[GCP] Uploading image failed: %v", err)
+			log.Fatalf("[GCP] Uploading image failed: %v", err)
 		}
 	}
 
 	// Import Image to Compute Engine
 	if !skipImport {
-		logrus.Infof("[GCP] 📥 Importing image into Compute Engine as '%s'", imageName)
+		log.Printf("[GCP] 📥 Importing image into Compute Engine as '%s'", imageName)
 		_, importErr := g.ComputeImageInsert(ctx, bucketName, objectName, imageName, regions, guestOSFeatures)
 
 		// Cleanup storage before checking for errors
-		logrus.Infof("[GCP] 🧹 Deleting uploaded image file: %s/%s", bucketName, objectName)
+		log.Printf("[GCP] 🧹 Deleting uploaded image file: %s/%s", bucketName, objectName)
 		if err = g.StorageObjectDelete(ctx, bucketName, objectName); err != nil {
-			logrus.Warnf("[GCP] Encountered error while deleting object: %v", err)
+			log.Printf("[GCP] Encountered error while deleting object: %v", err)
 		}
 
 		// check error from ComputeImageImport()
 		if importErr != nil {
-			logrus.Fatalf("[GCP] Importing image failed: %v", importErr)
+			log.Fatalf("[GCP] Importing image failed: %v", importErr)
 		}
-		logrus.Infof("[GCP] 💿 Image URL: %s", g.ComputeImageURL(imageName))
+		log.Printf("[GCP] 💿 Image URL: %s", g.ComputeImageURL(imageName))
 	}
 
 	// Share the imported Image with specified accounts using IAM policy
 	if len(shareWith) > 0 {
-		logrus.Infof("[GCP] 🔗 Sharing the image with: %+v", shareWith)
+		log.Printf("[GCP] 🔗 Sharing the image with: %+v", shareWith)
 		err = g.ComputeImageShare(ctx, imageName, []string(shareWith))
 		if err != nil {
-			logrus.Fatalf("[GCP] Sharing image failed: %s", err)
+			log.Fatalf("[GCP] Sharing image failed: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
Series of commits which replace logrus with either `log` or `log/slog` in case of `osbuild-jobsite-*` binaries. This is because these two tools have `-json` argument that enables JSON logging to standard output and I did not want to break the contract. I am not sure where or how these are used.