### PR TITLE
go.mod: bump images to v0.144.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.438
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
 	github.com/osbuild/blueprint v1.6.0
-	github.com/osbuild/images v0.143.0
+	github.com/osbuild/images v0.144.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -578,8 +578,8 @@ github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXch
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/osbuild/blueprint v1.6.0 h1:HUV1w/dMxpgqOgVtHhfTZE3zRmWQkuW/qTfx9smKImI=
 github.com/osbuild/blueprint v1.6.0/go.mod h1:0d3dlY8aSJ6jM6NHwBmJFF1VIySsp/GsDpcJQ0yrOqM=
-github.com/osbuild/images v0.143.0 h1:RRDE7DkDJla1k3lB3/KHUNmG9OAMjdXyBQVnqEScbZ0=
-github.com/osbuild/images v0.143.0/go.mod h1:CLuNhj3sO++pzzVzd2hkJ7L3rHzm6XY9zpm+0ERiY6A=
+github.com/osbuild/images v0.144.0 h1:p8l71YH+x7yE1XJF7Qy74/xdicJ6VTF93I0mKZVmsfc=
+github.com/osbuild/images v0.144.0/go.mod h1:jY21PhkxIozII4M0xCqZL7poLtFwDJlEGj88pb3lalQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/vendor/github.com/osbuild/images/pkg/customizations/fsnode/dir.go
+++ b/vendor/github.com/osbuild/images/pkg/customizations/fsnode/dir.go
@@ -7,10 +7,6 @@ type Directory struct {
 	ensureParentDirs bool
 }
 
-func (d *Directory) IsDir() bool {
-	return true
-}
-
 func (d *Directory) EnsureParentDirs() bool {
 	if d == nil {
 		return false

--- a/vendor/github.com/osbuild/images/pkg/customizations/fsnode/file.go
+++ b/vendor/github.com/osbuild/images/pkg/customizations/fsnode/file.go
@@ -9,10 +9,6 @@ type File struct {
 	data []byte
 }
 
-func (f *File) IsDir() bool {
-	return false
-}
-
 func (f *File) Data() []byte {
 	if f == nil {
 		return nil

--- a/vendor/github.com/osbuild/images/pkg/customizations/fsnode/fsnode.go
+++ b/vendor/github.com/osbuild/images/pkg/customizations/fsnode/fsnode.go
@@ -10,16 +10,6 @@ import (
 const usernameRegex = `^[A-Za-z0-9_.][A-Za-z0-9_.-]{0,31}$`
 const groupnameRegex = `^[A-Za-z0-9_][A-Za-z0-9_-]{0,31}$`
 
-type FsNode interface {
-	Path() string
-	Mode() *os.FileMode
-	// User can return either a string (user name/group name), an int64 (UID/GID) or nil
-	User() interface{}
-	// Group can return either a string (user name/group name), an int64 (UID/GID) or nil
-	Group() interface{}
-	IsDir() bool
-}
-
 type baseFsNode struct {
 	path  string
 	mode  *os.FileMode
@@ -126,8 +116,4 @@ func (f *baseFsNode) validate() error {
 	}
 
 	return nil
-}
-
-func (f *baseFsNode) IsDir() bool {
-	panic("IsDir() called on baseFsNode")
 }

--- a/vendor/github.com/osbuild/images/pkg/distro/defs/loader.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/defs/loader.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/osbuild/images/pkg/disk"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/experimentalflags"
+	"github.com/osbuild/images/pkg/olog"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -304,7 +304,7 @@ func load(distroNameVer string) (*toplevelYAML, error) {
 	// searchPaths down the stack instead
 	var dataFS fs.FS = DataFS
 	if overrideDir := experimentalflags.String("yamldir"); overrideDir != "" {
-		logrus.Warnf("using experimental override dir %q", overrideDir)
+		olog.Printf("WARNING: using experimental override dir %q", overrideDir)
 		dataFS = os.DirFS(overrideDir)
 	}
 

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/images.go
@@ -233,7 +233,7 @@ func osCustomizations(
 	if options.Subscription != nil {
 		subscriptionStatus = subscription.RHSMConfigWithSubscription
 		if options.Subscription.Proxy != "" {
-			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Proxy: options.Subscription.Proxy}
+			osc.InsightsClientConfig = &osbuild.InsightsClientConfigStageOptions{Config: osbuild.InsightsClientConfig{Proxy: options.Subscription.Proxy}}
 		}
 	} else {
 		subscriptionStatus = subscription.RHSMConfigNoSubscription

--- a/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ami.go
+++ b/vendor/github.com/osbuild/images/pkg/distro/rhel/rhel10/ami.go
@@ -265,9 +265,6 @@ func defaultEc2ImageConfig() *distro.ImageConfig {
 				},
 			},
 		},
-		Authselect: &osbuild.AuthselectStageOptions{
-			Profile: "sssd",
-		},
 		SshdConfig: &osbuild.SshdConfigStageOptions{
 			Config: osbuild.SshdConfigConfig{
 				PasswordAuthentication: common.ToPtr(false),

--- a/vendor/github.com/osbuild/images/pkg/manifest/os.go
+++ b/vendor/github.com/osbuild/images/pkg/manifest/os.go
@@ -669,7 +669,7 @@ func (p *OS) serialize() osbuild.Pipeline {
 			panic(err)
 		}
 		pipeline.AddStage(subStage)
-		p.OSCustomizations.Directories = append(p.OSCustomizations.Directories, subDirs...)
+		pipeline.AddStages(osbuild.GenDirectoryNodesStages(subDirs)...)
 		p.addInlineDataAndStages(&pipeline, subFiles)
 		p.OSCustomizations.EnabledServices = append(p.OSCustomizations.EnabledServices, subServices...)
 	}

--- a/vendor/github.com/osbuild/images/pkg/olog/package.go
+++ b/vendor/github.com/osbuild/images/pkg/olog/package.go
@@ -1,0 +1,3 @@
+// Package olog provides a wrapper around the standard log package. It is used for
+// all logging in the project. By default, the output is discarded.
+package olog

--- a/vendor/github.com/osbuild/images/pkg/olog/proxy.go
+++ b/vendor/github.com/osbuild/images/pkg/olog/proxy.go
@@ -1,0 +1,83 @@
+package olog
+
+import "io"
+
+// Print is a proxy for log.Print.
+func Print(v ...any) {
+	Default().Print(v...)
+}
+
+// Printf is a proxy for log.Printf.
+func Printf(format string, v ...any) {
+	Default().Printf(format, v...)
+}
+
+// Println is a proxy for log.Println.
+func Println(v ...any) {
+	Default().Println(v...)
+}
+
+// Fatal is a proxy for log.Fatal.
+func Fatal(v ...any) {
+	Default().Fatal(v...)
+}
+
+// Fatalf is a proxy for log.Fatalf.
+func Fatalf(format string, v ...any) {
+	Default().Fatalf(format, v...)
+}
+
+// Fatalln is a proxy for log.Fatalln.
+func Fatalln(v ...any) {
+	Default().Fatalln(v...)
+}
+
+// Panic is a proxy for log.Panic.
+func Panic(v ...any) {
+	Default().Panic(v...)
+}
+
+// Panicf is a proxy for log.Panicf.
+func Panicf(format string, v ...any) {
+	Default().Panicf(format, v...)
+}
+
+// Panicln is a proxy for log.Panicln.
+func Panicln(v ...any) {
+	Default().Panicln(v...)
+}
+
+// Writer is a proxy for log.Writer.
+func Writer() io.Writer {
+	return Default().Writer()
+}
+
+// Output is a proxy for log.Output.
+func Output(calldepth int, s string) error {
+	return Default().Output(calldepth+1, s)
+}
+
+// SetOutput is a proxy for log.SetOutput.
+func SetOutput(w io.Writer) {
+	Default().SetOutput(w)
+}
+
+// Flags is a proxy for log.Flags.
+func Flags() int {
+	return Default().Flags()
+}
+
+// SetFlags is a proxy for log.SetFlags.
+func SetFlags(flag int) {
+	Default().SetFlags(flag)
+}
+
+// Prefix is a proxy for log.Prefix.
+func Prefix() string {
+	return Default().Prefix()
+}
+
+// SetPrefix is a proxy for log.SetPrefix.
+func SetPrefix(prefix string) {
+	Default().SetPrefix(prefix)
+}

--- a/vendor/github.com/osbuild/images/pkg/olog/var.go
+++ b/vendor/github.com/osbuild/images/pkg/olog/var.go
@@ -1,0 +1,30 @@
+package olog
+
+import (
+	"io"
+	"log"
+	"sync/atomic"
+)
+
+var logger atomic.Pointer[log.Logger]
+
+func init() {
+	SetDefault(nil)
+}
+
+// SetDefault sets the default logger to the provided logger. When nil is passed,
+// the default logger is set to a no-op logger that discards all log messages.
+func SetDefault(l *log.Logger) {
+	if l == nil {
+		logger.Store(log.New(io.Discard, "", 0))
+		return
+	}
+
+	logger.Store(l)
+}
+
+// Default returns the default logger. If no logger has been set, it returns a
+// no-op logger that discards all log messages.
+func Default() *log.Logger {
+	return logger.Load()
+}

--- a/vendor/github.com/osbuild/images/pkg/osbuild/insights_client_config_stage.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/insights_client_config_stage.go
@@ -1,8 +1,12 @@
 package osbuild
 
-type InsightsClientConfigStageOptions struct {
+type InsightsClientConfig struct {
 	Proxy string `json:"proxy,omitempty"`
 	Path  string `json:"path,omitempty"`
+}
+
+type InsightsClientConfigStageOptions struct {
+	Config InsightsClientConfig `json:"config"`
 }
 
 func (InsightsClientConfigStageOptions) isStageOptions() {}

--- a/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
+++ b/vendor/github.com/osbuild/images/pkg/reporegistry/repository.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/osbuild/images/pkg/distroidparser"
+	"github.com/osbuild/images/pkg/olog"
 	"github.com/osbuild/images/pkg/rpmmd"
 )
 
@@ -54,7 +53,7 @@ func loadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, err
 				// without a dot to separate major and minor release versions
 				distro, err := distroidparser.DefaultParser.Standardize(distroIDStr)
 				if err != nil {
-					logrus.Warnf("failed to parse distro ID string, using it as is: %v", err)
+					olog.Printf("WARNING: failed to parse distro ID string, using it as is: %v", err)
 					// NB: Before the introduction of distro ID standardization, the filename
 					//     was used as the distro ID. This is kept for backward compatibility
 					//     if the filename can't be parsed.
@@ -76,7 +75,7 @@ func loadAllRepositoriesFromFS(confPaths []fs.FS) (rpmmd.DistrosRepoConfigs, err
 					return nil, err
 				}
 
-				logrus.Infof("Loaded repository configuration file: %s", fileEntry.Name())
+				olog.Printf("Loaded repository configuration file: %s", fileEntry.Name())
 
 				distrosRepoConfigs[distro] = distroRepos
 			}

--- a/vendor/github.com/osbuild/images/pkg/rhsm/secrets.go
+++ b/vendor/github.com/osbuild/images/pkg/rhsm/secrets.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/osbuild/images/pkg/olog"
 	"gopkg.in/ini.v1"
 )
 
@@ -111,7 +111,7 @@ func LoadSystemSubscriptions() (*Subscriptions, error) {
 	if err != nil {
 		// Consumer secrets are only needed when resolving
 		// ostree content (see commit 632f272)
-		logrus.Warnf("Failed to load consumer certs: %v", err)
+		olog.Printf("WARNING: Failed to load consumer certs: %v", err)
 	}
 
 	subscriptions, err1 := getListOfSubscriptions()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1049,7 +1049,7 @@ github.com/oracle/oci-go-sdk/v54/workrequests
 ## explicit; go 1.22.8
 github.com/osbuild/blueprint/internal/common
 github.com/osbuild/blueprint/pkg/blueprint
-# github.com/osbuild/images v0.143.0
+# github.com/osbuild/images v0.144.0
 ## explicit; go 1.22.8
 github.com/osbuild/images/data/dependencies
 github.com/osbuild/images/data/repositories
@@ -1089,6 +1089,7 @@ github.com/osbuild/images/pkg/dnfjson
 github.com/osbuild/images/pkg/experimentalflags
 github.com/osbuild/images/pkg/image
 github.com/osbuild/images/pkg/manifest
+github.com/osbuild/images/pkg/olog
 github.com/osbuild/images/pkg/osbuild
 github.com/osbuild/images/pkg/ostree
 github.com/osbuild/images/pkg/ostree/mock_ostree_repo


### PR DESCRIPTION
   tag v0.144.0
    Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>
    
    Changes with 0.144.0
    
    ----------------
      * customizations: drop `FsNode` interface as it is not used (#1490)
        * Author: Michael Vogt, Reviewers: Brian C. Lane, Simon de Vlieger
      * distro/rhel10/ami: unset authselect in ImageConfig (COMPOSER-2517) (#1469)
        * Author: Achilleas Koutsou, Reviewers: Brian C. Lane, Michael Vogt
      * manifest/os: immediately create directories (HMS-6043) (#1502)
        * Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Michael Vogt
      * osbuild: Add config to InsightsClientConfigStageOptions (#1503)
        * Author: rverdile, Reviewers: Michael Vogt, Sanne Raymaekers
      * refactor: replace logrus with stdlib log package (#1481)
        * Author: Lukáš Zapletal, Reviewers: Michael Vogt, Simon de Vlieger
    
    — Somewhere on the Internet, 2025-05-08
