### PR TITLE
templates/packer: set wanted-by to cloud-init.target

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-executor.service
+++ b/templates/packer/ansible/roles/common/files/worker-executor.service
@@ -10,4 +10,4 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/set_executor_hostname
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_executor.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -24,4 +24,4 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
 ExecStopPost=/usr/local/libexec/worker-initialization-scripts/on_exit.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target


### PR DESCRIPTION
The `cloud-init.target` in 9.6 has `After=multi-user.target` in its unit config. The worker initialization service was set to run before `multi-user.target`, but after `cloud-final.service`. This created an impossible situation and systemd just disabling the initialization service.

So this changes:
`multi-user.target -> worker-*.service -> cloud-final.service -> multi-user.target`
to
`cloud-init.target -> worker-*.service -> cloud-final.service -> multi-user.target`.

Thus resolving the loop.

---

on the graph you can see the worker-initialization -> cloud-final -> multi target -> worker-initialization loop.

![worker-cycle](https://github.com/user-attachments/assets/81b9f65d-a1a3-40ca-b450-18cb28ca841e)

---

fixed loop
![worker-cycle-fixed](https://github.com/user-attachments/assets/b1861443-3a82-44cd-ae0f-317e7e2f5309)

