### PR TITLE
CI: Run RHEL 10 nightly pipeline on PRs

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -94,7 +94,7 @@ jobs:
             git push -f ci
           fi
 
-      - name: Trigger GitLab nightly pipeline against this PR
+      - name: Trigger GitLab RHEL 9 nightly pipeline against this PR
         if: env.GITLAB_TOKEN && steps.pr_data.outputs.pr_branch
         run: |
             # osbuild-composer
@@ -106,4 +106,17 @@ jobs:
                 --form "variables[CI_PIPELINE_SOURCE]=schedule" \
                 --form "variables[NIGHTLY]=true" \
                 --form "variables[RHEL_MAJOR]=9" \
+                "https://gitlab.com/api/v4/projects/$PROJECT_ID/trigger/pipeline"
+
+      - name: Trigger GitLab RHEL 10 nightly pipeline against this PR
+        if: env.GITLAB_TOKEN && steps.pr_data.outputs.pr_branch
+        run: |
+            # osbuild-composer
+            PROJECT_ID=34771166
+            # Simulate a nightly CI pipeline against this PR
+            curl --request POST --fail --form "token=$GITLAB_TOKEN" \
+                --form ref=${{ steps.pr_data.outputs.pr_branch }} \
+                --form "variables[CI_PIPELINE_SOURCE]=schedule" \
+                --form "variables[NIGHTLY]=true" \
+                --form "variables[RHEL_MAJOR]=10" \
                 "https://gitlab.com/api/v4/projects/$PROJECT_ID/trigger/pipeline"


### PR DESCRIPTION
Add RHEL 10 nightly pipeline to PRs as well to avoid test breaking changes being introduced into main.
