### PR TITLE
Schutzfile: add fedora-42

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -85,6 +85,49 @@
       }
     ]
   },
+  "fedora-42": {
+    "dependencies": {
+      "osbuild": {
+        "commit": "42281231b0ee08f1dd08aed86eb187bcb26bbf44"
+      }
+    },
+    "repos": [
+      {
+        "file": "/etc/yum.repos.d/fedora.repo",
+        "x86_64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f42/f42-x86_64-fedora-20250512"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "fedora",
+            "name": "fedora",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f42/f42-aarch64-fedora-20250512"
+          }
+        ]
+      },
+      {
+        "file": "/etc/yum.repos.d/fedora-updates.repo",
+        "x86_64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f42/f42-x86_64-updates-released-20250605"
+          }
+        ],
+        "aarch64": [
+          {
+            "title": "updates",
+            "name": "updates",
+            "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f42/f42-aarch64-updates-released-20250605"
+          }
+        ]
+      }
+    ]
+  },
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {


### PR DESCRIPTION
The packer job actually looks for the osbuild dependency that matches the distro name that it's about to build. So in the case of fedora-42, a fedora-42 Schutzfile entry is needed.
