### PR TITLE
CI: disable know to be bad tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,15 +332,18 @@ Image Tests:
           - aws/rhel-10.1-nightly-aarch64
         INTERNAL_NETWORK: ["true"]
 
-Trigger-rhel-edge-ci:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE != "schedule"'
-  stage: test
-  interruptible: true
-  tags:
-    - shell
-  script:
-    - 'curl -u "${SCHUTZBOT_LOGIN}" -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/osbuild/rhel-edge-ci/dispatches -d "{\"event_type\":\"osbuild-composer-ci\",\"client_payload\":{\"pr_number\":\"${CI_COMMIT_BRANCH}\"}}"'
+# NB (thozza): The rhel-edge-ci job is currently disabled because the tests have been consistently failing for a while.
+# The tests need to be investigated and fixed before re-enabling the job.
+# See https://issues.redhat.com/browse/HMS-8719
+# Trigger-rhel-edge-ci:
+#   rules:
+#     - if: '$CI_PIPELINE_SOURCE != "schedule"'
+#   stage: test
+#   interruptible: true
+#   tags:
+#     - shell
+#   script:
+#     - 'curl -u "${SCHUTZBOT_LOGIN}" -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/osbuild/rhel-edge-ci/dispatches -d "{\"event_type\":\"osbuild-composer-ci\",\"client_payload\":{\"pr_number\":\"${CI_COMMIT_BRANCH}\"}}"'
 
 .integration_base:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -831,8 +831,11 @@ Installer:
       - RUNNER:
           - rhos-01/rhel-9.7-nightly-x86_64
           - rhos-01/centos-stream-9-x86_64
-          - rhos-01/rhel-10.1-nightly-x86_64
-          - rhos-01/centos-stream-10-x86_64
+          # NB (thozza): The test is disabled for RHEL 10.1 due to https://issues.redhat.com/browse/RHEL-96222
+          # Re-enable it once kernel-6.12.0-97.el10 lands in the repositories.
+          # See https://issues.redhat.com/browse/HMS-8718
+          # - rhos-01/rhel-10.1-nightly-x86_64
+          # - rhos-01/centos-stream-10-x86_64
 
 ContainerUpload:
   stage: test


### PR DESCRIPTION
**CI: disable Installer test on c10s / el10.1 due to a known bug**

The ticket to re-enable the test is:
https://issues.redhat.com/browse/HMS-8718

Signed-off-by: Tomáš Hozza <thozza@redhat.com>

---

**CI: disable consistently failing EDGE CI tests**

These test have been failing consistently for very long time (many
months). They need to be investigated and fixed before re-enabling them.

The ticket to re-enable them is:
https://issues.redhat.com/browse/HMS-8719

Signed-off-by: Tomáš Hozza <thozza@redhat.com>

---