### PR TITLE
ci: introduce gobump gha

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -1,0 +1,22 @@
+---
+name: "Updates Go dependencies via gobump"
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  schedule:
+    # Every Sunday at 15:00
+    - cron: "0 15 * * 0"
+
+jobs:
+  bump-deps-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run gobump-deps action
+        uses: lzap/gobump@v1
+        with:
+          go_version: "1.22.0"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exec_pr: ./tools/prepare-source.sh


### PR DESCRIPTION
Since gobump proven to be useful in `images`, I am proposing it for composer as well. We would drop other dependency bots and only use gobump. It bumps weekly.

This can only be tested after GHA exists and then it can be triggered against `upstream` branch manually to fine-tune it. It is the exact copy from `images` job: https://github.com/osbuild/images/blob/main/.github/workflows/gobump.yml
