### PR TITLE
[RHEL 8.10] go.mod: bump osbuild/images to v0.40.1 [RHEL-95416]

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,18 +34,8 @@ jobs:
 - job: copr_build
   trigger: pull_request
   targets: &build_targets
-    - centos-stream-8-aarch64
-    - centos-stream-8-x86_64
-    - centos-stream-9-aarch64
-    - centos-stream-9-x86_64
-    - fedora-all-aarch64
-    - fedora-all-s390x
-    - fedora-all-ppc64le
-    - fedora-all
     - rhel-8-aarch64
     - rhel-8-x86_64
-    - rhel-9-aarch64
-    - rhel-9-x86_64
 - job: copr_build
   trigger: commit
   branch: main

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/openshift-online/ocm-sdk-go v0.1.398
 	github.com/oracle/oci-go-sdk/v54 v54.0.0
-	github.com/osbuild/images v0.40.0
+	github.com/osbuild/images v0.40.1
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1
 	github.com/osbuild/pulp-client v0.1.0
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.398 h1:6C1mDcPxzG4jSduOaWixTTI5gSEO+
 github.com/openshift-online/ocm-sdk-go v0.1.398/go.mod h1:tke8vKcE7eHKyRbkJv6qo4ljo919zhx04uyQTcgF5cQ=
 github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXchUUZ+LS4=
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
-github.com/osbuild/images v0.40.0 h1:aVlg1+0CiVY6ViuEAMjEIBXvXfTtbKGHHIgQ8N95YWE=
-github.com/osbuild/images v0.40.0/go.mod h1:RyfQIjcdjGQ+wKcqLCd5KrCixO0xsDRaDYCgorPFVXk=
+github.com/osbuild/images v0.40.1 h1:7cB05CX6nqZAUKdDlwfptwGHwa2boECmWLWoLDM9caw=
+github.com/osbuild/images v0.40.1/go.mod h1:RyfQIjcdjGQ+wKcqLCd5KrCixO0xsDRaDYCgorPFVXk=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1 h1:UFEJIcPa46W8gtWgOYzriRKYyy1t6SWL0BI7fPTuVvc=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20231117174845-e969a9dc3cd1/go.mod h1:z+WA+dX6qMwc7fqY5jCzESDIlg4WR2sBQezxsoXv9Ik=
 github.com/osbuild/pulp-client v0.1.0 h1:L0C4ezBJGTamN3BKdv+rKLuq/WxXJbsFwz/Hj7aEmJ8=

--- a/vendor/github.com/osbuild/images/pkg/image/anaconda_ostree_installer.go
+++ b/vendor/github.com/osbuild/images/pkg/image/anaconda_ostree_installer.go
@@ -98,7 +98,7 @@ func (img *AnacondaOSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoLabel := fmt.Sprintf(img.ISOLabelTempl, img.Platform.GetArch())
 
 	rootfsImagePipeline := manifest.NewISORootfsImg(buildPipeline, anacondaPipeline)
-	rootfsImagePipeline.Size = 4 * common.GibiByte
+	rootfsImagePipeline.Size = 10 * common.GibiByte // NOTE: should be big enough to fit the anaconda-tree
 
 	bootTreePipeline := manifest.NewEFIBootTree(buildPipeline, img.Product, img.OSVersion)
 	bootTreePipeline.Platform = img.Platform

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -851,7 +851,7 @@ github.com/oracle/oci-go-sdk/v54/identity
 github.com/oracle/oci-go-sdk/v54/objectstorage
 github.com/oracle/oci-go-sdk/v54/objectstorage/transfer
 github.com/oracle/oci-go-sdk/v54/workrequests
-# github.com/osbuild/images v0.40.0
+# github.com/osbuild/images v0.40.1
 ## explicit; go 1.19
 github.com/osbuild/images/internal/common
 github.com/osbuild/images/internal/environment


### PR DESCRIPTION
Fixes the size of the ISO rootfs to fit the anaconda tree for the edge-installer.

See osbuild/images#1594
