### PR TITLE
osbuild-dnf-json-tests: use `distrofactory` to get `centos-9`

### DIFF
--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
-	"github.com/osbuild/images/pkg/distro/rhel/rhel9"
+	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/dnfjson"
 	"github.com/osbuild/images/pkg/ostree"
 	"github.com/osbuild/images/pkg/reporegistry"
@@ -29,7 +29,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 	repoDir := "/usr/share/tests/osbuild-composer/repositories"
 
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
-	cs9 := rhel9.DistroFactory("centos-9")
+	cs9 := distrofactory.NewDefault().GetDistro("centos-9")
 	require.NotNil(t, cs9)
 
 	// Set up temporary directory for rpm/dnf cache
@@ -86,7 +86,7 @@ func TestDepsolvePackageSets(t *testing.T) {
 	repoDir := "/usr/share/tests/osbuild-composer/repositories"
 
 	// NOTE: we can add RHEL, but don't make it hard requirement because it will fail outside of VPN
-	cs9 := rhel9.DistroFactory("centos-9")
+	cs9 := distrofactory.NewDefault().GetDistro("centos-9")
 	require.NotNil(t, cs9)
 
 	// Set up temporary directory for rpm/dnf cache


### PR DESCRIPTION
The test was importing `distro/rhel/rhel9` directly instead of using the `distrofactory`. This is problematic as the go module for `rhel9` is going away. This commit fixes this by going via the `distrofactory` which will keep working.

Needed for  https://github.com/osbuild/images/pull/1645