### PR TITLE
test/ubi-wsl.sh: add backward compatibility for composer < v146

### DIFF
--- a/test/cases/ubi-wsl.sh
+++ b/test/cases/ubi-wsl.sh
@@ -134,6 +134,14 @@ greenprint "📀 Getting disk image"
 get_compose_image "$COMPOSE_ID"
 
 DISK="$COMPOSE_ID-image.wsl"
+
+# backward compatibility for RHEL nightly tests
+if ! nvrGreaterOrEqual "osbuild-composer" "146"; then
+    DISK="$COMPOSE_ID-disk.tar.gz"
+fi
+
+greenprint "Looking for disk image: $DISK"
+
 if [ ! -f "$DISK" ]; then
     redprint "Disk image missing from results"
     exit 1


### PR DESCRIPTION
Adjust the test case, so that it does not fail when run against older osbuild-composer version, i.e. the one from RHEL-10 nightly CI pipelines.

