### PR TITLE
schutzbot/update_github_status.sh: fix GA pipeline status reporting

### DIFF
--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -29,7 +29,11 @@ fi
 
 CONTEXT="Schutzbot on GitLab"
 if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
-    CONTEXT="$CONTEXT, RHEL-${RHEL_MAJOR:-}-nightly"
+    if [[ "$NIGHTLY" == "true" ]]; then
+        CONTEXT="$CONTEXT, scheduled RHEL-${RHEL_MAJOR:-}-nightly"
+    else
+        CONTEXT="$CONTEXT, scheduled RHEL GA"
+    fi
 fi
 
 curl \


### PR DESCRIPTION
Previously, the script didn't distinguish between the scheduled RHEL-X nightly pipeline and the scheduled RHEL GA pipeline when reporting status back to GitHub. Moreover the scheduled RHEL GA pipeline on GitLab had RHEL_MAJOR variable set to "9". As a result, the scheduled RHEL GA pipeline status has been reported to GitHub as "Schutzbot on GitLab, RHEL-9-nightly", which effectively overrode the RHEL-9 nightly pipeline status for the same commit.

Fix the script reporting the status back to GitHub, to take the NIGHLY variable value into consideration when building up the status context.

I've also modified the RHEL GA scheduled pipeline settings in GitLab to not specify any RHEL_MAJOR, which was a relict from pre-RHEL-10 days.