### PR TITLE
templates/packer: avoid errors in worker-executor startup

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Worker Initialization Service
 ConditionPathExists=!/etc/worker-first-boot
+ConditionPathExists=!/tmp/worker-run-executor-service
 Wants=cloud-final.service
 After=cloud-final.service
 


### PR DESCRIPTION
When the worker executor starts up, many error messages and warnings are shown in the system logs, `worker-initialization.service` should actually not run at all (if I understood correctly!). The service crashes and functionally that's fine, but it just messes up the log, raises questions and can be avoided by just not running it.

@croissanne is this valid? Would this remove the errors I saw?