### PR TITLE
cloudapi: use distrofactory to get rhel-9.3

### DIFF
--- a/internal/cloudapi/v2/imagerequest_test.go
+++ b/internal/cloudapi/v2/imagerequest_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/osbuild/images/pkg/arch"
-	"github.com/osbuild/images/pkg/distro/rhel/rhel9"
 	"github.com/osbuild/images/pkg/distro/test_distro"
+	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
 
@@ -58,7 +58,7 @@ func TestGetOstreeOptions(t *testing.T) {
 func TestGetTargets(t *testing.T) {
 	at := assert.New(t)
 
-	r9 := rhel9.DistroFactory("rhel-9.3")
+	r9 := distrofactory.NewDefault().GetDistro("rhel-9.3")
 	require.NotNil(t, r9)
 	arch, err := r9.GetArch(arch.ARCH_X86_64.String())
 	at.NoError(err)


### PR DESCRIPTION
Same as in 57813199cf6298a8f78222dad6e75163b63aade7.

The test was importing `distro/rhel/rhel9`, which is going away, instead of using the distrofactory.