### PR TITLE
workflows: use correct token for gobump

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -18,5 +18,5 @@ jobs:
         uses: lzap/gobump@main
         with:
           go_version: "1.23.9"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           exec_pr: ./tools/prepare-source.sh


### PR DESCRIPTION
The newly added gobump was using the default token but this one is not configured with all required permissions for this repo. This was causing tests not being executed on github.

---

Tested in CRC, seems to help: https://github.com/osbuild/image-builder-crc/pull/1656

Will fix gobump PR where tests are not being triggered: https://github.com/osbuild/osbuild-composer/pull/4793