### PR TITLE
.github/workflows/gobump: use schutzbot token

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -18,5 +18,5 @@ jobs:
         uses: lzap/gobump@main
         with:
           go_version: "1.23.9"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           exec_pr: ./tools/prepare-source.sh


### PR DESCRIPTION
Github actions using the default token cannot create PRs where workflows are triggered. Use the schutzbot token to run the gobump workflow, as it will trigger workflows on the PRs it creates.