### PR TITLE
Packer: skip packer-plugin-amazon version 1.3.10 due to missing checksum

### DIFF
--- a/templates/packer/config.pkr.hcl
+++ b/templates/packer/config.pkr.hcl
@@ -1,7 +1,9 @@
 packer {
   required_plugins {
     amazon = {
-      version = ">= 1.2.3"
+      # we need to skip version 1.3.10 due to a bug
+      # https://github.com/hashicorp/packer-plugin-amazon/issues/586
+      version = ">= 1.2.3, != 1.3.10"
       source = "github.com/hashicorp/amazon"
     }
   }


### PR DESCRIPTION
The 1.3.10 release has some issues and fails when used by Packer. See https://github.com/hashicorp/packer-plugin-amazon/issues/586 for more information.