### PR TITLE
Test/regression-old-worker-new-composer: make the test case more robust

### DIFF
--- a/test/cases/regression-old-worker-new-composer.sh
+++ b/test/cases/regression-old-worker-new-composer.sh
@@ -34,12 +34,6 @@ DESIRED_WORKER_RPM="osbuild-composer-worker-$((CURRENT_WORKER_VERSION - 3))"
 DESIRED_TAG_SHA=$(curl -s "https://api.github.com/repos/osbuild/osbuild-composer/git/ref/tags/v$((CURRENT_WORKER_VERSION-3))" | jq -r '.object.sha')
 DESIRED_COMMIT_SHA=$(curl -s "https://api.github.com/repos/osbuild/osbuild-composer/git/tags/$DESIRED_TAG_SHA" | jq -r '.object.sha')
 
-# Get commit hash of latest composer version, only used for verification.
-CURRENT_COMPOSER_VERSION=$(rpm -q --qf '%{version}\n' osbuild-composer)
-
-COMPOSER_LATEST_TAG_SHA=$(curl -s "https://api.github.com/repos/osbuild/osbuild-composer/git/ref/tags/v$((CURRENT_COMPOSER_VERSION-1))" | jq -r '.object.sha')
-COMPOSER_LATEST_COMMIT_SHA=$(curl -s "https://api.github.com/repos/osbuild/osbuild-composer/git/tags/$COMPOSER_LATEST_TAG_SHA" | jq -r '.object.sha')
-
 COMPOSER_CONTAINER_NAME="composer"
 
 # Container image used for cloud provider CLI tools
@@ -393,7 +387,6 @@ $AWS_CMD s3api put-object-tagging \
 
 greenprint "✅ Successfully tagged S3 object"
 
-setup_repo osbuild-composer "$COMPOSER_LATEST_COMMIT_SHA" 10
 OSBUILD_GIT_COMMIT=$(cat Schutzfile | jq -r '.["'"${ID}-${VERSION_ID}"'"].dependencies.osbuild.commit')
 setup_repo osbuild "$OSBUILD_GIT_COMMIT" 10
 


### PR DESCRIPTION
The test case is testing that old version of osbuild-composer worker
still works with the current version of the osbuild-composer under test.
This is to ensure that we do not break backward compatibility of the
worker API.

The test case first installs the version of osbuild-composer under test,
to determine its version. It uses GH to determine the upstream commit
SHA of an osbuild-composer version older by three releases than the
current version under test. The installed osbuild-composer* RPMs are
then removed.

In the next phase, the test case sets up RPM repo for the "old" composer
version from CI S3 cache and installs the osbuild-composer-worker
package from it. Lastly, the current version of osbuild-composer under
test is pulled as a container, which is built by a previous job within
the same CI pipeline.

Finally, the test case runs a testing image build for qcow2 type, using
the current version of osbuild-composer under test running inside a
container, and the old worker running locally. The built image is then
downloaded from S3 and inspected using osbuild-image-info tool.

Previously, the test case used to setup osbuild-composer RPM repo a
second time, without any apparent reason. The second repo used a third
version of osbuild-composer (different than the one used for the old
worker and the current version under test), which was creating another
dependency on old CI pipeline runs. This was most probably a leftover
from previous versions of the test case.

Let's remove the second setup of osbuild-composer RPM repo to reduce the
situations that can cause the test case to fail, in case the old CI
pipelines failed or didn't run at all.

---

The test case needs to install RPMs for an osbuild-composer version
which is older by three releases, than the version under test. This is
done by looking up the GH tag and its corresponding commit SHA. However,
it may happen that the CI pipeline for that commit SHA failed and there
were no RPMs built that can be installed.

To make the test case more robust, enhance it, so that it can iterate 10
commits back to the past, in order to find a commit SHA with a working
corresponding repository.

There is a slight chance that the traversal to older commits may cross
another release tag, so the RPM repository may contain older
osbuild-composer worker version than desired. In such case the test case
will fail. To not complicate the test case further, let's keep this
scenario unhandled, but explicitly mentioned in a comment.