### PR TITLE
Packer: install 'rsync' in the ubi-packer container (HMS-9287)

### DIFF
--- a/distribution/Dockerfile-ubi-packer
+++ b/distribution/Dockerfile-ubi-packer
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 RUN curl --location --output /etc/yum.repos.d/hashicorp.repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-RUN microdnf install -y packer openssh-clients unzip python3 python3-pip
+RUN microdnf install -y packer openssh-clients unzip python3 python3-pip rsync
 
 RUN pip3 install ansible
 RUN ansible-galaxy collection install ansible.posix


### PR DESCRIPTION
The build of the image fails in AppInfra when fetching RPMs on non-existence of rsync command.

/jira-epic HMS-9242

JIRA: [HMS-9287](https://issues.redhat.com/browse/HMS-9287)