### PR TITLE
[10.0] internal/blueprint: add JSON tailoring to bp conversion (HMS-9302)

### DIFF
--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -253,6 +253,10 @@ func Convert(bp Blueprint) iblueprint.Blueprint {
 				itailoring := iblueprint.OpenSCAPTailoringCustomizations(*tailoring)
 				ioscap.Tailoring = &itailoring
 			}
+			if jsonTailoring := oscap.JSONTailoring; jsonTailoring != nil {
+				ijsonTailoring := iblueprint.OpenSCAPJSONTailoringCustomizations(*jsonTailoring)
+				ioscap.JSONTailoring = &ijsonTailoring
+			}
 			customizations.OpenSCAP = &ioscap
 		}
 		if ign := c.Ignition; ign != nil {

--- a/internal/blueprint/blueprint_convert_test.go
+++ b/internal/blueprint/blueprint_convert_test.go
@@ -233,6 +233,10 @@ func TestConvert(t *testing.T) {
 							Selected:   []string{"cloth"},
 							Unselected: []string{"leather"},
 						},
+						JSONTailoring: &OpenSCAPJSONTailoringCustomizations{
+							ProfileID: "tailored_profile",
+							Filepath:  "path-to-json-file",
+						},
 					},
 					Ignition: &IgnitionCustomization{
 						Embedded: &EmbeddedIgnitionCustomization{
@@ -531,6 +535,10 @@ func TestConvert(t *testing.T) {
 						Tailoring: &iblueprint.OpenSCAPTailoringCustomizations{
 							Selected:   []string{"cloth"},
 							Unselected: []string{"leather"},
+						},
+						JSONTailoring: &iblueprint.OpenSCAPJSONTailoringCustomizations{
+							ProfileID: "tailored_profile",
+							Filepath:  "path-to-json-file",
 						},
 					},
 					Ignition: &iblueprint.IgnitionCustomization{


### PR DESCRIPTION
The blueprint convert function was missing the json tailoring case. This meant that if the json tailoring customization was provided in the blueprint, the customization would get ignored and the tailoring profile would not be applied to the image.