### PR TITLE
common: fix unclosed logrus logging pipes

### DIFF
--- a/internal/common/echo_logrus.go
+++ b/internal/common/echo_logrus.go
@@ -178,5 +178,9 @@ func (l *EchoLogrusLogger) Panicj(j lslog.JSON) {
 }
 
 func (l *EchoLogrusLogger) Write(p []byte) (n int, err error) {
-	return l.Logger.WithContext(l.Ctx).Writer().Write(p)
+	// Writer() from logrus returns PIPE that needs to be closed
+	w := l.Logger.WithContext(l.Ctx).Writer()
+	defer w.Close()
+
+	return w.Write(p)
 }


### PR DESCRIPTION
This is a backport of 1cde7e3. The original patch was not separated into individual commits unfortunately, therefore only the relevant line is being brought in. The original analysis:

---

It looks like both CloudAPI and WeldrAPI consume memory, process can go up to several gigabytes pretty quickly just by running a simple script.

while sleep 0.001; do
    curl --unix-socket /run/weldr/api.socket -XGET http://localhost/api/
    curl --unix-socket /run/cloudapi/api.socket -XGET http://localhost/api/
done

There is a logrus logger method called Write and WriteLevel which create a new logging entry, create a PIPE and spawn a goroutine that is reading from that PIPE. The caller is expected to close the PIPE writer which was not done.