### PR TITLE
test: run older CIV tag on nightlies

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -201,6 +201,13 @@ greenprint "Pulling cloud-image-val container"
 if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
   # If running on CIV, get dev container
   TAG=${CI_COMMIT_REF_SLUG}
+elif ! nvrGreaterOrEqual "osbuild-composer" "151"; then
+  # osbuild-composer v151 made changes in the Azure image definitions and CIV
+  # was updated to check for those changes:
+  # https://github.com/osbuild/cloud-image-val/pull/457
+  # This tag does not include those changes, so use it when running against
+  # older versions of composer.
+  TAG="pr-456"
 else
   # If not, get prod container
   TAG="prod"


### PR DESCRIPTION
CIV was recently updated [1] to cover changes in the upstream image definitions [2] in Azure images.  The 'pr-456' tag is the latest that does not include those changes.  Older versions of osbuild-composer are being tested in nightlies for 9.7 and 10.1, so it should run with the older image definitions that do not include the changes.

[1] https://github.com/osbuild/cloud-image-val/pull/457
[2] https://github.com/osbuild/images/pull/1814
