### PR TITLE
templates/packer: handle vector error

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
@@ -19,7 +19,7 @@ sources:
     type: vector
     address: ${PRIVATE_IP}:12005
 sinks:
-  worker:
+  worker_out:
     type: aws_cloudwatch_logs
     inputs:
       - journald
@@ -29,7 +29,7 @@ sinks:
     stream_name: worker_syslog_{{ host }}
     encoding:
       codec: json
-  executor:
+  executor_out:
     type: aws_cloudwatch_logs
     inputs:
       - executor


### PR DESCRIPTION
Names have to be unique across sources and sinks.

Fixes the following error:
```
Failed to load ["/etc/vector/vector.yaml"]
x More than one component with name "executor" (source, sink).
x Input "executor" for sink "executor" doesn't match any components.
```