### PR TITLE
Weldr API endpoints & store: don't use `rpmmd` package structs for serialization (HMS-9376)

### DIFF
--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/osbuild/images/pkg/sbom"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d distro.Distro, cacheDir string, repos []rpmmd.RepoConfig) (manifest.OSBuildManifest, []rpmmd.PackageSpec) {
@@ -180,7 +181,7 @@ func main() {
 			awsTarget,
 		},
 		id1,
-		packages,
+		weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(packages),
 	)
 	if err != nil {
 		panic(err)
@@ -195,7 +196,7 @@ func main() {
 			awsTarget,
 		},
 		id2,
-		packages,
+		weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(packages),
 	)
 	if err != nil {
 		panic(err)

--- a/internal/client/modules.go
+++ b/internal/client/modules.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	//	"strings"
 
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
 )
 
@@ -56,7 +54,7 @@ func ListModulesV0(socket *http.Client, moduleNames string) ([]weldr.ModuleName,
 }
 
 // GetModulesInfoV0 returns detailed module info on the named modules
-func GetModulesInfoV0(socket *http.Client, modulesNames string) ([]rpmmd.PackageInfo, *APIResponse, error) {
+func GetModulesInfoV0(socket *http.Client, modulesNames string) ([]weldr.PackageInfo, *APIResponse, error) {
 	body, resp, err := GetRaw(socket, "GET", "/api/v0/modules/info/"+modulesNames)
 	if resp != nil || err != nil {
 		return nil, resp, err

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	//	"strings"
 
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
 )
 
 // ListAllProjectsV0 returns a list of all the available project names
-func ListAllProjectsV0(socket *http.Client) ([]rpmmd.PackageInfo, *APIResponse, error) {
+func ListAllProjectsV0(socket *http.Client) ([]weldr.PackageInfo, *APIResponse, error) {
 	body, resp, err := GetJSONAll(socket, "/api/v0/projects/list")
 	if resp != nil || err != nil {
 		return nil, resp, err
@@ -27,7 +26,7 @@ func ListAllProjectsV0(socket *http.Client) ([]rpmmd.PackageInfo, *APIResponse, 
 }
 
 // ListSomeProjectsV0 returns a list of all the available project names
-func ListSomeProjectsV0(socket *http.Client, offset, limit int) ([]rpmmd.PackageInfo, *APIResponse, error) {
+func ListSomeProjectsV0(socket *http.Client, offset, limit int) ([]weldr.PackageInfo, *APIResponse, error) {
 	path := fmt.Sprintf("/api/v0/projects/list?offset=%d&limit=%d", offset, limit)
 	body, resp, err := GetRaw(socket, "GET", path)
 	if resp != nil || err != nil {
@@ -42,7 +41,7 @@ func ListSomeProjectsV0(socket *http.Client, offset, limit int) ([]rpmmd.Package
 }
 
 // GetProjectsInfoV0 returns detailed project info on the named projects
-func GetProjectsInfoV0(socket *http.Client, projNames string) ([]rpmmd.PackageInfo, *APIResponse, error) {
+func GetProjectsInfoV0(socket *http.Client, projNames string) ([]weldr.PackageInfo, *APIResponse, error) {
 	body, resp, err := GetRaw(socket, "GET", "/api/v0/projects/info/"+projNames)
 	if resp != nil || err != nil {
 		return nil, resp, err

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/weldr"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 // ListAllProjectsV0 returns a list of all the available project names
@@ -55,7 +55,7 @@ func GetProjectsInfoV0(socket *http.Client, projNames string) ([]weldr.PackageIn
 }
 
 // DepsolveProjectsV0 returns the dependencies of the names projects
-func DepsolveProjectsV0(socket *http.Client, projNames string) ([]rpmmd.PackageSpec, *APIResponse, error) {
+func DepsolveProjectsV0(socket *http.Client, projNames string) ([]weldrtypes.DepsolvedPackageInfo, *APIResponse, error) {
 	body, resp, err := GetRaw(socket, "GET", "/api/v0/projects/depsolve/"+projNames)
 	if resp != nil || err != nil {
 		return nil, resp, err

--- a/internal/store/compose.go
+++ b/internal/store/compose.go
@@ -12,14 +12,6 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
 
-type StateTransitionError struct {
-	message string
-}
-
-func (ste *StateTransitionError) Error() string {
-	return ste.message
-}
-
 // ImageBuild represents a single image build inside a compose
 type ImageBuild struct {
 	ID          int

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -9,7 +9,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/distrofactory"
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
@@ -95,7 +94,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 
 	s := New(nil, df, nil)
 
-	pkgs := []rpmmd.PackageSpec{
+	pkgs := []weldrtypes.DepsolvedPackageInfo{
 		{
 			Name:    "test1",
 			Epoch:   0,
@@ -122,7 +121,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 				Targets:     []*target.Target{awsTarget},
 				JobCreated:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
@@ -134,7 +133,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 				JobCreated:  date,
 				JobStarted:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000002"): {
 			Blueprint: &b,
@@ -147,7 +146,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 				JobStarted:  date,
 				JobFinished: date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
@@ -160,7 +159,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 				JobStarted:  date,
 				JobFinished: date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,
@@ -246,7 +245,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 
 	s := New(nil, df, nil)
 
-	pkgs := []rpmmd.PackageSpec{
+	pkgs := []weldrtypes.DepsolvedPackageInfo{
 		{
 			Name:    "test1",
 			Epoch:   0,
@@ -272,7 +271,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 				Targets:     []*target.Target{gcpTarget, awsTarget},
 				JobCreated:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
@@ -284,7 +283,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 				JobCreated:  date,
 				JobStarted:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
@@ -297,7 +296,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 				JobStarted:  date,
 				JobFinished: date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,
@@ -483,7 +482,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 
 	s := New(nil, df, nil)
 
-	pkgs := []rpmmd.PackageSpec{
+	pkgs := []weldrtypes.DepsolvedPackageInfo{
 		{
 			Name:    "test1",
 			Epoch:   0,
@@ -509,7 +508,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 				Targets:     []*target.Target{awsTarget},
 				JobCreated:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
@@ -521,7 +520,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 				JobCreated:  date,
 				JobStarted:  date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000002"): {
 			Blueprint: &b,
@@ -534,7 +533,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 				JobStarted:  date,
 				JobFinished: date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
@@ -547,7 +546,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 				JobStarted:  date,
 				JobFinished: date,
 			},
-			Packages: []rpmmd.PackageSpec{},
+			Packages: []weldrtypes.DepsolvedPackageInfo{},
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 func setupTestHostDistro(distroName, archName string) (Cleanup func()) {
@@ -111,10 +112,10 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 
 	s.blueprints[bName] = b
 
-	s.composes = map[uuid.UUID]Compose{
+	s.composes = map[uuid.UUID]weldrtypes.Compose{
 		uuid.MustParse("30000000-0000-0000-0000-000000000000"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBWaiting,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -125,7 +126,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBRunning,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -137,7 +138,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000002"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -150,7 +151,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFailed,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -163,7 +164,7 @@ func FixtureBase(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -261,10 +262,10 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 		}}
 
 	s.blueprints[bName] = b
-	s.composes = map[uuid.UUID]Compose{
+	s.composes = map[uuid.UUID]weldrtypes.Compose{
 		uuid.MustParse("30000000-0000-0000-0000-000000000000"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -275,7 +276,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -287,7 +288,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFailed,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -300,7 +301,7 @@ func FixtureFinished(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -498,10 +499,10 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		}}
 
 	s.blueprints[bName] = b
-	s.composes = map[uuid.UUID]Compose{
+	s.composes = map[uuid.UUID]weldrtypes.Compose{
 		uuid.MustParse("30000000-0000-0000-0000-000000000000"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBWaiting,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -512,7 +513,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000001"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBRunning,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -524,7 +525,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000002"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -537,7 +538,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000003"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFailed,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -550,7 +551,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000004"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,
@@ -563,7 +564,7 @@ func FixtureJobs(hostDistroName, hostArchName string) *Fixture {
 		},
 		uuid.MustParse("30000000-0000-0000-0000-000000000005"): {
 			Blueprint: &b,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: common.IBFinished,
 				ImageType:   imgType,
 				Manifest:    mf,

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -13,7 +13,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
@@ -38,9 +37,9 @@ type workspaceV0 map[string]blueprint.Blueprint
 // It contains all the information necessary to generate the inputs for the job, as
 // well as the job's state.
 type composeV0 struct {
-	Blueprint   *blueprint.Blueprint `json:"blueprint"`
-	ImageBuilds []imageBuildV0       `json:"image_builds"`
-	Packages    []rpmmd.PackageSpec  `json:"packages"`
+	Blueprint   *blueprint.Blueprint              `json:"blueprint"`
+	ImageBuilds []imageBuildV0                    `json:"image_builds"`
+	Packages    []weldrtypes.DepsolvedPackageInfo `json:"packages"`
 }
 
 type composesV0 map[uuid.UUID]composeV0
@@ -185,7 +184,7 @@ func newComposeFromV0(composeStruct composeV0, df *distrofactory.Factory) (weldr
 		return weldrtypes.Compose{}, err
 	}
 
-	pkgs := make([]rpmmd.PackageSpec, len(composeStruct.Packages))
+	pkgs := make([]weldrtypes.DepsolvedPackageInfo, len(composeStruct.Packages))
 	copy(pkgs, composeStruct.Packages)
 
 	return weldrtypes.Compose{
@@ -297,7 +296,7 @@ func newWorkspaceV0(workspace map[string]blueprint.Blueprint) workspaceV0 {
 func newComposeV0(compose weldrtypes.Compose) composeV0 {
 	bp := compose.Blueprint.DeepCopy()
 
-	pkgs := make([]rpmmd.PackageSpec, len(compose.Packages))
+	pkgs := make([]weldrtypes.DepsolvedPackageInfo, len(compose.Packages))
 	copy(pkgs, compose.Packages)
 
 	return composeV0{

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/distro/test_distro"
 	"github.com/osbuild/images/pkg/distrofactory"
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
@@ -1199,7 +1198,7 @@ func Test_newComposeV0(t *testing.T) {
 						QueueStatus: common.IBFinished,
 					},
 				},
-				Packages: []rpmmd.PackageSpec{},
+				Packages: []weldrtypes.DepsolvedPackageInfo{},
 			},
 		},
 	}
@@ -1307,7 +1306,7 @@ func Test_newComposeFromV0(t *testing.T) {
 					JobID:       uuid.MustParse("22445cd3-7fa5-4dca-b7f8-4f9857b3e3a0"),
 					QueueStatus: common.IBFinished,
 				},
-				Packages: []rpmmd.PackageSpec{},
+				Packages: []weldrtypes.DepsolvedPackageInfo{},
 			},
 		},
 	}
@@ -1440,7 +1439,7 @@ func Test_newComposesV0(t *testing.T) {
 							QueueStatus: common.IBFinished,
 						},
 					},
-					Packages: []rpmmd.PackageSpec{},
+					Packages: []weldrtypes.DepsolvedPackageInfo{},
 				},
 				uuid.MustParse("14c454d0-26f3-4a56-8ceb-a5673aaba686"): {
 					Blueprint: &bp,
@@ -1474,7 +1473,7 @@ func Test_newComposesV0(t *testing.T) {
 							QueueStatus: common.IBFinished,
 						},
 					},
-					Packages: []rpmmd.PackageSpec{},
+					Packages: []weldrtypes.DepsolvedPackageInfo{},
 				},
 			},
 		},
@@ -1616,7 +1615,7 @@ func Test_newComposesFromV0(t *testing.T) {
 						JobID:       uuid.MustParse("22445cd3-7fa5-4dca-b7f8-4f9857b3e3a0"),
 						QueueStatus: common.IBFinished,
 					},
-					Packages: []rpmmd.PackageSpec{},
+					Packages: []weldrtypes.DepsolvedPackageInfo{},
 				},
 				uuid.MustParse("14c454d0-26f3-4a56-8ceb-a5673aaba686"): {
 					Blueprint: &bp,
@@ -1648,7 +1647,7 @@ func Test_newComposesFromV0(t *testing.T) {
 						JobID:       uuid.MustParse("6ac04049-341a-4297-b50b-5424bec9f193"),
 						QueueStatus: common.IBFinished,
 					},
-					Packages: []rpmmd.PackageSpec{},
+					Packages: []weldrtypes.DepsolvedPackageInfo{},
 				},
 			},
 		},

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 // MustParseTime parses a time string and panics if there is an error
@@ -145,7 +146,7 @@ func TestStore_toStoreV0(t *testing.T) {
 	type fields struct {
 		blueprints        map[string]blueprint.Blueprint
 		workspace         map[string]blueprint.Blueprint
-		composes          map[uuid.UUID]Compose
+		composes          map[uuid.UUID]weldrtypes.Compose
 		sources           map[string]SourceConfig
 		blueprintsChanges map[string]map[string]blueprint.Change
 		blueprintsCommits map[string][]string
@@ -1130,14 +1131,14 @@ func Test_newComposeV0(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		compose Compose
+		compose weldrtypes.Compose
 		want    composeV0
 	}{
 		{
 			name: "qcow2 compose",
-			compose: Compose{
+			compose: weldrtypes.Compose{
 				Blueprint: &bp,
-				ImageBuild: ImageBuild{
+				ImageBuild: weldrtypes.ImageBuild{
 					ID:        0,
 					ImageType: testImageType,
 					Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1229,14 +1230,14 @@ func Test_newComposeFromV0(t *testing.T) {
 		name    string
 		compose composeV0
 		factory *distrofactory.Factory
-		want    Compose
+		want    weldrtypes.Compose
 		errOk   bool
 	}{
 		{
 			name:    "empty",
 			compose: composeV0{},
 			factory: df,
-			want:    Compose{},
+			want:    weldrtypes.Compose{},
 			errOk:   true,
 		},
 		{
@@ -1276,9 +1277,9 @@ func Test_newComposeFromV0(t *testing.T) {
 					},
 				},
 			},
-			want: Compose{
+			want: weldrtypes.Compose{
 				Blueprint: &bp,
-				ImageBuild: ImageBuild{
+				ImageBuild: weldrtypes.ImageBuild{
 					ID:        0,
 					ImageType: testImageType,
 					Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1337,15 +1338,15 @@ func Test_newComposesV0(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		composes map[uuid.UUID]Compose
+		composes map[uuid.UUID]weldrtypes.Compose
 		want     composesV0
 	}{
 		{
 			name: "two composes",
-			composes: map[uuid.UUID]Compose{
+			composes: map[uuid.UUID]weldrtypes.Compose{
 				uuid.MustParse("f53b49c0-d321-447e-8ab8-6e827891e3f0"): {
 					Blueprint: &bp,
-					ImageBuild: ImageBuild{
+					ImageBuild: weldrtypes.ImageBuild{
 						ID:        0,
 						ImageType: testImageType,
 						Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1376,7 +1377,7 @@ func Test_newComposesV0(t *testing.T) {
 				},
 				uuid.MustParse("14c454d0-26f3-4a56-8ceb-a5673aaba686"): {
 					Blueprint: &bp,
-					ImageBuild: ImageBuild{
+					ImageBuild: weldrtypes.ImageBuild{
 						ID:        0,
 						ImageType: testImageType,
 						Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1505,13 +1506,13 @@ func Test_newComposesFromV0(t *testing.T) {
 		name     string
 		registry *distrofactory.Factory
 		composes composesV0
-		want     map[uuid.UUID]Compose
+		want     map[uuid.UUID]weldrtypes.Compose
 	}{
 		{
 			name:     "empty",
 			registry: df,
 			composes: composesV0{},
-			want:     make(map[uuid.UUID]Compose),
+			want:     make(map[uuid.UUID]weldrtypes.Compose),
 		},
 		{
 			name:     "two composes",
@@ -1584,10 +1585,10 @@ func Test_newComposesFromV0(t *testing.T) {
 					},
 				},
 			},
-			want: map[uuid.UUID]Compose{
+			want: map[uuid.UUID]weldrtypes.Compose{
 				uuid.MustParse("f53b49c0-d321-447e-8ab8-6e827891e3f0"): {
 					Blueprint: &bp,
-					ImageBuild: ImageBuild{
+					ImageBuild: weldrtypes.ImageBuild{
 						ID:        0,
 						ImageType: testImageType,
 						Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1619,7 +1620,7 @@ func Test_newComposesFromV0(t *testing.T) {
 				},
 				uuid.MustParse("14c454d0-26f3-4a56-8ceb-a5673aaba686"): {
 					Blueprint: &bp,
-					ImageBuild: ImageBuild{
+					ImageBuild: weldrtypes.ImageBuild{
 						ID:        0,
 						ImageType: testImageType,
 						Manifest:  []byte("JSON MANIFEST GOES HERE"),
@@ -1668,7 +1669,7 @@ func Test_newImageBuildFromV0(t *testing.T) {
 		name  string
 		arch  distro.Arch
 		ib    imageBuildV0
-		want  ImageBuild
+		want  weldrtypes.ImageBuild
 		errOk bool
 	}{
 		{
@@ -1676,7 +1677,7 @@ func Test_newImageBuildFromV0(t *testing.T) {
 			arch:  testArch,
 			errOk: true,
 			ib:    imageBuildV0{},
-			want:  ImageBuild{},
+			want:  weldrtypes.ImageBuild{},
 		},
 		{
 			name:  "qcow2 image build",
@@ -1710,7 +1711,7 @@ func Test_newImageBuildFromV0(t *testing.T) {
 				JobID:       uuid.MustParse("22445cd3-7fa5-4dca-b7f8-4f9857b3e3a0"),
 				QueueStatus: common.IBFinished,
 			},
-			want: ImageBuild{
+			want: weldrtypes.ImageBuild{
 				ID:        0,
 				ImageType: testImageType,
 				Manifest:  []byte("JSON MANIFEST GOES HERE"),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/osbuild/images/pkg/distrofactory"
 	"github.com/osbuild/images/pkg/manifest"
 	"github.com/osbuild/osbuild-composer/internal/jsondb"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 
 	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/pkg/rpmmd"
@@ -46,7 +47,7 @@ const StoreDBName = "state"
 type Store struct {
 	blueprints        map[string]blueprint.Blueprint
 	workspace         map[string]blueprint.Blueprint
-	composes          map[uuid.UUID]Compose
+	composes          map[uuid.UUID]weldrtypes.Compose
 	sources           map[string]SourceConfig
 	blueprintsChanges map[string]map[string]blueprint.Change
 	blueprintsCommits map[string][]string
@@ -342,7 +343,7 @@ func (s *Store) TagBlueprint(name string) error {
 	})
 }
 
-func (s *Store) GetCompose(id uuid.UUID) (Compose, bool) {
+func (s *Store) GetCompose(id uuid.UUID) (weldrtypes.Compose, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -352,11 +353,11 @@ func (s *Store) GetCompose(id uuid.UUID) (Compose, bool) {
 
 // GetAllComposes creates a deep copy of all composes present in this store
 // and returns them as a dictionary with compose UUIDs as keys
-func (s *Store) GetAllComposes() map[uuid.UUID]Compose {
+func (s *Store) GetAllComposes() map[uuid.UUID]weldrtypes.Compose {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	composes := make(map[uuid.UUID]Compose)
+	composes := make(map[uuid.UUID]weldrtypes.Compose)
 
 	for id, singleCompose := range s.composes {
 		newCompose := singleCompose.DeepCopy()
@@ -385,9 +386,9 @@ func (s *Store) PushCompose(composeID uuid.UUID,
 
 	// FIXME: handle or comment this possible error
 	_ = s.change(func() error {
-		s.composes[composeID] = Compose{
+		s.composes[composeID] = weldrtypes.Compose{
 			Blueprint: bp,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				Manifest:   manifest,
 				ImageType:  imageType,
 				Targets:    targets,
@@ -427,9 +428,9 @@ func (s *Store) PushTestCompose(composeID uuid.UUID,
 
 	// FIXME: handle or comment this possible error
 	_ = s.change(func() error {
-		s.composes[composeID] = Compose{
+		s.composes[composeID] = weldrtypes.Compose{
 			Blueprint: bp,
-			ImageBuild: ImageBuild{
+			ImageBuild: weldrtypes.ImageBuild{
 				QueueStatus: status,
 				Manifest:    manifest,
 				ImageType:   imageType,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -374,7 +374,7 @@ func (s *Store) PushCompose(composeID uuid.UUID,
 	size uint64,
 	targets []*target.Target,
 	jobId uuid.UUID,
-	packages []rpmmd.PackageSpec) error {
+	packages []weldrtypes.DepsolvedPackageInfo) error {
 
 	if _, exists := s.GetCompose(composeID); exists {
 		panic("a compose with this id already exists")
@@ -413,7 +413,7 @@ func (s *Store) PushTestCompose(composeID uuid.UUID,
 	size uint64,
 	targets []*target.Target,
 	testSuccess bool,
-	packages []rpmmd.PackageSpec) error {
+	packages []weldrtypes.DepsolvedPackageInfo) error {
 
 	if targets == nil {
 		targets = []*target.Target{}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 // struct for sharing state between tests
@@ -30,8 +31,8 @@ type storeTest struct {
 	myChange         []blueprint.Change
 	myTarget         *target.Target
 	mySources        map[string]osbuild.Source
-	myCompose        Compose
-	myImageBuild     ImageBuild
+	myCompose        weldrtypes.Compose
+	myImageBuild     weldrtypes.ImageBuild
 	mySourceConfig   SourceConfig
 	myDistro         distro.Distro
 	myArch           distro.Arch
@@ -76,12 +77,12 @@ func (suite *storeTest) SetupSuite() {
 			Release: "1.fc35",
 			Arch:    "x86_64",
 		}}
-	suite.myCompose = Compose{
+	suite.myCompose = weldrtypes.Compose{
 		Blueprint:  &suite.myBP,
 		ImageBuild: suite.myImageBuild,
 		Packages:   suite.myPackages,
 	}
-	suite.myImageBuild = ImageBuild{
+	suite.myImageBuild = weldrtypes.ImageBuild{
 		ID: 123,
 	}
 	suite.mySources = make(map[string]osbuild.Source)
@@ -349,7 +350,7 @@ func (suite *storeTest) TestPushTestCompose() {
 }
 
 func (suite *storeTest) TestGetAllComposes() {
-	suite.myStore.composes = make(map[uuid.UUID]Compose)
+	suite.myStore.composes = make(map[uuid.UUID]weldrtypes.Compose)
 	suite.myStore.composes[uuid.New()] = suite.myCompose
 	compose := suite.myStore.GetAllComposes()
 	suite.Equal(suite.myStore.composes, compose)
@@ -357,11 +358,11 @@ func (suite *storeTest) TestGetAllComposes() {
 
 func (suite *storeTest) TestDeleteCompose() {
 	ID := uuid.New()
-	suite.myStore.composes = make(map[uuid.UUID]Compose)
+	suite.myStore.composes = make(map[uuid.UUID]weldrtypes.Compose)
 	suite.myStore.composes[ID] = suite.myCompose
 	err := suite.myStore.DeleteCompose(ID)
 	suite.NoError(err)
-	suite.Equal(suite.myStore.composes, map[uuid.UUID]Compose{})
+	suite.Equal(suite.myStore.composes, map[uuid.UUID]weldrtypes.Compose{})
 	err = suite.myStore.DeleteCompose(ID)
 	suite.Error(err)
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -39,9 +39,9 @@ type storeTest struct {
 	myImageType      distro.ImageType
 	myManifest       manifest.OSBuildManifest
 	myRepoConfig     []rpmmd.RepoConfig
-	myPackageSpec    []rpmmd.PackageSpec
+	myPackageSpec    []weldrtypes.DepsolvedPackageInfo
 	myImageOptions   distro.ImageOptions
-	myPackages       []rpmmd.PackageSpec
+	myPackages       []weldrtypes.DepsolvedPackageInfo
 }
 
 // func to initialize some default values before the suite is ran
@@ -51,7 +51,7 @@ func (suite *storeTest) SetupSuite() {
 		Name:       "testRepo",
 		MirrorList: "testURL",
 	}}
-	suite.myPackageSpec = []rpmmd.PackageSpec{rpmmd.PackageSpec{}}
+	suite.myPackageSpec = []weldrtypes.DepsolvedPackageInfo{weldrtypes.DepsolvedPackageInfo{}}
 	suite.myDistro = test_distro.DistroFactory(test_distro.TestDistro1Name)
 	suite.NotNil(suite.myDistro)
 	suite.myArch, err = suite.myDistro.GetArch(test_distro.TestArchName)
@@ -63,7 +63,7 @@ func (suite *storeTest) SetupSuite() {
 	suite.mySourceConfig = SourceConfig{
 		Name: "testSourceConfig",
 	}
-	suite.myPackages = []rpmmd.PackageSpec{
+	suite.myPackages = []weldrtypes.DepsolvedPackageInfo{
 		{
 			Name:    "test1",
 			Epoch:   0,
@@ -315,10 +315,10 @@ func (suite *storeTest) TestDeleteBlueprintFromWorkspace() {
 
 func (suite *storeTest) TestPushCompose() {
 	testID := uuid.New()
-	err := suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, uuid.New(), []rpmmd.PackageSpec{})
+	err := suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, uuid.New(), []weldrtypes.DepsolvedPackageInfo{})
 	suite.NoError(err)
 	suite.Panics(func() {
-		err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, uuid.New(), []rpmmd.PackageSpec{})
+		err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, uuid.New(), []weldrtypes.DepsolvedPackageInfo{})
 	})
 	suite.NoError(err)
 
@@ -330,11 +330,11 @@ func (suite *storeTest) TestPushCompose() {
 
 func (suite *storeTest) TestPushTestCompose() {
 	ID := uuid.New()
-	err := suite.myStore.PushTestCompose(ID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, true, []rpmmd.PackageSpec{})
+	err := suite.myStore.PushTestCompose(ID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, true, []weldrtypes.DepsolvedPackageInfo{})
 	suite.NoError(err)
 	suite.Equal(common.ImageBuildState(2), suite.myStore.composes[ID].ImageBuild.QueueStatus)
 	ID = uuid.New()
-	err = suite.myStore.PushTestCompose(ID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, false, []rpmmd.PackageSpec{})
+	err = suite.myStore.PushTestCompose(ID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, false, []weldrtypes.DepsolvedPackageInfo{})
 	suite.NoError(err)
 	suite.Equal(common.ImageBuildState(3), suite.myStore.composes[ID].ImageBuild.QueueStatus)
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -1138,10 +1138,10 @@ func (api *API) projectsListHandler(writer http.ResponseWriter, request *http.Re
 	}
 
 	type reply struct {
-		Total    uint                `json:"total"`
-		Offset   uint                `json:"offset"`
-		Limit    uint                `json:"limit"`
-		Projects []rpmmd.PackageInfo `json:"projects"`
+		Total    uint          `json:"total"`
+		Offset   uint          `json:"offset"`
+		Limit    uint          `json:"limit"`
+		Projects []PackageInfo `json:"projects"`
 	}
 
 	offset, limit, err := parseOffsetAndLimit(request.URL.Query())
@@ -1181,13 +1181,13 @@ func (api *API) projectsListHandler(writer http.ResponseWriter, request *http.Re
 		return
 	}
 
-	packageInfos := availablePackages.ToPackageInfos()
+	packageInfos := RPMMDPackageListToPackageInfos(availablePackages)
 
 	total := uint(len(packageInfos))
 	start := min(offset, total)
 	n := min(limit, total-start)
 
-	packages := make([]rpmmd.PackageInfo, n)
+	packages := make([]PackageInfo, n)
 	for i := uint(0); i < n; i++ {
 		packages[i] = packageInfos[start+i]
 	}
@@ -1207,10 +1207,10 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 	}
 
 	type projectsReply struct {
-		Projects []rpmmd.PackageInfo `json:"projects"`
+		Projects []PackageInfo `json:"projects"`
 	}
 	type modulesReply struct {
-		Modules []rpmmd.PackageInfo `json:"modules"`
+		Modules []PackageInfo `json:"modules"`
 	}
 
 	// handle both projects/info and modules/info, the latter includes dependencies
@@ -1278,7 +1278,7 @@ func (api *API) modulesInfoHandler(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	packageInfos := foundPackages.ToPackageInfos()
+	packageInfos := RPMMDPackageListToPackageInfos(foundPackages)
 
 	if modulesRequested {
 		repos, err := api.allRepositories(distroName, archName)
@@ -1334,6 +1334,7 @@ func (api *API) projectsDepsolveHandler(writer http.ResponseWriter, request *htt
 	}
 
 	type reply struct {
+		// XXX: Projects should not be using rpmmd.PackageSpec for serialization
 		Projects []rpmmd.PackageSpec `json:"projects"`
 	}
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -47,6 +47,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/target"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
@@ -379,7 +380,7 @@ func composeStateFromJobStatus(js *worker.JobStatus, result *worker.OSBuildJobRe
 // Returns the state of the image in `compose` and the times the job was
 // queued, started, and finished. Assumes that there's only one image in the
 // compose.
-func (api *API) getComposeStatus(compose store.Compose) (*composeStatus, error) {
+func (api *API) getComposeStatus(compose weldrtypes.Compose) (*composeStatus, error) {
 	jobId := compose.ImageBuild.JobID
 
 	// backwards compatibility: composes that were around before splitting
@@ -425,7 +426,7 @@ func (api *API) getComposeStatus(compose store.Compose) (*composeStatus, error) 
 // Opens the image file for `compose`. This asks the worker server for the
 // artifact first, and then falls back to looking in
 // `{outputs}/{composeId}/{imageBuildId}` for backwards compatibility.
-func (api *API) openImageFile(composeId uuid.UUID, compose store.Compose) (io.Reader, int64, error) {
+func (api *API) openImageFile(composeId uuid.UUID, compose weldrtypes.Compose) (io.Reader, int64, error) {
 	name := compose.ImageBuild.ImageType.Filename()
 
 	reader, size, err := api.workers.JobArtifact(compose.ImageBuild.JobID, name)

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/store"
 	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/test"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
@@ -1044,7 +1045,7 @@ func TestCompose(t *testing.T) {
 	omf, err := ostreeManifest.Serialize(rPkgs, rContainers, rCommits, nil)
 	require.NoError(t, err)
 
-	expectedComposeLocal := &store.Compose{
+	expectedComposeLocal := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -1054,7 +1055,7 @@ func TestCompose(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   imgType,
 			Size:        imgType.Size(0),
@@ -1074,7 +1075,7 @@ func TestCompose(t *testing.T) {
 		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
 	}
 
-	expectedComposeLocalAndAws := &store.Compose{
+	expectedComposeLocalAndAws := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -1084,7 +1085,7 @@ func TestCompose(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   imgType,
 			Size:        imgType.Size(0),
@@ -1121,7 +1122,7 @@ func TestCompose(t *testing.T) {
 		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
 	}
 
-	expectedComposeOSTree := &store.Compose{
+	expectedComposeOSTree := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -1131,7 +1132,7 @@ func TestCompose(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   ostreeImgType,
 			Size:        ostreeImgType.Size(0),
@@ -1159,7 +1160,7 @@ func TestCompose(t *testing.T) {
 
 	omfo, err := ostreeManifest.Serialize(rPkgs, rContainers, rCommits, nil)
 	require.NoError(t, err)
-	expectedComposeOSTreeOther := &store.Compose{
+	expectedComposeOSTreeOther := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -1169,7 +1170,7 @@ func TestCompose(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   ostreeImgType,
 			Size:        ostreeImgType.Size(0),
@@ -1203,7 +1204,7 @@ func TestCompose(t *testing.T) {
 	mf2, err := manifest2.Serialize(rPkgs, rContainers, rCommits, nil)
 	require.NoError(t, err)
 
-	expectedComposeGoodDistro := &store.Compose{
+	expectedComposeGoodDistro := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test-distro-2",
 			Version:        "0.0.0",
@@ -1214,7 +1215,7 @@ func TestCompose(t *testing.T) {
 			Customizations: nil,
 			Distro:         testDistro2Name,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   imgType2,
 			Size:        imgType2.Size(0),
@@ -1243,7 +1244,7 @@ func TestCompose(t *testing.T) {
 		Body            string
 		ExpectedStatus  int
 		ExpectedJSON    string
-		ExpectedCompose *store.Compose
+		ExpectedCompose *weldrtypes.Compose
 		IgnoreFields    []string
 		GetSolverFn     GetSolverFn
 	}{
@@ -1457,7 +1458,7 @@ func TestCompose(t *testing.T) {
 			require.Equalf(t, 1, len(composes), "%s: %s: bad compose count in store", name, c.Path)
 
 			// I have no idea how to get the compose in better way
-			var composeStruct store.Compose
+			var composeStruct weldrtypes.Compose
 			for _, c := range composes {
 				composeStruct = c
 				break
@@ -2516,7 +2517,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 	mf, err := manifest.Serialize(rPkgs, rContainers, rCommits, nil)
 	require.NoError(t, err)
 
-	expectedComposeLocal := &store.Compose{
+	expectedComposeLocal := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -2526,7 +2527,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   imgType,
 			Size:        imgType.Size(0),
@@ -2546,7 +2547,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
 	}
 
-	expectedComposeLocal2 := &store.Compose{
+	expectedComposeLocal2 := &weldrtypes.Compose{
 		Blueprint: &blueprint.Blueprint{
 			Name:           "test",
 			Version:        "0.0.0",
@@ -2556,7 +2557,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 			Groups:         []blueprint.Group{},
 			Customizations: nil,
 		},
-		ImageBuild: store.ImageBuild{
+		ImageBuild: weldrtypes.ImageBuild{
 			QueueStatus: common.IBWaiting,
 			ImageType:   imgType2,
 			Size:        imgType2.Size(0),
@@ -2582,7 +2583,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 		imageTypeDenylist map[string][]string
 		ExpectedStatus    int
 		ExpectedJSON      string
-		ExpectedCompose   *store.Compose
+		ExpectedCompose   *weldrtypes.Compose
 		IgnoreFields      []string
 		GetSolverFn       GetSolverFn
 	}{
@@ -2710,7 +2711,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 			composes := sf.Store.GetAllComposes()
 			require.Equalf(t, 1, len(composes), "%s: bad compose count in store", c.Path)
 
-			var composeStruct store.Compose
+			var composeStruct weldrtypes.Compose
 			for _, c := range composes {
 				composeStruct = c
 				break

--- a/internal/weldr/api_test.go
+++ b/internal/weldr/api_test.go
@@ -1072,7 +1072,7 @@ func TestCompose(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	expectedComposeLocalAndAws := &weldrtypes.Compose{
@@ -1119,7 +1119,7 @@ func TestCompose(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	expectedComposeOSTree := &weldrtypes.Compose{
@@ -1149,7 +1149,7 @@ func TestCompose(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	ostreeOptionsOther := ostree.ImageOptions{ImageRef: otherRef, URL: ostreeRepoOther.Server.URL}
@@ -1187,7 +1187,7 @@ func TestCompose(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	// For 2nd distribution
@@ -1232,7 +1232,7 @@ func TestCompose(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID2),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID2)),
 	}
 
 	getSolverFn := getBaseMockDepsolveDNFSolverFn(testRepoID)
@@ -2544,7 +2544,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	expectedComposeLocal2 := &weldrtypes.Compose{
@@ -2574,7 +2574,7 @@ func TestComposePOST_ImageTypeDenylist(t *testing.T) {
 				},
 			},
 		},
-		Packages: depsolvednf_mock.BaseDepsolveResult(testRepoID),
+		Packages: weldrtypes.RPMMDPackageSpecListToDepsolvedPackageInfoList(depsolvednf_mock.BaseDepsolveResult(testRepoID)),
 	}
 
 	var cases = []struct {

--- a/internal/weldr/compose.go
+++ b/internal/weldr/compose.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/osbuild/osbuild-composer/internal/common"
-	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 type ComposeEntry struct {
@@ -22,7 +22,7 @@ type ComposeEntry struct {
 	Uploads     []uploadResponse       `json:"uploads,omitempty"`
 }
 
-func composeToComposeEntry(id uuid.UUID, compose store.Compose, status *composeStatus, includeUploads bool) *ComposeEntry {
+func composeToComposeEntry(id uuid.UUID, compose weldrtypes.Compose, status *composeStatus, includeUploads bool) *ComposeEntry {
 	var composeEntry ComposeEntry
 
 	composeEntry.ID = id

--- a/internal/weldr/json.go
+++ b/internal/weldr/json.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/store"
+	"github.com/osbuild/osbuild-composer/internal/weldrtypes"
 )
 
 // StatusV0 is the response to /api/status from a v0+ server
@@ -274,14 +275,13 @@ type PackageBuild struct {
 }
 
 type PackageInfo struct {
-	Name        string         `json:"name"`
-	Summary     string         `json:"summary"`
-	Description string         `json:"description"`
-	Homepage    string         `json:"homepage"`
-	UpstreamVCS string         `json:"upstream_vcs"`
-	Builds      []PackageBuild `json:"builds"`
-	// XXX: Dependencies should not be using rpmmd.PackageSpec for serialization
-	Dependencies []rpmmd.PackageSpec `json:"dependencies,omitempty"`
+	Name         string                            `json:"name"`
+	Summary      string                            `json:"summary"`
+	Description  string                            `json:"description"`
+	Homepage     string                            `json:"homepage"`
+	UpstreamVCS  string                            `json:"upstream_vcs"`
+	Builds       []PackageBuild                    `json:"builds"`
+	Dependencies []weldrtypes.DepsolvedPackageInfo `json:"dependencies,omitempty"`
 }
 
 func RPMMDPackageToPackageBuild(pkg rpmmd.Package) PackageBuild {
@@ -351,8 +351,7 @@ type ProjectsInfoV0 struct {
 
 // ProjectsDependenciesV0 is the response to /projects/depsolve request
 type ProjectsDependenciesV0 struct {
-	// XXX: Projects should not be using rpmmd.PackageSpec for serialization
-	Projects []rpmmd.PackageSpec `json:"projects"`
+	Projects []weldrtypes.DepsolvedPackageInfo `json:"projects"`
 }
 
 type ModuleName struct {
@@ -436,7 +435,7 @@ type ComposeInfoResponseV0 struct {
 	Blueprint *blueprint.Blueprint `json:"blueprint"` // blueprint not frozen!
 	Commit    string               `json:"commit"`    // empty for now
 	Deps      struct {
-		Packages []rpmmd.Package `json:"packages"`
+		Packages []weldrtypes.DepsolvedPackageInfo `json:"packages"`
 	} `json:"deps"`
 	ComposeType string           `json:"compose_type"`
 	QueueStatus string           `json:"queue_status"`

--- a/internal/weldrtypes/compose.go
+++ b/internal/weldrtypes/compose.go
@@ -2,7 +2,6 @@ package weldrtypes
 
 import (
 	"github.com/osbuild/blueprint/pkg/blueprint"
-	"github.com/osbuild/images/pkg/rpmmd"
 )
 
 // A Compose represent the task of building a set of images from a single blueprint.
@@ -11,7 +10,7 @@ import (
 type Compose struct {
 	Blueprint  *blueprint.Blueprint
 	ImageBuild ImageBuild
-	Packages   []rpmmd.PackageSpec
+	Packages   []DepsolvedPackageInfo
 }
 
 // DeepCopy creates a copy of the Compose structure
@@ -21,7 +20,7 @@ func (c *Compose) DeepCopy() Compose {
 		bpCopy := *c.Blueprint
 		newBpPtr = &bpCopy
 	}
-	pkgs := make([]rpmmd.PackageSpec, len(c.Packages))
+	pkgs := make([]DepsolvedPackageInfo, len(c.Packages))
 	copy(pkgs, c.Packages)
 
 	return Compose{

--- a/internal/weldrtypes/compose.go
+++ b/internal/weldrtypes/compose.go
@@ -1,0 +1,32 @@
+package weldrtypes
+
+import (
+	"github.com/osbuild/blueprint/pkg/blueprint"
+	"github.com/osbuild/images/pkg/rpmmd"
+)
+
+// A Compose represent the task of building a set of images from a single blueprint.
+// It contains all the information necessary to generate the inputs for the job, as
+// well as the job's state.
+type Compose struct {
+	Blueprint  *blueprint.Blueprint
+	ImageBuild ImageBuild
+	Packages   []rpmmd.PackageSpec
+}
+
+// DeepCopy creates a copy of the Compose structure
+func (c *Compose) DeepCopy() Compose {
+	var newBpPtr *blueprint.Blueprint = nil
+	if c.Blueprint != nil {
+		bpCopy := *c.Blueprint
+		newBpPtr = &bpCopy
+	}
+	pkgs := make([]rpmmd.PackageSpec, len(c.Packages))
+	copy(pkgs, c.Packages)
+
+	return Compose{
+		Blueprint:  newBpPtr,
+		ImageBuild: c.ImageBuild.DeepCopy(),
+		Packages:   pkgs,
+	}
+}

--- a/internal/weldrtypes/imagebuild.go
+++ b/internal/weldrtypes/imagebuild.go
@@ -1,13 +1,11 @@
-package store
+package weldrtypes
 
 import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/osbuild/blueprint/pkg/blueprint"
 	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
-	"github.com/osbuild/images/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/target"
 )
@@ -48,31 +46,5 @@ func (ib *ImageBuild) DeepCopy() ImageBuild {
 		JobFinished: ib.JobFinished,
 		Size:        ib.Size,
 		JobID:       ib.JobID,
-	}
-}
-
-// A Compose represent the task of building a set of images from a single blueprint.
-// It contains all the information necessary to generate the inputs for the job, as
-// well as the job's state.
-type Compose struct {
-	Blueprint  *blueprint.Blueprint
-	ImageBuild ImageBuild
-	Packages   []rpmmd.PackageSpec
-}
-
-// DeepCopy creates a copy of the Compose structure
-func (c *Compose) DeepCopy() Compose {
-	var newBpPtr *blueprint.Blueprint = nil
-	if c.Blueprint != nil {
-		bpCopy := *c.Blueprint
-		newBpPtr = &bpCopy
-	}
-	pkgs := make([]rpmmd.PackageSpec, len(c.Packages))
-	copy(pkgs, c.Packages)
-
-	return Compose{
-		Blueprint:  newBpPtr,
-		ImageBuild: c.ImageBuild.DeepCopy(),
-		Packages:   pkgs,
 	}
 }

--- a/internal/weldrtypes/package.go
+++ b/internal/weldrtypes/package.go
@@ -1,0 +1,50 @@
+package weldrtypes
+
+import "github.com/osbuild/images/pkg/rpmmd"
+
+// DepsolvedPackageInfo is the API representation of a package that has been depsolved.
+type DepsolvedPackageInfo struct {
+	Name           string `json:"name"`
+	Epoch          uint   `json:"epoch"`
+	Version        string `json:"version,omitempty"`
+	Release        string `json:"release,omitempty"`
+	Arch           string `json:"arch,omitempty"`
+	RemoteLocation string `json:"remote_location,omitempty"`
+	Checksum       string `json:"checksum,omitempty"`
+
+	// NB: the fields below are most probably useless for the purpose of this structure.
+	// Most of them are omitted when not set or set to default values.
+	// Path is useless without the base URL.
+	// RepoID is useless because it is a hash of multiple values of the repository used
+	// for depsolving, thus it is not useful to the end user.
+	Secrets   string `json:"secrets,omitempty"`
+	CheckGPG  bool   `json:"check_gpg,omitempty"`
+	IgnoreSSL bool   `json:"ignore_ssl,omitempty"`
+	Path      string `json:"path,omitempty"`
+	RepoID    string `json:"repo_id,omitempty"`
+}
+
+func RPMMDPackageSpecToDepsolvedPackageInfo(pkg rpmmd.PackageSpec) DepsolvedPackageInfo {
+	return DepsolvedPackageInfo{
+		Name:           pkg.Name,
+		Epoch:          pkg.Epoch,
+		Version:        pkg.Version,
+		Release:        pkg.Release,
+		Arch:           pkg.Arch,
+		RemoteLocation: pkg.RemoteLocation,
+		Checksum:       pkg.Checksum,
+		Secrets:        pkg.Secrets,
+		CheckGPG:       pkg.CheckGPG,
+		IgnoreSSL:      pkg.IgnoreSSL,
+		Path:           pkg.Path,
+		RepoID:         pkg.RepoID,
+	}
+}
+
+func RPMMDPackageSpecListToDepsolvedPackageInfoList(pkgs []rpmmd.PackageSpec) []DepsolvedPackageInfo {
+	results := make([]DepsolvedPackageInfo, len(pkgs))
+	for i, pkg := range pkgs {
+		results[i] = RPMMDPackageSpecToDepsolvedPackageInfo(pkg)
+	}
+	return results
+}


### PR DESCRIPTION
Weldr API endpoints and the JSON store, used only by Weldr API, directly use `rpmmd` data structures representing packages for serialization. This means that any changes to the data structures in `osbuild/images` affect Weldr API endpoint responses and the store. This PR decouples Weldr API endpoints and store from `rpmmd` structures.

Note that the `rpmmd.RepoConfig` is still used for serialization. It may make sense to decouple it in the future as well, but I omitted it at this point because it does not block the refactoring I plan to do in `osbuild/images` as part of the SBOM rearchitecture.

/jira-epic HMS-8910

JIRA: [HMS-9376](https://issues.redhat.com/browse/HMS-9376)