### PR TITLE
cloudapi/v2: recover from panics in serializeManifest (HMS-9379)

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -464,6 +464,11 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 	logWithId := logrus.WithField("jobId", manifestJobID)
 
 	defer func() {
+		if r := recover(); r != nil {
+			logWithId.Errorf("Recovered from panic in serializeManifest: %v", r)
+			jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, "Error serializing manifest", r)
+		}
+
 		// token == uuid.Nil indicates that no worker even started processing
 		if token == uuid.Nil {
 			if jobResult.JobError != nil {


### PR DESCRIPTION
Certain code paths result in a panic from images. While this should be avoided in images, let's make the manifest generation job slightly more robust by recovering from these panics. Currently these panics crash the container and force a restart, this could impact other manifest jobs on the same pod.