### PR TITLE
worker/executor: drop cloudwatch logging from executor (HMS-9304)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,6 @@ build: $(BUILDDIR)/bin/ build-maintenance
 	go build -o $<osbuild-composer ./cmd/osbuild-composer/
 	go build -o $<osbuild-worker ./cmd/osbuild-worker/
 	go build -o $<osbuild-worker-executor ./cmd/osbuild-worker-executor/
-	go build -o $<osbuild-upload-azure ./cmd/osbuild-upload-azure/
-	go build -o $<osbuild-upload-aws ./cmd/osbuild-upload-aws/
-	go build -o $<osbuild-upload-gcp ./cmd/osbuild-upload-gcp/
-	go build -o $<osbuild-upload-oci ./cmd/osbuild-upload-oci/
-	go build -o $<osbuild-upload-generic-s3 ./cmd/osbuild-upload-generic-s3/
 	go build -o $<osbuild-mock-openid-provider ./cmd/osbuild-mock-openid-provider
 	# also build the test binaries
 	go test -c -tags=integration -o $<osbuild-composer-cli-tests ./cmd/osbuild-composer-cli-tests/main_test.go

--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -68,10 +68,9 @@ type containersConfig struct {
 }
 
 type executorConfig struct {
-	Type            string `toml:"type"`
-	IAMProfile      string `toml:"iam_profile"`
-	KeyName         string `toml:"key_name"`
-	CloudWatchGroup string `toml:"cloudwatch_group"`
+	Type       string `toml:"type"`
+	IAMProfile string `toml:"iam_profile"`
+	KeyName    string `toml:"key_name"`
 }
 
 type repositoryMTLSConfig struct {

--- a/cmd/osbuild-worker/config_test.go
+++ b/cmd/osbuild-worker/config_test.go
@@ -70,16 +70,14 @@ offline_token = "/etc/osbuild-worker/offline_token"
 type = "aws.ec2"
 iam_profile = "osbuild-worker"
 key_name = "osbuild-worker"
-cloudwatch_group = "osbuild-worker"
 `,
 			want: &workerConfig{
 				BasePath: "/api/image-builder-worker/v1",
 				DNFJson:  "/usr/libexec/osbuild-depsolve-dnf",
 				OSBuildExecutor: &executorConfig{
-					Type:            "aws.ec2",
-					IAMProfile:      "osbuild-worker",
-					KeyName:         "osbuild-worker",
-					CloudWatchGroup: "osbuild-worker",
+					Type:       "aws.ec2",
+					IAMProfile: "osbuild-worker",
+					KeyName:    "osbuild-worker",
 				},
 				Composer: &composerConfig{
 					Proxy: "http://proxy.example.com",

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -79,10 +79,9 @@ type PulpConfiguration struct {
 }
 
 type ExecutorConfiguration struct {
-	Type            string
-	IAMProfile      string
-	KeyName         string
-	CloudWatchGroup string
+	Type       string
+	IAMProfile string
+	KeyName    string
 }
 
 type OSBuildJobImpl struct {
@@ -513,7 +512,7 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 			return err
 		}
 		defer os.RemoveAll(tmpDir)
-		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName, impl.OSBuildExecutor.CloudWatchGroup, job.Id().String(), tmpDir)
+		executor = osbuildexecutor.NewAWSEC2Executor(impl.OSBuildExecutor.IAMProfile, impl.OSBuildExecutor.KeyName, job.Id().String(), tmpDir)
 	default:
 		osbuildJobResult.JobError = clienterrors.New(clienterrors.ErrorInvalidConfig, "No osbuild executor defined", nil)
 		return err

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -470,10 +470,9 @@ var run = func() {
 			Store:  store,
 			Output: output,
 			OSBuildExecutor: ExecutorConfiguration{
-				Type:            config.OSBuildExecutor.Type,
-				IAMProfile:      config.OSBuildExecutor.IAMProfile,
-				KeyName:         config.OSBuildExecutor.KeyName,
-				CloudWatchGroup: config.OSBuildExecutor.CloudWatchGroup,
+				Type:       config.OSBuildExecutor.Type,
+				IAMProfile: config.OSBuildExecutor.IAMProfile,
+				KeyName:    config.OSBuildExecutor.KeyName,
 			},
 			KojiServers: kojiServers,
 			GCPConfig:   gcpConfig,

--- a/internal/osbuildexecutor/runner-impl-aws-ec2.go
+++ b/internal/osbuildexecutor/runner-impl-aws-ec2.go
@@ -22,11 +22,10 @@ import (
 )
 
 type awsEC2Executor struct {
-	iamProfile      string
-	keyName         string
-	cloudWatchGroup string
-	hostname        string
-	tmpDir          string
+	iamProfile string
+	keyName    string
+	hostname   string
+	tmpDir     string
 }
 
 func prepareSources(manifest []byte, store string, extraEnv []string, result bool, errorWriter io.Writer) error {
@@ -269,7 +268,7 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 		return nil, fmt.Errorf("Failed to get default aws client in %s region: %w", region, err)
 	}
 
-	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName, ec2e.cloudWatchGroup, ec2e.hostname)
+	si, err := aws.RunSecureInstance(ec2e.iamProfile, ec2e.keyName, ec2e.hostname)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start secure instance: %w", err)
 	}
@@ -318,11 +317,10 @@ func (ec2e *awsEC2Executor) RunOSBuild(manifest []byte, opts *OsbuildOpts, error
 	return osbuildResult, nil
 }
 
-func NewAWSEC2Executor(iamProfile, keyName, cloudWatchGroup, hostname, tmpDir string) Executor {
+func NewAWSEC2Executor(iamProfile, keyName, hostname, tmpDir string) Executor {
 	return &awsEC2Executor{
 		iamProfile,
 		keyName,
-		cloudWatchGroup,
 		hostname,
 		tmpDir,
 	}

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/vector.sh
@@ -7,6 +7,7 @@ echo "Writing vector config."
 ID_DOC=$(curl -Ls http://169.254.169.254/latest/dynamic/instance-identity/document)
 REGION=$(echo "$ID_DOC" | jq -r .region)
 PRIVATE_IP=$(echo "$ID_DOC" | jq -r .privateIp)
+OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-osbuild-executor-log-group}
 
 sudo mkdir -p /etc/vector
 sudo tee /etc/vector/vector.yaml > /dev/null << EOF
@@ -35,7 +36,7 @@ sinks:
       - executor
     region: ${REGION}
     endpoint: ${CLOUDWATCH_LOGS_ENDPOINT_URL}
-    group_name: ${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-osbuild-executor-log-group}
+    group_name: ${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}
     stream_name: executor_syslog__{{ host }}
     encoding:
       codec: json

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_config.sh
@@ -5,13 +5,7 @@ source /tmp/cloud_init_vars
 
 echo "Writing osbuild_executor config to worker configuration."
 OSBUILD_EXECUTOR_IAM_PROFILE=${OSBUILD_EXECUTOR_IAM_PROFILE:-osbuild-executor}
-OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-}
 OSBUILD_EXECUTOR_TYPE=${OSBUILD_EXECUTOR_TYPE:-aws.ec2}
-
-CLOUDWATCH_GROUP_CONFIG=""
-if [ -n "${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}" ]; then
-    CLOUDWATCH_GROUP_CONFIG="cloudwatch_group = \"${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}\""
-fi
 
 sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null << EOF
 [osbuild_executor]

--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/worker_executor.sh
@@ -6,43 +6,25 @@ source /etc/os-release
 source /tmp/cloud_init_vars || true
 
 echo "Writing vector config."
-REGION=$(curl -Ls http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
-HOSTNAME=$(hostname)
-CLOUDWATCH_ENDPOINT="https://logs.$REGION.amazonaws.com"
-OSBUILD_EXECUTOR_CLOUDWATCH_GROUP=${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP:-osbuild-executor-log-group}
 HOST_WORKER_ADDRESS=${HOST_WORKER_ADDRESS:-127.0.0.1}
 
-sudo mkdir -p /etc/vector
-sudo tee /etc/vector/vector.yaml > /dev/null << EOF
+if [ "$HOST_WORKER_ADDRESS" != "127.0.0.1" ]; then
+    sudo mkdir -p /etc/vector
+    sudo tee /etc/vector/vector.yaml > /dev/null << EOF
 sources:
   journald:
     type: journald
     exclude_units:
       - vector.service
 sinks:
-  cloudwatch:
-    type: aws_cloudwatch_logs
-    inputs:
-      - journald
-    region: ${REGION}
-    endpoint: ${CLOUDWATCH_ENDPOINT}
-    group_name: ${OSBUILD_EXECUTOR_CLOUDWATCH_GROUP}
-    stream_name: worker_syslog_{{ host }}
-    encoding:
-      codec: json
-EOF
-
-if [ "$HOST_WORKER_ADDRESS" != "127.0.0.1" ]; then
-    sudo tee -a /etc/vector/vector.yaml > /dev/null <<EOF
   host_worker:
     type: vector
     inputs:
       - journald
     address: ${HOST_WORKER_ADDRESS}:12005
 EOF
-fi
-
 sudo systemctl enable --now vector
+fi
 
 echo "Starting worker executor"
 /usr/libexec/osbuild-composer/osbuild-worker-executor -host 0.0.0.0


### PR DESCRIPTION
This drops cloudwatch logging from the executor:
```
    worker: remove cloudwatch group option from aws.ec2 executor
    
    Logs should be forwarded from the executor to the worker.
    
    This facilitates isolating the executor from the internet. Cloudwatch
    doesn't have a well-defined IP range, so it's tricky to update the
    executor's security group in such a way to allow only cloudwatch
    traffic. By forwarding any log traffic from the executor via the worker,
    this problem is eliminated.
    
    Note that this just prepares for the needed security group changes which
    would isolate the executor from the internet.
```

See  #4858.