### PR TITLE
go.mod: update osbuild/images to v0.198.0 (HMS-9444)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/openshift-online/ocm-sdk-go v0.1.477
 	github.com/osbuild/blueprint v1.13.0
-	github.com/osbuild/images v0.197.0
+	github.com/osbuild/images v0.198.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/ksuid v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXch
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/osbuild/blueprint v1.13.0 h1:blo22+S2ZX5bBmjGcRveoTUrV4Ms7kLfKyb32WyuymA=
 github.com/osbuild/blueprint v1.13.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.197.0 h1:JSwivw9X2HLgGPq1NG407FrSbyNlfwdACwI0g6kUkjY=
-github.com/osbuild/images v0.197.0/go.mod h1:xkXfw5CIy0bVNTNdB6GXiewu/IzBgpofkItDJPAzGA4=
+github.com/osbuild/images v0.198.0 h1:ssr2AtYu3LWpymWXPgyI6KXVRBZ9C0xW8vG+TJUGxqI=
+github.com/osbuild/images v0.198.0/go.mod h1:xkXfw5CIy0bVNTNdB6GXiewu/IzBgpofkItDJPAzGA4=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=

--- a/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
+++ b/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
@@ -154,6 +154,8 @@ distros:
       # mount util
       x86_64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
       aarch64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      s390x: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      ppc64le: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
 
   - <<: *centos10
     name: "almalinux_kitten-10"
@@ -254,6 +256,8 @@ distros:
       # mount util
       x86_64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
       aarch64: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      s390x: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
+      ppc64le: "quay.io/toolbx-images/centos-toolbox:stream{{.MajorVersion}}"
 
   - &rhel8
     name: "rhel-{{.MajorVersion}}.{{.MinorVersion}}"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -961,7 +961,7 @@ github.com/oracle/oci-go-sdk/v54/workrequests
 ## explicit; go 1.23.9
 github.com/osbuild/blueprint/internal/common
 github.com/osbuild/blueprint/pkg/blueprint
-# github.com/osbuild/images v0.197.0
+# github.com/osbuild/images v0.198.0
 ## explicit; go 1.23.9
 github.com/osbuild/images/data/dependencies
 github.com/osbuild/images/data/distrodefs


### PR DESCRIPTION
tag v0.198.0
Tagger: imagebuilder-bot <imagebuilder-bots+imagebuilder-bot@redhat.com>

Changes with 0.198.0

----------------
  - defs/centos: cross-arch for s390x, ppc64le (osbuild/images#1905)
    - Author: Simon de Vlieger, Reviewers: Achilleas Koutsou, Michael Vogt
  - distro: turn all errors from distro.ValidateConfig() into warnings (osbuild/images#1904)
    - Author: Achilleas Koutsou, Reviewers: Michael Vogt, Sanne Raymaekers, Simon de Vlieger
  - test/configs: add jq to all test configs that require it (osbuild/images#1899)
    - Author: Achilleas Koutsou, Reviewers: Lukáš Zapletal, Simon de Vlieger

— Somewhere on the Internet, 2025-09-29

---