### PR TITLE
executor: remove internet access entirely (HMS-9304)

### DIFF
--- a/internal/cloud/awscloud/client-interfaces.go
+++ b/internal/cloud/awscloud/client-interfaces.go
@@ -10,10 +10,13 @@ import (
 
 type EC2 interface {
 	// Security Groups
+	AuthorizeSecurityGroupEgress(context.Context, *ec2.AuthorizeSecurityGroupEgressInput, ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
 	AuthorizeSecurityGroupIngress(context.Context, *ec2.AuthorizeSecurityGroupIngressInput, ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
 	CreateSecurityGroup(context.Context, *ec2.CreateSecurityGroupInput, ...func(*ec2.Options)) (*ec2.CreateSecurityGroupOutput, error)
 	DeleteSecurityGroup(context.Context, *ec2.DeleteSecurityGroupInput, ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error)
 	DescribeSecurityGroups(context.Context, *ec2.DescribeSecurityGroupsInput, ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+	DescribeSecurityGroupRules(context.Context, *ec2.DescribeSecurityGroupRulesInput, ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupRulesOutput, error)
+	RevokeSecurityGroupEgress(context.Context, *ec2.RevokeSecurityGroupEgressInput, ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error)
 
 	// Subnets
 	CreateSubnet(context.Context, *ec2.CreateSubnetInput, ...func(*ec2.Options)) (*ec2.CreateSubnetOutput, error)

--- a/internal/cloud/awscloud/mocks_test.go
+++ b/internal/cloud/awscloud/mocks_test.go
@@ -49,6 +49,13 @@ func newEc2Mock(t *testing.T) *ec2mock {
 	}
 }
 
+func (m *ec2mock) AuthorizeSecurityGroupEgress(ctx context.Context, input *ec2.AuthorizeSecurityGroupEgressInput, optfns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	m.calledFn["AuthorizeSecurityGroupEgress"] += 1
+	return &ec2.AuthorizeSecurityGroupEgressOutput{
+		Return: aws.Bool(true),
+	}, nil
+}
+
 func (m *ec2mock) AuthorizeSecurityGroupIngress(ctx context.Context, input *ec2.AuthorizeSecurityGroupIngressInput, optfns ...func(*ec2.Options)) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	m.calledFn["AuthorizeSecurityGroupIngress"] += 1
 	return &ec2.AuthorizeSecurityGroupIngressOutput{
@@ -87,6 +94,25 @@ func (m *ec2mock) DescribeSecurityGroups(ctx context.Context, input *ec2.Describ
 				},
 			},
 		},
+	}, nil
+}
+
+func (m *ec2mock) DescribeSecurityGroupRules(ctx context.Context, input *ec2.DescribeSecurityGroupRulesInput, optfns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupRulesOutput, error) {
+	m.calledFn["DescribeSecurityGroupRules"] += 1
+	return &ec2.DescribeSecurityGroupRulesOutput{
+		SecurityGroupRules: []ec2types.SecurityGroupRule{
+			{
+				IsEgress:            aws.Bool(true),
+				SecurityGroupRuleId: aws.String("sgr-id"),
+			},
+		},
+	}, nil
+}
+
+func (m *ec2mock) RevokeSecurityGroupEgress(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput, optfns ...func(*ec2.Options)) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	m.calledFn["RevokeSecurityGroupEgress"] += 1
+	return &ec2.RevokeSecurityGroupEgressOutput{
+		Return: aws.Bool(true),
 	}, nil
 }
 

--- a/internal/cloud/awscloud/secure-instance_test.go
+++ b/internal/cloud/awscloud/secure-instance_test.go
@@ -71,6 +71,9 @@ func TestSIRunSecureInstance(t *testing.T) {
 	require.Equal(t, 1, m.calledFn["CreateFleet"])
 	require.Equal(t, 1, m.calledFn["CreateSecurityGroup"])
 	require.Equal(t, 1, m.calledFn["CreateLaunchTemplate"])
+	require.Equal(t, 1, m.calledFn["AuthorizeSecurityGroupEgress"])
+	require.Equal(t, 1, m.calledFn["AuthorizeSecurityGroupIngress"])
+	require.Equal(t, 1, m.calledFn["RevokeSecurityGroupEgress"])
 }
 
 func TestSITerminateSecureInstance(t *testing.T) {


### PR DESCRIPTION
   cloud/awscloud: revoke internet access from executor
    
    After the vector forwarding (#4858), it should be safe to remove
    internet access from executors again.
    
    By default security groups are created with internet access (egress to
    0.0.0.0/0) being allowed. First remove all egress rules in the
    executor's security group, then add a rule which allows egress to the
    worker host