### PR TITLE
CloudAPI: fix `/compose/{id}/manifests` endpoint behavior on manifest generation errors (HMS-9501)

### DIFF
--- a/internal/cloudapi/v2/export_test.go
+++ b/internal/cloudapi/v2/export_test.go
@@ -1,0 +1,18 @@
+package v2
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/osbuild/images/pkg/manifest"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+)
+
+// OverrideSerializeManifestFunc overrides the serializeManifestFunc for testing
+func OverrideSerializeManifestFunc(f func(ctx context.Context, manifestSource *manifest.Manifest, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID uuid.UUID, seed int64)) func() {
+	originalSerializeManifestFunc := serializeManifestFunc
+	serializeManifestFunc = f
+	return func() {
+		serializeManifestFunc = originalSerializeManifestFunc
+	}
+}

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -878,6 +878,9 @@ func (h *apiHandlers) getComposeManifestsImpl(ctx echo.Context, jobId uuid.UUID)
 					if err != nil {
 						return HTTPErrorWithInternal(ErrorComposeNotFound, fmt.Errorf("job %q: %v", jobId, err))
 					}
+					if manifestResult.JobError != nil {
+						return HTTPErrorWithInternal(ErrorFailedToMakeManifest, fmt.Errorf("job %q: %v", jobId, manifestResult.JobError))
+					}
 					mf = manifestResult.Manifest
 				}
 
@@ -906,6 +909,9 @@ func (h *apiHandlers) getComposeManifestsImpl(ctx echo.Context, jobId uuid.UUID)
 			_, manifestResult, err := manifestJobResultsFromJobDeps(h.server.workers, buildInfo.Deps)
 			if err != nil {
 				return HTTPErrorWithInternal(ErrorComposeNotFound, fmt.Errorf("job %q: %v", jobId, err))
+			}
+			if manifestResult.JobError != nil {
+				return HTTPErrorWithInternal(ErrorFailedToMakeManifest, fmt.Errorf("job %q: %v", jobId, manifestResult.JobError))
 			}
 			mf = manifestResult.Manifest
 		}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -694,7 +694,7 @@ func serializeManifest(ctx context.Context, manifestSource *manifest.Manifest, w
 	ms, err := manifestSource.Serialize(depsolveResultsInTheRightFormat, containerSpecs, ostreeCommitSpecs, nil)
 	if err != nil {
 		reason := "Error serializing manifest"
-		jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, reason, nil)
+		jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, reason, err.Error())
 		return
 	}
 

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -40,6 +40,10 @@ import (
 // How long to wait for a depsolve job to finish
 const depsolveTimeoutMin = 5
 
+// serializeManifestFunc is used to serialize the manifest
+// it can be overridden for testing
+var serializeManifestFunc = serializeManifest
+
 // Server represents the state of the cloud Server
 type Server struct {
 	workers *worker.Server
@@ -270,7 +274,7 @@ func (s *Server) enqueueCompose(irs []imageRequest, channel string) (uuid.UUID, 
 
 	s.goroutinesGroup.Add(1)
 	go func() {
-		serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
+		serializeManifestFunc(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
 		defer s.goroutinesGroup.Done()
 	}()
 
@@ -433,7 +437,7 @@ func (s *Server) enqueueKojiCompose(taskID uint64, server, name, version, releas
 		// copy the image request while passing it into the goroutine to prevent data races
 		s.goroutinesGroup.Add(1)
 		go func(ir imageRequest) {
-			serializeManifest(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
+			serializeManifestFunc(s.goroutinesCtx, manifestSource, s.workers, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID, ir.manifestSeed)
 			defer s.goroutinesGroup.Done()
 		}(ir)
 	}

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -400,7 +400,7 @@ func TestKojiCompose(t *testing.T) {
 		},
 	}
 
-	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe":{"url":""}}}}}`
+	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe":{"url":"https://pkg1.example.com/1.33-2.fc30.x86_64.rpm"}}}}}`
 	expectedManifests := `{"manifests":[` + emptyManifest + `,` + emptyManifest + `],"kind":"ComposeManifests"}`
 	for idx, c := range cases {
 		name, version, release := "foo", "1", "2"

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -880,16 +880,14 @@ func TestComposeManifests(t *testing.T) {
 			jobResult: worker.ManifestJobByIDResult{
 				Manifest: manifest.OSBuildManifest([]byte(`{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe":{"url":"https://pkg1.example.com/1.33-2.fc30.x86_64.rpm"}}}}}`)),
 			}},
-		// TODO: this case should actually fail, but it doesn't
 		{
 			name: "failure",
 			jobResult: worker.ManifestJobByIDResult{
-				Manifest: manifest.OSBuildManifest([]byte(`null`)),
 				JobResult: worker.JobResult{
 					JobError: clienterrors.New(clienterrors.ErrorManifestDependency, "Manifest generation test error", "Package XYZ does not have a RemoteLocation"),
 				},
 			},
-			//expectedError: clienterrors.New(clienterrors.ErrorManifestDependency, "Manifest generation test error", "Package XYZ does not have a RemoteLocation"),
+			expectedError: clienterrors.New(clienterrors.ErrorManifestDependency, "Manifest generation test error", "Package XYZ does not have a RemoteLocation"),
 		},
 	}
 

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -90,24 +90,19 @@ func mockDepsolve(t *testing.T, workerServer *worker.Server, wg *sync.WaitGroup,
 			if err != nil {
 				continue
 			}
+			dummyPackage := rpmmd.PackageSpec{
+				Name:           "pkg1",
+				Version:        "1.33",
+				Release:        "2.fc30",
+				Arch:           "x86_64",
+				Checksum:       "sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe",
+				RemoteLocation: "https://pkg1.example.com/1.33-2.fc30.x86_64.rpm",
+			}
 			dJR := &worker.DepsolveJobResult{
 				PackageSpecs: map[string][]rpmmd.PackageSpec{
 					// Used when depsolving a manifest
-					"build": {
-						{
-							Name:     "pkg1",
-							Checksum: "sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe",
-						},
-					},
-					"os": {
-						{
-							Name:     "pkg1",
-							Version:  "1.33",
-							Release:  "2.fc30",
-							Arch:     "x86_64",
-							Checksum: "sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe",
-						},
-					},
+					"build": {dummyPackage},
+					"os":    {dummyPackage},
 				},
 				SbomDocs: map[string]worker.SbomDoc{
 					"build": {
@@ -837,7 +832,7 @@ func TestComposeStatusSuccess(t *testing.T) {
 		]
 	}`, jobId, jobId))
 
-	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe":{"url":""}}}}}`
+	emptyManifest := `{"version":"2","pipelines":[{"name":"build"},{"name":"os"}],"sources":{"org.osbuild.curl":{"items":{"sha256:e50ddb78a37f5851d1a5c37a4c77d59123153c156e628e064b9daa378f45a2fe":{"url":"https://pkg1.example.com/1.33-2.fc30.x86_64.rpm"}}}}}`
 	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET", fmt.Sprintf("/api/image-builder-composer/v2/composes/%v/manifests", jobId), ``, http.StatusOK, fmt.Sprintf(`
 	{
 		"href": "/api/image-builder-composer/v2/composes/%v/manifests",

--- a/internal/test/apicall.go
+++ b/internal/test/apicall.go
@@ -75,7 +75,7 @@ func (a APICall) Do(t *testing.T) APICallResult {
 	require.NoErrorf(t, err, "%s: could not read response body", a.Path)
 
 	if a.ExpectedStatus != 0 {
-		assert.Equalf(t, a.ExpectedStatus, resp.StatusCode, "%s: SendHTTP failed for path", a.Path)
+		assert.Equalf(t, a.ExpectedStatus, resp.StatusCode, "%s: SendHTTP failed for path; body: %s", a.Path, string(body))
 	}
 	if a.ExpectedBody != nil {
 		err = a.ExpectedBody.Validate(body)


### PR DESCRIPTION
While porting https://github.com/osbuild/images/pull/1907 to osbuild-composer, I ran into the problem that the CloudAPI endpoint for compose manifests was not checking manifest generation job results and would return a 'nil' value instead of an error if the manifest generation failed.

Moreover, the mock data used by unit tests for depsolved packages was not complete and was lacking basic properties, such as the remote location URL, which is needed to generate an osbuild manifest.

This PR addresses the issues mentioned above, it also adds a unit test for compose manifests Cloud API endpoint and improves unit tests where failure debugging was previously unnecessarily complicated.

/jira-epic HMS-8910

JIRA: [HMS-9501](https://issues.redhat.com/browse/HMS-9501)