### PR TITLE
internal/cloudapi: rename OverrideSerializeManifestFunc for consistency

### DIFF
--- a/internal/cloudapi/v2/export_test.go
+++ b/internal/cloudapi/v2/export_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
-// OverrideSerializeManifestFunc overrides the serializeManifestFunc for testing
-func OverrideSerializeManifestFunc(f func(ctx context.Context, manifestSource *manifest.Manifest, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID uuid.UUID, seed int64)) func() {
+// MockSerializeManifestFunc overrides the serializeManifestFunc for testing
+func MockSerializeManifestFunc(f func(ctx context.Context, manifestSource *manifest.Manifest, workers *worker.Server, depsolveJobID, containerResolveJobID, ostreeResolveJobID, manifestJobID uuid.UUID, seed int64)) (restore func()) {
 	originalSerializeManifestFunc := serializeManifestFunc
 	serializeManifestFunc = f
 	return func() {

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -923,7 +923,7 @@ func TestComposeManifests(t *testing.T) {
 				err = workers.FinishJob(token, result)
 				require.NoError(t, err)
 			}
-			defer v2.OverrideSerializeManifestFunc(serializeManifestFunc)()
+			defer v2.MockSerializeManifestFunc(serializeManifestFunc)()
 
 			srv, wrksrv, _, cancel := newV2Server(t, t.TempDir(), false, false)
 			defer cancel()


### PR DESCRIPTION
Rename the function to MockSerializeManifestFunc() to be consistent with how we name function like this one. Additionally, name the return func() 'restore' to signal its purpose.