### PR TITLE
go.mod: bump images to v0.178.1 (HMS-9502)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/openshift-online/ocm-sdk-go v0.1.473
 	github.com/osbuild/blueprint v1.13.0
-	github.com/osbuild/images v0.178.0
+	github.com/osbuild/images v0.178.1
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/prometheus/client_golang v1.23.0
 	github.com/segmentio/ksuid v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXch
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/osbuild/blueprint v1.13.0 h1:blo22+S2ZX5bBmjGcRveoTUrV4Ms7kLfKyb32WyuymA=
 github.com/osbuild/blueprint v1.13.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.178.0 h1:ojCD1rRtO+khFHpRHUxd6ydXBarEu+6pwt0w8oqilaY=
-github.com/osbuild/images v0.178.0/go.mod h1:7CfDwGb8YA4erIzvMnqJysVpSu52i6l/f3h82usGPTg=
+github.com/osbuild/images v0.178.1 h1:tHRAc+nS5TLlEWXb4YHbTUID4GbGCf1XIRJkTx8aQOs=
+github.com/osbuild/images v0.178.1/go.mod h1:7CfDwGb8YA4erIzvMnqJysVpSu52i6l/f3h82usGPTg=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=

--- a/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
+++ b/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
@@ -214,6 +214,7 @@ distros:
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_high"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary"
       - "xccdf_org.ssgproject.content_profile_anssi_bp28_minimal"
+      - "xccdf_org.ssgproject.content_profile_bsi"
       - "xccdf_org.ssgproject.content_profile_ccn_advanced"
       - "xccdf_org.ssgproject.content_profile_ccn_basic"
       - "xccdf_org.ssgproject.content_profile_ccn_intermediate"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -958,7 +958,7 @@ github.com/oracle/oci-go-sdk/v54/workrequests
 ## explicit; go 1.23.9
 github.com/osbuild/blueprint/internal/common
 github.com/osbuild/blueprint/pkg/blueprint
-# github.com/osbuild/images v0.178.0
+# github.com/osbuild/images v0.178.1
 ## explicit; go 1.23.9
 github.com/osbuild/images/data/dependencies
 github.com/osbuild/images/data/distrodefs


### PR DESCRIPTION
Changes with 0.178.1

----------------
distrodefs: enable bsi oscap profile for RHEL-9.7 (HMS-9458) (#1917) Author: Gianluca Zuccarelli, Reviewers: Achilleas Koutsou, Michael Vogt, Simon de Vlieger

— Somewhere on the Internet, 2025-10-07

JIRA: [HMS-9502](https://issues.redhat.com/browse/HMS-9502)