### PR TITLE
test/cases/usbi-wsl: delete azure resources in order

### DIFF
--- a/test/cases/ubi-wsl.sh
+++ b/test/cases/ubi-wsl.sh
@@ -45,7 +45,9 @@ function cleanup() {
     NSG_ID=$(jq -r '.networkSecurityGroup.id' "$TEMPDIR"/nic_details.json)
     PUBLICIP_ID=$(jq -r '.ipConfigurations[0].publicIPAddress.id' "$TEMPDIR"/nic_details.json)
 
-    $AZURE_CMD resource delete --no-wait --ids "$VM_ID" "$OSDISK_ID" "$NIC_ID" "$NSG_ID" "$PUBLICIP_ID"
+    for id in "$VM_ID" "$OSDISK_ID" "$NIC_ID" "$NSG_ID" "$PUBLICIP_ID"; do
+        $AZURE_CMD resource delete --ids "$id"
+    done
     sudo rm -rf "$TEMPDIR"
 }
 trap cleanup EXIT


### PR DESCRIPTION
Sometimes resources fail to delete, so delete them one by one, in order, without `--no-wait`. Mirrored from the azure api test case, which seems to work better.