### PR TITLE
go.mod: update images to v0.209.0

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -518,21 +518,14 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		return err
 	}
 
-	exportPaths := []string{}
-	for _, jobTarget := range jobArgs.Targets {
-		exportPaths = append(exportPaths, path.Join(jobTarget.OsbuildArtifact.ExportName, jobTarget.OsbuildArtifact.ExportFilename))
-	}
-
 	logWithId.Infof("Extra env: %q", extraEnv)
-	opts := &osbuildexecutor.OsbuildOpts{
-		StoreDir:    impl.Store,
-		OutputDir:   outputDirectory,
-		Exports:     exports,
-		ExportPaths: exportPaths,
-		ExtraEnv:    extraEnv,
-		Result:      true,
+	opts := &osbuild.OSBuildOptions{
+		StoreDir:   impl.Store,
+		OutputDir:  outputDirectory,
+		ExtraEnv:   extraEnv,
+		JSONOutput: true,
 	}
-	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, opts, os.Stderr)
+	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, exports, nil, os.Stderr, opts)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.New(clienterrors.ErrorBuildJob, "osbuild build failed", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/openshift-online/ocm-sdk-go v0.1.478
 	github.com/osbuild/blueprint v1.16.0
-	github.com/osbuild/images v0.208.0
+	github.com/osbuild/images v0.209.0
 	github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/ksuid v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/oracle/oci-go-sdk/v54 v54.0.0 h1:CDLjeSejv2aDpElAJrhKpi6zvT/zhZCZuXch
 github.com/oracle/oci-go-sdk/v54 v54.0.0/go.mod h1:+t+yvcFGVp+3ZnztnyxqXfQDsMlq8U25faBLa+mqCMc=
 github.com/osbuild/blueprint v1.16.0 h1:f/kHih+xpeJ1v7wtIfzdHPZTsiXsqKeDQ1+rrue6298=
 github.com/osbuild/blueprint v1.16.0/go.mod h1:HPlJzkEl7q5g8hzaGksUk7ifFAy9QFw9LmzhuFOAVm4=
-github.com/osbuild/images v0.208.0 h1:7vkLGfu71v+9zORdgBfxFtpkhNnd2Z6ghw60Fj71vBE=
-github.com/osbuild/images v0.208.0/go.mod h1:tZqcrs3eNUA0VPs1h3YCnbnpAskVVfo36CIi2USSfDs=
+github.com/osbuild/images v0.209.0 h1:9BRf+N0op1WbQkc+7zVRBZxg4dqS4lty3i2stF3G9lo=
+github.com/osbuild/images v0.209.0/go.mod h1:tZqcrs3eNUA0VPs1h3YCnbnpAskVVfo36CIi2USSfDs=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d h1:r9BFPDv0uuA9k1947Jybcxs36c/pTywWS1gjeizvtcQ=
 github.com/osbuild/osbuild-composer/pkg/splunk_logger v0.0.0-20240814102216-0239db53236d/go.mod h1:zR1iu/hOuf+OQNJlk70tju9IqzzM4ycq0ectkFBm94U=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=

--- a/internal/osbuildexecutor/osbuild-executor.go
+++ b/internal/osbuildexecutor/osbuild-executor.go
@@ -6,16 +6,6 @@ import (
 	"github.com/osbuild/images/pkg/osbuild"
 )
 
-type OsbuildOpts struct {
-	StoreDir    string
-	OutputDir   string
-	Exports     []string
-	ExportPaths []string
-	Checkpoints []string
-	ExtraEnv    []string
-	Result      bool
-}
-
 type Executor interface {
-	RunOSBuild(manifest []byte, opts *OsbuildOpts, errorWriter io.Writer) (*osbuild.Result, error)
+	RunOSBuild(manifest []byte, exports, checkpoints []string, errorWriter io.Writer, opts *osbuild.OSBuildOptions) (*osbuild.Result, error)
 }

--- a/internal/osbuildexecutor/runner-impl-host.go
+++ b/internal/osbuildexecutor/runner-impl-host.go
@@ -8,12 +8,8 @@ import (
 
 type hostExecutor struct{}
 
-func (he *hostExecutor) RunOSBuild(manifest []byte, opts *OsbuildOpts, errorWriter io.Writer) (*osbuild.Result, error) {
-	if opts == nil {
-		opts = &OsbuildOpts{}
-	}
-
-	return osbuild.RunOSBuild(manifest, opts.StoreDir, opts.OutputDir, opts.Exports, opts.Checkpoints, opts.ExtraEnv, opts.Result, errorWriter)
+func (he *hostExecutor) RunOSBuild(manifest []byte, exports, checkpoints []string, errorWriter io.Writer, opts *osbuild.OSBuildOptions) (*osbuild.Result, error) {
+	return osbuild.RunOSBuild(manifest, exports, checkpoints, errorWriter, opts)
 }
 
 func NewHostExecutor() Executor {

--- a/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
+++ b/vendor/github.com/osbuild/images/data/distrodefs/distros.yaml
@@ -114,6 +114,8 @@ distros:
       - "xccdf_org.ssgproject.content_profile_e8"
       - "xccdf_org.ssgproject.content_profile_hipaa"
       - "xccdf_org.ssgproject.content_profile_ism_o"
+      - "xccdf_org.ssgproject.content_profile_ism_o_secret"
+      - "xccdf_org.ssgproject.content_profile_ism_o_top_secret"
       - "xccdf_org.ssgproject.content_profile_ospp"
       - "xccdf_org.ssgproject.content_profile_pci-dss"
       - "xccdf_org.ssgproject.content_profile_stig"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -961,7 +961,7 @@ github.com/oracle/oci-go-sdk/v54/workrequests
 ## explicit; go 1.23.9
 github.com/osbuild/blueprint/internal/common
 github.com/osbuild/blueprint/pkg/blueprint
-# github.com/osbuild/images v0.208.0
+# github.com/osbuild/images v0.209.0
 ## explicit; go 1.23.9
 github.com/osbuild/images/data/dependencies
 github.com/osbuild/images/data/distrodefs


### PR DESCRIPTION
In adapting to the new osbuild/osbuild-exec code, ExportPaths got dropped. This variable / option was not used anywhere anyway.

Changes with 0.209.0
----------------
  - gitlab: run ostree manifest generation and builds only when needed (osbuild/images#1961)
    - Author: Achilleas Koutsou, Reviewers: Simon de Vlieger, Tomáš Hozza
  - osbuild/osbuild-exec: extract building the osbuild cmd to helper (osbuild/images#1963)
    - Author: Sanne Raymaekers, Reviewers: Achilleas Koutsou, Simon de Vlieger
  - rhel10: add ism secret & top secret oscap profiles (HMS-9507) (osbuild/images#1962)
    - Author: Gianluca Zuccarelli, Reviewers: Lukáš Zapletal, Sanne Raymaekers