### PR TITLE
ci: re-enable vmware tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -467,34 +467,25 @@ gcp.sh:
   variables:
     SCRIPT: gcp.sh
 
-# NOTE(akoutsou): The vmware tests are consistently failing. While the
-# build succeeds, the upload fails with:
-#   Unable to protect host, if the host isn't running as part of an
-#   autoscaling group, this can safely be ignored: operation error Auto
-#   Scaling: DescribeAutoScalingInstances, get identity: get credentials:
-#   failed to refresh cached credentials, no EC2 IMDS role found, operation
-#   error ec2imds: GetMetadata, http response error StatusCode: 404, request
-#   to EC2 IMDS failed
-# Disabling the test until we have time to look into it furhter.
-# vmware.sh_vmdk:
-#   extends: .integration_rhel
-#   rules:
-#     # Run only on x86_64
-#     - !reference [.upstream_rules_x86_64, rules]
-#     - !reference [.nightly_rules_x86_64, rules]
-#     - !reference [.ga_rules_x86_64, rules]
-#   variables:
-#     SCRIPT: vmware.sh vmdk
+vmware.sh_vmdk:
+  extends: .integration_rhel
+  rules:
+    # Run only on x86_64
+    - !reference [.upstream_rules_x86_64, rules]
+    - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
+  variables:
+    SCRIPT: vmware.sh vmdk
 
-# vmware.sh_ova:
-#   extends: .integration_rhel
-#   rules:
-#     # Run only on x86_64
-#     - !reference [.upstream_rules_x86_64, rules]
-#     - !reference [.nightly_rules_x86_64, rules]
-#     - !reference [.ga_rules_x86_64, rules]
-#   variables:
-#     SCRIPT: vmware.sh ova
+vmware.sh_ova:
+  extends: .integration_rhel
+  rules:
+    # Run only on x86_64
+    - !reference [.upstream_rules_x86_64, rules]
+    - !reference [.nightly_rules_x86_64, rules]
+    - !reference [.ga_rules_x86_64, rules]
+  variables:
+    SCRIPT: vmware.sh ova
 
 filesystem.sh:
   extends: .integration


### PR DESCRIPTION
The CI configuration has been updated with fresh new values.  Let's start testing VMWare builds again.

Thanks @chris1984 for taking care of this.