### PR TITLE
renovate: config for batch updates every Sunday

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "groupName": "go-modules",
+      "matchManagers": [
+        "gomod"
+      ],
+      "schedule": [
+        "on sunday"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I currently don't have access to the konflux application to disable renovate / mintmaker on this repo, like I did with bootc-image-builder.  Until we do, let's at least make the PRs less noisy by batching them into once a week.

Add a renovate config to do all Go dependency updates in one batch every Sunday.