### PR TITLE
renovate.json: ignore gomod updates and set other limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "schedule:earlyMondays"
+  ],
+  "prConcurrentLimit": 3,
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
The konflux bots are very noisy if not restrained.