### PR TITLE
.github/renovate: disable dockerfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    "docker:disable"
   ],
   "prConcurrentLimit": 3,
   "gomod": {


### PR DESCRIPTION
See #4939 updating a few containers which are only used in the docker-compose setup. This just generates more noise.