### PR TITLE
templates/openshift: switch to konflux images (HMS-9722)

### DIFF
--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -274,7 +274,7 @@ objects:
 parameters:
   - description: composer image name
     name: IMAGE_NAME
-    value: quay.io/app-sre/composer
+    value: quay.io/redhat-services-prod/insights-management-tenant/image-builder-composer/osbuild-composer
     required: true
   - description: composer image tag
     name: IMAGE_TAG

--- a/templates/openshift/maintenance.yml
+++ b/templates/openshift/maintenance.yml
@@ -166,7 +166,7 @@ objects:
 parameters:
   - description: maintenance image name
     name: IMAGE_NAME
-    value: quay.io/app-sre/composer-maintenance
+    value: quay.io/redhat-services-prod/insights-management-tenant/image-builder-composer/osbuild-composer-maintenance
     required: true
   - description: composer image tag
     name: IMAGE_TAG


### PR DESCRIPTION
The composer and maintenance images are both built in konflux now. This means the deployments can switch over to those images.