### PR TITLE
osbuild-worker-executor: ignore item order in tarball in test

### DIFF
--- a/cmd/osbuild-worker-executor/handler_build_test.go
+++ b/cmd/osbuild-worker-executor/handler_build_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,8 +163,14 @@ echo "fake-build-result" > %[1]s/build/output/image/disk.img
 	assert.NoError(t, os.WriteFile(tarPath, body, 0644))
 	cmd := exec.Command("tar", "-tf", tarPath)
 	out, err := cmd.Output()
+	expected := []string{"output/",
+		"output/image/",
+		"output/image/disk.img",
+		"output/osbuild-result.json",
+	}
+	actual := strings.Split(strings.TrimSpace(string(out)), "\n")
 	assert.NoError(t, err)
-	assert.Equal(t, "output/\noutput/image/\noutput/image/disk.img\noutput/osbuild-result.json\n", string(out))
+	assert.ElementsMatch(t, expected, actual)
 }
 
 func TestBuildErrorsForMultipleBuilds(t *testing.T) {


### PR DESCRIPTION
While preparing #4964, this test failed for me locally and I had to change the order.  Then, when the tests ran on GitHub, the file order was the same as the original.  This is probably based on the version of `tar` being used.

---


In TestBuildIntegration(), the contents of the output tarball (`tar -tf`) are compared with an expected list of files.  The check is done by direct string match with the output.  However, the order of elements in the archive is not guaranteed to be stable.  Since the file order isn't significant for the test or the feature, compare the archive contents using an element matching check on a list of strings.