### PR TITLE
test/{api,ubi}: pin cloud-tools to an older version

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -90,7 +90,9 @@ source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 
 # Container image used for cloud provider CLI tools
-export CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"
+# TODO: Unpin the container once the cloud-tools image has working azure-cli
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2422741
+export CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest-202509011147"
 
 #
 # Provision the software under test.

--- a/test/cases/ubi-wsl.sh
+++ b/test/cases/ubi-wsl.sh
@@ -13,7 +13,9 @@ source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 set -euo pipefail
 
 # Container image used for cloud provider CLI tools
-CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"
+# TODO: Unpin the container once the cloud-tools image has working azure-cli
+# See https://bugzilla.redhat.com/show_bug.cgi?id=2422741
+CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest-202509011147"
 
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh none


### PR DESCRIPTION
azcli in Fedora 43 is currently broken,
see See https://bugzilla.redhat.com/show_bug.cgi?id=2422741