### PR TITLE
templates/packer: wait for the requisite grace on exit

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/on_exit.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/on_exit.sh
@@ -5,6 +5,8 @@ if [ "$SERVICE_RESULT" == "success" ]; then
     exit 0
 fi
 
-echo "Worker initialization failed,  setting instance state to unhealthy"
+echo "Worker initialization failed, setting instance state to unhealthy after grace period"
+# grace period is 300 seconds, before that aws will not allow setting the instance status to unhealthy
+sleep 300s
 INSTANCE_ID=$(curl -Ls http://169.254.169.254/latest/meta-data/instance-id)
 /usr/local/bin/aws autoscaling set-instance-health --instance-id "$INSTANCE_ID" --health-status Unhealthy


### PR DESCRIPTION
Before setting the instance to unhealthy, wait for the grace period to have passed. The grace period is 300 seconds.