### PR TITLE
ci: gobump blueprint separately

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -20,7 +20,7 @@ jobs:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           exec_pr: ./tools/prepare-source.sh
-          include: "github.com/osbuild/images"
+          include: "github.com/osbuild/images github.com/osbuild/blueprint"
           commit_message: "deps: bump osbuild/images dependency"
 
       - name: Cleaup repository
@@ -32,5 +32,5 @@ jobs:
           go_version: "1.23.9"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           exec_pr: ./tools/prepare-source.sh
-          exclude: "github.com/osbuild/images"
+          exclude: "github.com/osbuild/images,github.com/osbuild/blueprint"
           commit_message: "deps: update dependencies (w/o osbuild/images)"


### PR DESCRIPTION
SSIA

https://github.com/osbuild/image-builder-cli/pull/423

For the record, excluding is a command line option and is comma separated while including is passed as space-separated arguments. That is how gobump CLI works.