### PR TITLE
packit: Build RHEL10 RPMs for x86 and ARM in COPR

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,6 +50,8 @@ jobs:
     - rhel-8-x86_64
     - rhel-9-aarch64
     - rhel-9-x86_64
+    - rhel-10-x86_64
+    - rhel-10-aarch64
 - job: copr_build
   trigger: commit
   branch: main


### PR DESCRIPTION
Since we release into RHEL10 it would be convenient to also build those RPMs in COPR.