### PR TITLE
cloudapi/v2: add distro metadata endpoint (HMS-9643)

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -83,6 +83,7 @@ const (
 	ErrorArtifactNotFound                         ServiceErrorCode = 1022
 	ErrorDeletingJob                              ServiceErrorCode = 1023
 	ErrorDeletingArtifacts                        ServiceErrorCode = 1024
+	ErrorGettingImageTypes                        ServiceErrorCode = 1025
 
 	// Errors contained within this file
 	ErrorUnspecified          ServiceErrorCode = 10000
@@ -173,6 +174,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorGettingComposeList, http.StatusInternalServerError, "Unable to get list of composes"},
 		serviceError{ErrorDeletingJob, http.StatusBadRequest, "Unable to delete job"},
 		serviceError{ErrorDeletingArtifacts, http.StatusInternalServerError, "Unable to delete job artifacts"},
+		serviceError{ErrorGettingImageTypes, http.StatusInternalServerError, "Unable to get list of image types"},
 
 		serviceError{ErrorUnspecified, http.StatusInternalServerError, "Unspecified internal error "},
 		serviceError{ErrorNotHTTPError, http.StatusInternalServerError, "Error is not an instance of HTTPError"},

--- a/internal/cloudapi/v2/openapi.v2.yml
+++ b/internal/cloudapi/v2/openapi.v2.yml
@@ -657,6 +657,58 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /distributions/{distro}:
+    get:
+      operationId: getDistribution
+      summary: Get details for a specific distribution
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: distro
+          schema:
+            type: string
+            example: 'rhel-9.6'
+          required: true
+          description: Name of the distribution
+        - in: query
+          name: image_type
+          schema:
+            type: array
+            items:
+              type: string
+            example: ['ami', 'aws']
+          required: false
+          description: Filter by image type. Multiple values can be specified.
+        - in: query
+          name: architecture
+          schema:
+            type: array
+            items:
+              type: string
+            example: ['x86_64', 'aarch64']
+          required: false
+          description: Filter by architecture. Multiple values can be specified.
+      responses:
+        '200':
+          description: Distribution details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DistributionDetails'
+        '404':
+          description: Distribution not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /errors/{id}:
     get:
       operationId: getError
@@ -834,6 +886,144 @@ components:
           items:
             $ref: '#/components/schemas/BlueprintRepository'
 
+    DistributionDetails:
+      allOf:
+      - $ref: '#/components/schemas/ObjectReference'
+      - type: object
+        description: Complete metadata for a specific distribution from images library
+        additionalProperties: false
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the distribution
+            example: 'rhel-9.6'
+          codename:
+            type: string
+            description: Codename of the distribution
+            example: ''
+          releasever:
+            type: string
+            description: Release version used in repo files
+            example: '9'
+          os_version:
+            type: string
+            description: Full OS version including minor version
+            example: '9.6'
+          module_platform_id:
+            type: string
+            description: Module platform ID for DNF modularity
+            example: 'platform:el9'
+          product:
+            type: string
+            description: Product name
+            example: 'Red Hat Enterprise Linux'
+          ostree_ref:
+            type: string
+            description: Default OSTree reference template
+            example: 'rhel/9/%s/edge'
+          architectures:
+            type: object
+            description: Map of architecture names to their details
+            additionalProperties:
+              $ref: '#/components/schemas/ArchitectureInfo'
+
+    ArchitectureInfo:
+      type: object
+      description: Architecture metadata from images library
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Architecture name
+          example: 'x86_64'
+        image_types:
+          type: object
+          description: Map of image type names to their details
+          additionalProperties:
+            $ref: '#/components/schemas/ImageTypeInfo'
+
+    ImageTypeInfo:
+      type: object
+      description: Image type metadata from images library
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Image type name
+          example: 'ami'
+        aliases:
+          type: array
+          description: Alternative names for this image type
+          items:
+            type: string
+            example: 'aws'
+        filename:
+          type: string
+          description: Canonical filename for the image
+          example: 'image.raw'
+        mime_type:
+          type: string
+          description: MIME type of the image
+          example: 'application/octet-stream'
+        ostree_ref:
+          type: string
+          description: Default OSTree ref for this image type
+          example: ''
+        iso_label:
+          type: string
+          nullable: true
+          description: ISO label (only for ISO image types)
+          example: null
+        default_size:
+          type: integer
+          format: uint64
+          description: Default image size in bytes
+          example: 1073741824
+        partition_type:
+          type: string
+          enum:
+            - gpt
+            - dos
+          description: Partition table type
+        base_partition_table:
+          $ref: '#/components/schemas/Disk'
+        boot_mode:
+          type: string
+          enum:
+            - legacy
+            - uefi
+            - hybrid
+            - none
+          description: Boot mode for the image
+        payload_package_sets:
+          type: array
+          description: Package set names safe for custom packages via custom repos
+          items:
+            type: string
+            example: 'blueprint'
+        exports:
+          type: array
+          description: Names of stages that produce the build output
+          items:
+            type: string
+            example: 'image'
+        required_blueprint_options:
+          type: array
+          description: Customization options required by this image type
+          items:
+            type: string
+        supported_blueprint_options:
+          type: array
+          description: Customization options supported by this image type
+          items:
+            type: string
+          example: ['distro', 'packages', 'customizations.cacerts', 'customizations.sshkey']
     ComposeStatus:
       allOf:
       - $ref: '#/components/schemas/ObjectReference'

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -482,6 +482,394 @@ func TestGetDistributionList(t *testing.T) {
 	}`, "gpgkeys", "baseurl")
 }
 
+func TestGetDistribution(t *testing.T) {
+	srv, _, _, cancel := newV2Server(t, t.TempDir(), nil)
+	defer cancel()
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1?architecture=test_arch", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_ostree_type": {
+						"name": "test_ostree_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/non-existent", ``, http.StatusBadRequest, `
+	{
+		"code": "IMAGE-BUILDER-COMPOSER-4",
+		"reason": "Unsupported distribution"
+	}`, "operation_id", "href", "id", "kind", "details")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1?architecture=test_arch&image_type=test_type", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1?image_type=test_type", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			},
+			"test_arch2": {
+				"name": "test_arch2",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1?architecture=test_arch&image_type=test_type&image_type=test_ostree_type", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_ostree_type": {
+						"name": "test_ostree_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1?architecture=test_arch&architecture=test_arch2", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_ostree_type": {
+						"name": "test_ostree_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			},
+			"test_arch2": {
+				"name": "test_arch2",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_type2": {
+						"name": "test_type2",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "GET",
+		"/api/image-builder-composer/v2/distributions/test-distro-1", ``, http.StatusOK, `
+	{
+		"id": "test-distro-1",
+		"kind": "DistributionDetails",
+		"href": "/api/image-builder-composer/v2/distributions/test-distro-1",
+		"name": "test-distro-1",
+		"releasever": "1",
+		"os_version": "1",
+		"module_platform_id": "platform:test-distro-1",
+		"product": "test-distro-1",
+		"ostree_ref": "test/1/x86_64/edge",
+		"architectures": {
+			"test_arch": {
+				"name": "test_arch",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_ostree_type": {
+						"name": "test_ostree_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			},
+			"test_arch2": {
+				"name": "test_arch2",
+				"image_types": {
+					"test_type": {
+						"name": "test_type",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"test_type2": {
+						"name": "test_type2",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			},
+			"test_arch3": {
+				"name": "test_arch3",
+				"image_types": {
+					"ami": {
+						"name": "ami",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"rhel-edge-commit": {
+						"name": "rhel-edge-commit",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"rhel-edge-installer": {
+						"name": "rhel-edge-installer",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "test/1/x86_64/edge",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"gce": {
+						"name": "gce",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"image-installer": {
+						"name": "image-installer",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"qcow2": {
+						"name": "qcow2",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"vhd": {
+						"name": "vhd",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					},
+					"vmdk": {
+						"name": "vmdk",
+						"filename": "test.img",
+						"mime_type": "application/x-test",
+						"ostree_ref": "",
+						"default_size": 1073741824,
+						"boot_mode": "hybrid",
+						"payload_package_sets": ["blueprint"],
+						"exports": ["assembler"]
+					}
+				}
+			}
+		}
+	}`, "codename", "aliases", "iso_label", "partition_type", "required_blueprint_options", "supported_blueprint_options")
+}
+
 func TestCompose(t *testing.T) {
 	srv, _, _, cancel := newV2Server(t, t.TempDir(), nil)
 	defer cancel()


### PR DESCRIPTION
Adds an endpoint for getting distro metadata - /distributions/{distro}. Returns all metadata distro has defined in osbuild/images. Includes arch metadata and corresponding image types metadata. Supports filtering by image type and by architecture and allows multiple values for both of these options.

Example output from  `/distributions/rhel-9.6?architecture=x86_64&image_type=ami`: 
```
{
  "architectures": {
    "aarch64": {
      "image_types": {
        "ami": {
          "aliases": [
            "aws"
          ],
          "base_partition_table": {
            "partitions": [
              {
                "fs_type": "vfat",
                "label": "ESP",
                "minsize": "209715200",
                "mountpoint": "/boot/efi"
              },
              {
                "fs_type": "xfs",
                "label": "boot",
                "minsize": "1073741824",
                "mountpoint": "/boot"
              },
              {
                "fs_type": "xfs",
                "label": "root",
                "minsize": "2147483648",
                "mountpoint": "/"
              }
            ],
            "type": "gpt"
          },
          "boot_mode": "uefi",
          "default_size": 10737418240,
          "exports": [
            "image"
          ],
          "filename": "image.raw",
          "iso_label": null,
          "mime_type": "application/octet-stream",
          "name": "ami",
          "ostree_ref": "",
          "partition_type": "gpt",
          "payload_package_sets": [
            "blueprint"
          ],
          "required_blueprint_options": null,
          "supported_blueprint_options": [
            "distro",
            "packages",
            "modules",
            "groups",
            "enabled_modules",
            "containers",
            "customizations.cacerts",
            "customizations.directories",
            "customizations.disk",
            "customizations.dnf",
            "customizations.files",
            "customizations.filesystem",
            "customizations.partitioning_mode",
            "customizations.fips",
            "customizations.firewall",
            "customizations.user",
            "customizations.sshkey",
            "customizations.group",
            "customizations.hostname",
            "customizations.kernel",
            "customizations.locale",
            "customizations.openscap",
            "customizations.repositories",
            "customizations.rpm",
            "customizations.services",
            "customizations.timezone",
            "customizations.rhsm",
            "name",
            "version",
            "description"
          ]
        }
      },
      "name": "aarch64"
    }
  },
  "codename": "",
  "module_platform_id": "platform:el9",
  "name": "rhel-9.6",
  "os_version": "9.6",
  "ostree_ref": "rhel/9/%s/edge",
  "product": "Red Hat Enterprise Linux",
  "releasever": "9"
}
```

