### PR TITLE
tools/build-rpms: build rpms on rhel 10

### DIFF
--- a/tools/appsre-ansible/rpmbuild.yml
+++ b/tools/appsre-ansible/rpmbuild.yml
@@ -17,16 +17,16 @@
     become: yes
     dnf:
       state: present
-      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+      name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
       disable_gpg_check: yes
 
   - name: Disable RHUI repos
     become: yes
     shell: >-
       dnf config-manager \
-        --set-disabled rhel-9-baseos-rhui-rpms \
-        --set-disabled rhel-9-appstream-rhui-rpms \
-        --set-disabled rhui-client-config-server-9
+        --set-disabled rhel-10-baseos-rhui-rpms \
+        --set-disabled rhel-10-appstream-rhui-rpms \
+        --set-disabled rhui-client-config-server-10
 
   - name: Enable rhsm repository management
     become: yes
@@ -140,7 +140,7 @@
     until: result is success
     shell: >-
         mock
-        -r "rhel-9-{{ ansible_architecture }}"
+        -r "rhel-10-{{ ansible_architecture }}"
         --rebuild
         --define "commit {{ OSBUILD_COMMIT }}"
         --define "_rpmfilename %%{NAME}.rpm"
@@ -167,7 +167,7 @@
     until: result is success
     shell: >-
         mock
-        -r "rhel-9-{{ ansible_architecture }}"
+        -r "rhel-10-{{ ansible_architecture }}"
         --rebuild
         --define "commit {{ COMPOSER_COMMIT }}"
         --define "_rpmfilename %%{NAME}.rpm"

--- a/tools/build-rpms.py
+++ b/tools/build-rpms.py
@@ -14,13 +14,13 @@ import boto3
 
 arch_info = {}
 arch_info["x86_64"] = {
-    # RHEL-9.6.0_HVM-20250910-x86_64-0-Access2-GP3
-    "ImageId": "ami-01aaf1c29c7e0f0af",
+    # RHEL-10.0.0_HVM-20251030-x86_64-0-Access2-GP3
+    "ImageId": "ami-0d2cf1078cac15da9",
     "InstanceType": "m7a.large"
 }
 arch_info["aarch64"] = {
-    # RHEL-9.6.0_HVM-20250910-arm64-0-Access2-GP3
-    "ImageId": "ami-06f37afe6d4f43c47",
+    # RHEL-10.1.0_HVM_GA-20251031-arm64-0-Access2-GP3
+    "ImageId": "ami-03d9eec0fe95df48d",
     "InstanceType": "m7g.large"
 }
 


### PR DESCRIPTION
4f25b231472885ebfe50b293bdd5543f6f2fbac0 did not update the rpmbuild task, resulting in a mismatch between the target worker version (10) and the rpms being built (9).