### PR TITLE
templates/packer: increase timeout of ExecStop(Post) commands

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -7,6 +7,7 @@ After=cloud-final.service
 
 [Service]
 Type=oneshot
+TimeoutStopSec=500
 ExecStart=touch /etc/worker-first-boot
 ExecStart=/usr/local/libexec/worker-initialization-scripts/set_hostname.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/vector.sh


### PR DESCRIPTION
The default timeout for stop commands is 90 seconds. As the `on_exit` script needs to wait for the instance start grace period of 300 seconds to have passed, increase the timeout for the worker-initialization service to 500.