### PR TITLE
test: enable cloud-image-validator [HMS-9868]

### DIFF
--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -205,80 +205,77 @@ if nvrGreaterOrEqual "osbuild-composer" "83"; then
     esac
 fi
 
-# CIV tests temporarily disabled.  See https://issues.redhat.com/browse/HMS-9868
-# if [[ "$ID" == "fedora" ]]; then
-#   # fedora uses fedora
-#   SSH_USER="fedora"
-# else
-#   # RHEL and centos use ec2-user
-#   SSH_USER="ec2-user"
-# fi
+if [[ "$ID" == "fedora" ]]; then
+  # fedora uses fedora
+  SSH_USER="fedora"
+else
+  # RHEL and centos use ec2-user
+  SSH_USER="ec2-user"
+fi
 
-# greenprint "Pulling cloud-image-val container"
+greenprint "Pulling cloud-image-val container"
 
-# if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
-#   # If running on CIV, get dev container
-#   TAG=${CI_COMMIT_REF_SLUG}
-# else
-#   # If not, get prod container
-#   TAG="prod"
-# fi
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+else
+  # If not, get prod container
+  TAG="prod"
+fi
 
-# CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
 
-# sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
-# greenprint "Running cloud-image-val on generated image"
+greenprint "Running cloud-image-val on generated image"
 
-# tee "${TEMPDIR}/resource-file.json" <<EOF
-# {
-#     "provider": "aws",
-#     "instances": [
-#         {
-#             "ami": "$AMI_IMAGE_ID",
-#             "region": "us-east-1",
-#             "instance_type": "t3.medium",
-#             "username": "$SSH_USER",
-#             "name": "civ-testing-image",
-#             "spot_instance": true
-#         }
-#     ]
-# }
-# EOF
+tee "${TEMPDIR}/resource-file.json" <<EOF
+{
+    "provider": "aws",
+    "instances": [
+        {
+            "ami": "$AMI_IMAGE_ID",
+            "region": "us-east-1",
+            "instance_type": "t3.medium",
+            "username": "$SSH_USER",
+            "name": "civ-testing-image",
+            "spot_instance": true
+        }
+    ]
+}
+EOF
 
-# if [ "$ARCH" == "aarch64" ]; then
-#     sed -i s/t3.medium/m6g.medium/ "${TEMPDIR}/resource-file.json"
-# fi
+if [ "$ARCH" == "aarch64" ]; then
+    sed -i s/t3.medium/m6g.medium/ "${TEMPDIR}/resource-file.json"
+fi
 
-# if [ -z "$CIV_CONFIG_FILE" ]; then
-#     redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
-#     exit 1
-# fi
+if [ -z "$CIV_CONFIG_FILE" ]; then
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
+    exit 1
+fi
 
-# cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
+cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 
-# # temporary workaround for
-# # https://issues.redhat.com/browse/CLOUDX-488
-# if nvrGreaterOrEqual "osbuild-composer" "83"; then
-#     sudo "${CONTAINER_RUNTIME}" run \
-#         --net=host \
-#         -a stdout -a stderr \
-#         -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
-#         -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
-#         -e AWS_REGION="${AWS_REGION}" \
-#         -e JIRA_PAT="${JIRA_PAT}" \
-#         -v "${TEMPDIR}":/tmp:Z \
-#         "${CONTAINER_CLOUD_IMAGE_VAL}" \
-#         python cloud-image-val.py \
-#         -c /tmp/civ_config.yml \
-#         && RESULTS=1 || RESULTS=0
+# temporary workaround for
+# https://issues.redhat.com/browse/CLOUDX-488
+if nvrGreaterOrEqual "osbuild-composer" "83"; then
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
+        -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
+        -e AWS_REGION="${AWS_REGION}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-#     mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-# else
-#     RESULTS=1
-# fi
-
-RESULTS=1  # NOTE: remove when re-enabling CIV
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
+else
+    RESULTS=1
+fi
 
 # Clean up our mess.
 greenprint "🧼 Cleaning up"

--- a/test/cases/aws.sh
+++ b/test/cases/aws.sh
@@ -191,80 +191,77 @@ if nvrGreaterOrEqual "osbuild-composer" "83"; then
     esac
 fi
 
-# CIV tests temporarily disabled.  See https://issues.redhat.com/browse/HMS-9868
-# if [[ "$ID" == "fedora" ]]; then
-#   # fedora uses fedora
-#   SSH_USER="fedora"
-# else
-#   # RHEL and centos use ec2-user
-#   SSH_USER="ec2-user"
-# fi
+if [[ "$ID" == "fedora" ]]; then
+  # fedora uses fedora
+  SSH_USER="fedora"
+else
+  # RHEL and centos use ec2-user
+  SSH_USER="ec2-user"
+fi
 
-# greenprint "Pulling cloud-image-val container"
+greenprint "Pulling cloud-image-val container"
 
-# if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
-#   # If running on CIV, get dev container
-#   TAG=${CI_COMMIT_REF_SLUG}
-# else
-#   # If not, get prod container
-#   TAG="prod"
-# fi
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+else
+  # If not, get prod container
+  TAG="prod"
+fi
 
-# CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
 
-# sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
-# greenprint "Running cloud-image-val on generated image"
+greenprint "Running cloud-image-val on generated image"
 
-# tee "${TEMPDIR}/resource-file.json" <<EOF
-# {
-#     "provider": "aws",
-#     "instances": [
-#         {
-#             "ami": "$AMI_IMAGE_ID",
-#             "region": "us-east-1",
-#             "instance_type": "t3.medium",
-#             "username": "$SSH_USER",
-#             "name": "civ-testing-image",
-#             "spot_instance": true
-#         }
-#     ]
-# }
-# EOF
+tee "${TEMPDIR}/resource-file.json" <<EOF
+{
+    "provider": "aws",
+    "instances": [
+        {
+            "ami": "$AMI_IMAGE_ID",
+            "region": "us-east-1",
+            "instance_type": "t3.medium",
+            "username": "$SSH_USER",
+            "name": "civ-testing-image",
+            "spot_instance": true
+        }
+    ]
+}
+EOF
 
-# if [ "$ARCH" == "aarch64" ]; then
-#     sed -i s/t3.medium/m6g.medium/ "${TEMPDIR}/resource-file.json"
-# fi
+if [ "$ARCH" == "aarch64" ]; then
+    sed -i s/t3.medium/m6g.medium/ "${TEMPDIR}/resource-file.json"
+fi
 
-# if [ -z "$CIV_CONFIG_FILE" ]; then
-#     redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
-#     exit 1
-# fi
+if [ -z "$CIV_CONFIG_FILE" ]; then
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
+    exit 1
+fi
 
-# cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
+cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 
-# # temporary workaround for
-# # https://issues.redhat.com/browse/CLOUDX-488
-# if nvrGreaterOrEqual "osbuild-composer" "83"; then
-#     sudo "${CONTAINER_RUNTIME}" run \
-#         --net=host \
-#         -a stdout -a stderr \
-#         -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
-#         -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
-#         -e AWS_REGION="${AWS_REGION}" \
-#         -e JIRA_PAT="${JIRA_PAT}" \
-#         -v "${TEMPDIR}":/tmp:Z \
-#         "${CONTAINER_CLOUD_IMAGE_VAL}" \
-#         python cloud-image-val.py \
-#         -c /tmp/civ_config.yml \
-#         && RESULTS=1 || RESULTS=0
+# temporary workaround for
+# https://issues.redhat.com/browse/CLOUDX-488
+if nvrGreaterOrEqual "osbuild-composer" "83"; then
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e AWS_ACCESS_KEY_ID="${V2_AWS_ACCESS_KEY_ID}" \
+        -e AWS_SECRET_ACCESS_KEY="${V2_AWS_SECRET_ACCESS_KEY}" \
+        -e AWS_REGION="${AWS_REGION}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-#     mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-# else
-#     RESULTS=1
-# fi
-
-RESULTS=1  # NOTE: remove when re-enabling CIV
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
+else
+    RESULTS=1
+fi
 
 # Clean up our mess.
 greenprint "🧼 Cleaning up"

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -196,78 +196,75 @@ fi
 
 export BLOB_URL="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$AZURE_CONTAINER_NAME/$IMAGE_KEY.vhd"
 
-# CIV tests temporarily disabled.  See https://issues.redhat.com/browse/HMS-9868
-# greenprint "Pulling cloud-image-val container"
+greenprint "Pulling cloud-image-val container"
 
-# if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
-#   # If running on CIV, get dev container
-#   TAG=${CI_COMMIT_REF_SLUG}
-# elif ! nvrGreaterOrEqual "osbuild-composer" "151"; then
-#   # osbuild-composer v151 made changes in the Azure image definitions and CIV
-#   # was updated to check for those changes:
-#   # https://github.com/osbuild/cloud-image-val/pull/457
-#   # This tag does not include those changes, so use it when running against
-#   # older versions of composer.
-#   TAG="pr-456"
-# else
-#   # If not, get prod container
-#   TAG="prod"
-# fi
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+elif ! nvrGreaterOrEqual "osbuild-composer" "151"; then
+  # osbuild-composer v151 made changes in the Azure image definitions and CIV
+  # was updated to check for those changes:
+  # https://github.com/osbuild/cloud-image-val/pull/457
+  # This tag does not include those changes, so use it when running against
+  # older versions of composer.
+  TAG="pr-456"
+else
+  # If not, get prod container
+  TAG="prod"
+fi
 
-# CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
 
-# sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
-# greenprint "Running cloud-image-val on generated image"
+greenprint "Running cloud-image-val on generated image"
 
-# tee "${TEMPDIR}/resource-file.json" <<EOF
-# {
-#   "subscription_id": "${AZURE_SUBSCRIPTION_ID}",
-#   "resource_group": "${AZURE_RESOURCE_GROUP}",
-#   "provider": "azure",
-#   "instances": [
-#     {
-#       "vhd_uri": "${BLOB_URL}",
-#       "arch": "${ARCH}",
-#       "location": "${AZURE_LOCATION}",
-#       "name": "${IMAGE_KEY}",
-#       "hyper_v_generation": "${HYPER_V_GEN}",
-#       "storage_account": "${AZURE_STORAGE_ACCOUNT}"
-#     }
-#   ]
-# }
-# EOF
+tee "${TEMPDIR}/resource-file.json" <<EOF
+{
+  "subscription_id": "${AZURE_SUBSCRIPTION_ID}",
+  "resource_group": "${AZURE_RESOURCE_GROUP}",
+  "provider": "azure",
+  "instances": [
+    {
+      "vhd_uri": "${BLOB_URL}",
+      "arch": "${ARCH}",
+      "location": "${AZURE_LOCATION}",
+      "name": "${IMAGE_KEY}",
+      "hyper_v_generation": "${HYPER_V_GEN}",
+      "storage_account": "${AZURE_STORAGE_ACCOUNT}"
+    }
+  ]
+}
+EOF
 
-# if [ -z "$CIV_CONFIG_FILE" ]; then
-#     redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
-#     exit 1
-# fi
+if [ -z "$CIV_CONFIG_FILE" ]; then
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
+    exit 1
+fi
 
-# cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
+cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 
-# # temporary workaround for
-# # https://issues.redhat.com/browse/CLOUDX-488
-# if nvrGreaterOrEqual "osbuild-composer" "83"; then
-#     sudo "${CONTAINER_RUNTIME}" run \
-#         --net=host \
-#         -a stdout -a stderr \
-#         -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
-#         -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
-#         -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
-#         -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
-#         -e JIRA_PAT="${JIRA_PAT}" \
-#         -v "${TEMPDIR}":/tmp:Z \
-#         "${CONTAINER_CLOUD_IMAGE_VAL}" \
-#         python cloud-image-val.py \
-#         -c /tmp/civ_config.yml \
-#         && RESULTS=1 || RESULTS=0
+# temporary workaround for
+# https://issues.redhat.com/browse/CLOUDX-488
+if nvrGreaterOrEqual "osbuild-composer" "83"; then
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
+        -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
+        -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+        -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-#     mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-# else
-#     RESULTS=1
-# fi
-
-RESULTS=1  # NOTE: remove when re-enabling CIV
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
+else
+    RESULTS=1
+fi
 
 # Also delete the compose so we don't run out of disk space
 sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null

--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -179,78 +179,75 @@ fi
 
 export BLOB_URL="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$AZURE_CONTAINER_NAME/$IMAGE_KEY.vhd"
 
-# CIV tests temporarily disabled.  See https://issues.redhat.com/browse/HMS-9868
-# greenprint "Pulling cloud-image-val container"
+greenprint "Pulling cloud-image-val container"
 
-# if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
-#   # If running on CIV, get dev container
-#   TAG=${CI_COMMIT_REF_SLUG}
-# elif ! nvrGreaterOrEqual "osbuild-composer" "151"; then
-#   # osbuild-composer v151 made changes in the Azure image definitions and CIV
-#   # was updated to check for those changes:
-#   # https://github.com/osbuild/cloud-image-val/pull/457
-#   # This tag does not include those changes, so use it when running against
-#   # older versions of composer.
-#   TAG="pr-456"
-# else
-#   # If not, get prod container
-#   TAG="prod"
-# fi
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+elif ! nvrGreaterOrEqual "osbuild-composer" "151"; then
+  # osbuild-composer v151 made changes in the Azure image definitions and CIV
+  # was updated to check for those changes:
+  # https://github.com/osbuild/cloud-image-val/pull/457
+  # This tag does not include those changes, so use it when running against
+  # older versions of composer.
+  TAG="pr-456"
+else
+  # If not, get prod container
+  TAG="prod"
+fi
 
-# CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val:$TAG"
 
-# sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
+sudo "${CONTAINER_RUNTIME}" pull "${CONTAINER_CLOUD_IMAGE_VAL}"
 
-# greenprint "Running cloud-image-val on generated image"
+greenprint "Running cloud-image-val on generated image"
 
-# tee "${TEMPDIR}/resource-file.json" <<EOF
-# {
-#   "subscription_id": "${AZURE_SUBSCRIPTION_ID}",
-#   "resource_group": "${AZURE_RESOURCE_GROUP}",
-#   "provider": "azure",
-#   "instances": [
-#     {
-#       "vhd_uri": "${BLOB_URL}",
-#       "arch": "${ARCH}",
-#       "location": "${AZURE_LOCATION}",
-#       "name": "${IMAGE_KEY}",
-#       "hyper_v_generation": "${HYPER_V_GEN}",
-#       "storage_account": "${AZURE_STORAGE_ACCOUNT}"
-#     }
-#   ]
-# }
-# EOF
+tee "${TEMPDIR}/resource-file.json" <<EOF
+{
+  "subscription_id": "${AZURE_SUBSCRIPTION_ID}",
+  "resource_group": "${AZURE_RESOURCE_GROUP}",
+  "provider": "azure",
+  "instances": [
+    {
+      "vhd_uri": "${BLOB_URL}",
+      "arch": "${ARCH}",
+      "location": "${AZURE_LOCATION}",
+      "name": "${IMAGE_KEY}",
+      "hyper_v_generation": "${HYPER_V_GEN}",
+      "storage_account": "${AZURE_STORAGE_ACCOUNT}"
+    }
+  ]
+}
+EOF
 
-# if [ -z "$CIV_CONFIG_FILE" ]; then
-#     redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
-#     exit 1
-# fi
+if [ -z "$CIV_CONFIG_FILE" ]; then
+    redprint "ERROR: please provide the variable CIV_CONFIG_FILE"
+    exit 1
+fi
 
-# cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
+cp "${CIV_CONFIG_FILE}" "${TEMPDIR}/civ_config.yml"
 
-# # temporary workaround for
-# # https://issues.redhat.com/browse/CLOUDX-488
-# if nvrGreaterOrEqual "osbuild-composer" "83"; then
-#     sudo "${CONTAINER_RUNTIME}" run \
-#         --net=host \
-#         -a stdout -a stderr \
-#         -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
-#         -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
-#         -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
-#         -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
-#         -e JIRA_PAT="${JIRA_PAT}" \
-#         -v "${TEMPDIR}":/tmp:Z \
-#         "${CONTAINER_CLOUD_IMAGE_VAL}" \
-#         python cloud-image-val.py \
-#         -c /tmp/civ_config.yml \
-#         && RESULTS=1 || RESULTS=0
+# temporary workaround for
+# https://issues.redhat.com/browse/CLOUDX-488
+if nvrGreaterOrEqual "osbuild-composer" "83"; then
+    sudo "${CONTAINER_RUNTIME}" run \
+        --net=host \
+        -a stdout -a stderr \
+        -e ARM_CLIENT_ID="${V2_AZURE_CLIENT_ID}" \
+        -e ARM_CLIENT_SECRET="${V2_AZURE_CLIENT_SECRET}" \
+        -e ARM_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID}" \
+        -e ARM_TENANT_ID="${AZURE_TENANT_ID}" \
+        -e JIRA_PAT="${JIRA_PAT}" \
+        -v "${TEMPDIR}":/tmp:Z \
+        "${CONTAINER_CLOUD_IMAGE_VAL}" \
+        python cloud-image-val.py \
+        -c /tmp/civ_config.yml \
+        && RESULTS=1 || RESULTS=0
 
-#     mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
-# else
-#     RESULTS=1
-# fi
-
-RESULTS=1  # NOTE: remove when re-enabling CIV
+    mv "${TEMPDIR}"/report.html "${ARTIFACTS}"
+else
+    RESULTS=1
+fi
 
 # Also delete the compose so we don't run out of disk space
 sudo composer-cli compose delete "${COMPOSE_ID}" > /dev/null


### PR DESCRIPTION
This reverts commit 23594710227e4d60631b0aa4ed4957503df390d7.

---

We disabled CIV a while ago because it was failing on some cloud configuration issue.  Let's re-enable it and fix any issues it has now that we have a bit more capacity.