### PR TITLE
depsolve: add rhui flag to skip RHSM cert lookup for cloud RHUI repos

### DIFF
--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -664,6 +664,7 @@ type DepsolvedRepoConfig struct {
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 	PackageSets    []string `json:"package_sets,omitempty"`

--- a/internal/worker/json_test.go
+++ b/internal/worker/json_test.go
@@ -918,6 +918,14 @@ func TestDepsolvedRepoConfigJSONRoundtrip(t *testing.T) {
 				SSLClientCert:  "/etc/pki/client.crt",
 			},
 		},
+		{
+			name: "rhui",
+			config: DepsolvedRepoConfig{
+				Id:       "rhel-8-baseos-rhui-rpms",
+				BaseURLs: []string{"https://rhui.us-east-1.aws.ce.redhat.com/baseos"},
+				RHUI:     true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -952,6 +960,14 @@ func TestDepsolvedRepoConfigRPMMDConversion(t *testing.T) {
 				CheckGPG:  common.ToPtr(true),
 				IgnoreSSL: common.ToPtr(false),
 				RHSM:      true,
+			},
+		},
+		{
+			name: "rhui",
+			config: rpmmd.RepoConfig{
+				Id:       "rhel-8-baseos-rhui-rpms",
+				BaseURLs: []string{"https://rhui.us-east-1.aws.ce.redhat.com/baseos"},
+				RHUI:     true,
 			},
 		},
 	}

--- a/vendor/github.com/osbuild/images/pkg/depsolvednf/depsolvednf.go
+++ b/vendor/github.com/osbuild/images/pkg/depsolvednf/depsolvednf.go
@@ -446,16 +446,23 @@ func (s *Solver) SearchMetadata(repos []rpmmd.RepoConfig, packages []string) (rp
 	return pkgs, nil
 }
 
-// applyRHSMSecrets overrides the Secrets field on packages from RHSM repos.
+// applyRHSMSecrets overrides the Secrets field on packages from RHSM or RHUI repos.
 // The activeHandler sets "org.osbuild.mtls" for repos with SSLClientKey,
-// but RHSM repos need "org.osbuild.rhsm" instead.
+// but RHSM repos need "org.osbuild.rhsm" and RHUI repos need "org.osbuild.rhui" instead.
 func applyRHSMSecrets(pkgs rpmmd.PackageList, repos []rpmmd.RepoConfig) {
-	rhsmRepos := make(map[string]bool)
+	type repoFlags struct {
+		rhsm bool
+		rhui bool
+	}
+	repoMap := make(map[string]repoFlags)
 	for _, repo := range repos {
-		rhsmRepos[repo.Hash()] = repo.RHSM
+		repoMap[repo.Hash()] = repoFlags{rhsm: repo.RHSM, rhui: repo.RHUI}
 	}
 	for i := range pkgs {
-		if rhsmRepos[pkgs[i].RepoID] {
+		flags := repoMap[pkgs[i].RepoID]
+		if flags.rhui {
+			pkgs[i].Secrets = "org.osbuild.rhui"
+		} else if flags.rhsm {
 			pkgs[i].Secrets = "org.osbuild.rhsm"
 		}
 	}
@@ -505,11 +512,13 @@ func validatePackageSetRepoChain(pkgSets []rpmmd.PackageSet) error {
 }
 
 // validateSubscriptionsForRepos checks that RHSM subscriptions are available
-// for any repositories that require them.
+// for any repositories that require them. Repositories with RHUI set to true
+// are skipped since they use cloud instance identity for authentication
+// instead of RHSM entitlement certificates.
 func validateSubscriptionsForRepos(pkgSets []rpmmd.PackageSet, haveSubscriptions bool, subsErr error) error {
 	for _, ps := range pkgSets {
 		for _, repo := range ps.Repositories {
-			if repo.RHSM && !haveSubscriptions {
+			if repo.RHSM && !repo.RHUI && !haveSubscriptions {
 				return fmt.Errorf("This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources (error details: %w)", subsErr)
 			}
 		}

--- a/vendor/github.com/osbuild/images/pkg/depsolvednf/v2.go
+++ b/vendor/github.com/osbuild/images/pkg/depsolvednf/v2.go
@@ -47,6 +47,7 @@ type v2Repository struct {
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 }
 
 // v2Package represents an RPM package with full metadata.
@@ -429,7 +430,12 @@ func (h *v2Handler) reposFromRPMMD(cfg *solverConfig, rpmRepos []rpmmd.RepoConfi
 			dr.SSLVerify = common.ToPtr(!*rr.IgnoreSSL)
 		}
 
-		if rr.RHSM {
+		if rr.RHUI {
+			// RHUI repos delegate secret discovery to osbuild-depsolve-dnf.
+			// The Python solver reads the host RHUI repo files and discovers
+			// SSL certs from /etc/pki/rhui/ directly.
+			dr.RHUI = true
+		} else if rr.RHSM {
 			// TODO: Enable V2 RHSM secrets discovery by setting dr.RHSM = true
 			// and removing the client-side secrets resolution below.
 			// This requires functional testing to ensure RHSM secrets discovery

--- a/vendor/github.com/osbuild/images/pkg/osbuild/curl_source.go
+++ b/vendor/github.com/osbuild/images/pkg/osbuild/curl_source.go
@@ -45,6 +45,10 @@ func NewCurlPackageItem(pkg rpmmd.Package) (CurlSourceItem, error) {
 		item.Secrets = &URLSecrets{
 			Name: "org.osbuild.rhsm",
 		}
+	case "org.osbuild.rhui":
+		item.Secrets = &URLSecrets{
+			Name: "org.osbuild.rhui",
+		}
 	case "org.osbuild.mtls":
 		item.Secrets = &URLSecrets{
 			Name: "org.osbuild.mtls",

--- a/vendor/github.com/osbuild/images/pkg/rpmmd/repository.go
+++ b/vendor/github.com/osbuild/images/pkg/rpmmd/repository.go
@@ -24,6 +24,7 @@ type repository struct {
 	CheckGPG       bool     `json:"check_gpg,omitempty"`
 	IgnoreSSL      bool     `json:"ignore_ssl,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
@@ -83,6 +84,7 @@ type RepoConfig struct {
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ModuleHotfixes *bool    `json:"module_hotfixes,omitempty"`
 	RHSM           bool     `json:"rhsm,omitempty"`
+	RHUI           bool     `json:"rhui,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
 	PackageSets    []string `json:"package_sets,omitempty"`
@@ -119,6 +121,7 @@ func (r *RepoConfig) Hash() string {
 		bpts(r.IgnoreSSL)+
 		r.MetadataExpire+
 		bts(r.RHSM)+
+		bts(r.RHUI)+
 		bpts(r.ModuleHotfixes)+
 		r.SSLCACert+
 		r.SSLClientKey+
@@ -164,6 +167,7 @@ func LoadRepositoriesFromReader(r io.Reader) (map[string][]RepoConfig, error) {
 				GPGKeys:        keys,
 				CheckGPG:       &repo.CheckGPG,
 				RHSM:           repo.RHSM,
+				RHUI:           repo.RHUI,
 				MetadataExpire: repo.MetadataExpire,
 				ModuleHotfixes: repo.ModuleHotfixes,
 				ImageTypeTags:  repo.ImageTypeTags,


### PR DESCRIPTION
## Summary

Adds RHUI support to osbuild-composer so that the worker can generate manifests that use `org.osbuild.rhui` secrets for RPM downloads on cloud instances.

Closes #5028
Related: osbuild/osbuild-composer#820 (original report, closed as stale), osbuild/osbuild#2355 (companion osbuild changes), osbuild/images#2208 (companion images changes)

## Dependencies

This PR depends on two upstream PRs that must merge first:

1. **osbuild/images#2208** — adds `RHUI bool` to `RepoConfig`, `case "org.osbuild.rhui"` to `NewCurlPackageItem()`, and RHUI handling in `depsolvednf`
2. **osbuild/osbuild#2355** — adds the `org.osbuild.rhui` secrets provider, cloud provider detection, and identity header support

After osbuild/images#2208 merges, this PR will need an images dependency bump (`go mod vendor`) to pull in the RHUI changes, replacing the direct vendor edits currently included here.

## Changes

### `depsolve: add rhui flag to skip RHSM cert lookup for cloud RHUI repos`

- Add `RHUI bool` field to `DepsolvedRepoConfig` in `internal/worker/json.go` with JSON serialization support
- Add RHUI test cases to `TestDepsolvedRepoConfigJSONRoundtrip` and `TestDepsolvedRepoConfigRPMMDConversion`
- *Vendor changes (temporary, will be replaced by images bump):*
  - `curl_source.go` — add `case "org.osbuild.rhui"`
  - `repository.go` — add `RHUI bool` to `RepoConfig`
  - `depsolvednf.go` — RHUI secrets and subscription validation
  - `v2.go` — pass RHUI flag to solver

## Test plan

- [x] Unit tests for JSON round-trip with RHUI repos
- [x] Unit tests for RPMMD conversion with RHUI repos
- [x] Tested end-to-end on AWS EC2 RHEL 8 Cloud Access instance — successfully built a 10GB qcow2 image using RHUI repos

## Stopgap

Until this is merged, users can use [osbuild-rhui-shim](https://github.com/brandonrc/osbuild-rhui-shim) as a workaround.