### PR TITLE
dev: add bootc-dev helper script

### DIFF
--- a/Containerfile.devel
+++ b/Containerfile.devel
@@ -1,0 +1,86 @@
+FROM quay.io/fedora/fedora-bootc:latest AS baseos
+
+COPY osbuild-composer.spec osbuild-composer.spec
+
+RUN <<EORUN
+set -ex
+
+# Install composer plus useful utilities for development.
+dnf -y install osbuild osbuild-composer composer-cli osbuild-depsolve-dnf \
+    dnf-plugins-core rpm-build spectool redhat-rpm-config dnf5-plugins \
+    policycoreutils-python-utils socat
+
+# Install build dependencies for osbuild-composer just in case a rebuild is needed.
+dnf -y builddep osbuild-composer.spec
+
+# Enable osbuild-composer socket and set root password.
+systemctl enable osbuild-composer.socket
+echo "root:redhat" | chpasswd
+
+# Disable services which are not needed for development in host network.
+systemctl mask \
+    avahi-daemon.service \
+    avahi-daemon.socket \
+    NetworkManager.service \
+    NetworkManager-wait-online.service \
+    auditd.service \
+    systemd-hostnamed.service \
+    systemd-resolved.service \
+    firewalld.service \
+    fedora-readonly.service \
+    bootloader-update.service
+
+# Create HTTP bridges forCloudAPI -> 6061, Job -> 6062, Weldr -> 6063
+declare -A BRIDGES=( 
+    ["cloudapi"]="6061:/run/cloudapi/api.socket:osbuild-composer.socket" 
+    ["job"]="6062:/run/osbuild-composer/job.socket:osbuild-local-worker.socket" 
+    ["weldr"]="6063:/run/weldr/api.socket:osbuild-composer.socket" 
+)
+
+for NAME in "${!BRIDGES[@]}"; do
+    DATA="${BRIDGES[$NAME]}"
+    PORT="${DATA%%:*}"
+    REST="${DATA#*:}"
+    SOCK="${REST%%:*}"
+    UNIT="${REST#*:}"
+
+    cat <<EOF > /etc/systemd/system/socat-${NAME}.service
+[Unit]
+Description=Socat for osbuild-composer ${NAME}
+After=${UNIT}
+Requires=${UNIT}
+
+[Service]
+ExecStart=/usr/bin/socat TCP-LISTEN:${PORT},reuseaddr,fork UNIX-CONNECT:${SOCK}
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl enable socat-${NAME}.service
+done
+EORUN
+
+# Copy SSH public key to authorized_keys if it exists and configure SSH port.
+# Alghouth the intention is to run this via podman, update SELinux policy just
+# in case someone runs this in a VM.
+RUN --mount=type=secret,id=ssh_pubkey <<EORUN
+set -ex
+mkdir -p /var/roothome/.ssh
+chmod 700 /var/roothome
+
+if [ -f /run/secrets/ssh_pubkey ]; then
+    cat /run/secrets/ssh_pubkey > /var/roothome/.ssh/authorized_keys
+    chmod 600 /var/roothome/.ssh/authorized_keys
+    chown -R root:root /var/roothome/.ssh
+fi
+
+sed -i 's/#Port 22/Port 222/' /etc/ssh/sshd_config
+sed -i 's/#UseDNS yes/UseDNS no/' /etc/ssh/sshd_config
+echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+echo "PrintMotd no" >> /etc/ssh/sshd_config
+echo "PrintLastLog no" >> /etc/ssh/sshd_config
+semanage port -a -t ssh_port_t -p tcp 222
+EORUN

--- a/HACKING.md
+++ b/HACKING.md
@@ -71,6 +71,28 @@ The containers are a good way to quickly test small changes, but before
 submitting a Pull Request, it's recommended to run through all the tests using
 the [Virtual Machine](#virtual-machine) setup described above.
 
+## Bootable dev container
+
+The `Containerfile.devel` contains a Fedora-based bootc image definition that installs osbuild and its (build) dependencies, configures ssh to listen on port 222 so it can be easily started in podman host network, adds host machine ssh public keys, sets root password, exposes composer and workers through TCP and prepares the container to be either booted in podman or in a VM.
+
+This can be used as a development box to test changes, a helper script `bootc-dev` is provided.
+
+### Usage
+
+From the repository root, `./bootc-dev` manages a Podman container named `composer-git` built from `Containerfile.devel`. The container runs privileged with systemd and host networking (so HTTP bridges on 6061–6063 and SSH on 222 match the host).
+
+- **`build`** — Build the image with from `Containerfile.devel`. If `~/.ssh/id_rsa.pub` exists, it is passed as a build secret so root can log in via SSH with your key; otherwise root password `redhat` can be used.
+- **`start`** — Start the container in the background (`podman run -d …`) with host network configuration.
+- **`stop`** — Stop the container and remove it.
+- **`restart`** — Same as stop then start.
+- **`remove`** — Remove the container (`podman rm`); stop it first if it is still running.
+- **`logs`** — Follow journal lines inside the container; any extra arguments are passed to `journalctl`.
+- **`copy`** — On the host, build composer/worker/executor, `scp` it to the bootable container and restart services.
+- **`cli`** — Run `composer-cli` inside the container; pass subcommands and flags after `cli` (e.g. `./bootc-dev cli status show`).
+- **`ssh`** — Open an SSH session (or run a remote command) as `root@localhost` on port `222`, with host key checks disabled for convenience.
+
+To connect to the container, use `ssh -p 222 root@localhost`.
+
 ### Build and run
 
 To build the containers run:

--- a/bootc-dev
+++ b/bootc-dev
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+PUBKEY=$HOME/.ssh/id_rsa.pub
+NAME=composer-git
+CMD=$1
+
+function start() {
+    podman run -d --name $NAME --privileged --systemd=always --network=host --hostname $NAME $NAME
+}
+
+function sshcmd() {
+    ssh -p 222 -o GSSAPIAuthentication=no -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR root@localhost "$@"
+}
+
+if [ "$CMD" == "build" ]; then
+    if [ -f "$PUBKEY" ]; then
+        podman build --secret "id=ssh_pubkey,src=$PUBKEY" -f Containerfile.devel -t "$NAME" .
+    else
+        podman build -f Containerfile.devel -t $NAME .
+    fi
+elif [ "$CMD" == "start" ]; then
+    start
+elif [ "$CMD" == "stop" ]; then
+    podman stop $NAME
+    podman rm $NAME
+elif [ "$CMD" == "restart" ]; then
+    podman stop $NAME
+    podman rm $NAME
+    start
+elif [ "$CMD" == "remove" ]; then
+    podman rm $NAME
+elif [ "$CMD" == "logs" ]; then
+    if shift && [ $# -eq 0 ]; then
+        podman exec -it $NAME /usr/bin/journalctl -f -n 50
+    else
+        podman exec -it $NAME /usr/bin/journalctl "$@"
+    fi
+elif [ "$CMD" == "copy" ]; then
+    for BIN in osbuild-composer osbuild-worker osbuild-worker-executor; do
+        go build -o bin/$BIN ./cmd/$BIN/
+        podman cp bin/$BIN $NAME:/usr/libexec/osbuild-composer/$BIN
+    done
+    sshcmd "systemctl restart osbuild-composer.service osbuild-worker@1.service"
+elif [ "$CMD" == "cli" ]; then
+    shift
+    podman exec -it $NAME /usr/bin/composer-cli "$@"
+elif [ "$CMD" == "ssh" ]; then
+    shift
+    sshcmd "$@"
+else
+    echo "Usage: $0 <build|start|stop|restart|remove|copy|logs|ssh>"
+    exit 1
+fi


### PR DESCRIPTION
## Bootable dev container

The `Containerfile.devel` contains a Fedora-based bootc image definition that installs osbuild and its (build) dependencies, configures ssh to listen on port 222 so it can be easily started in podman host network, adds host machine ssh public keys, sets root password, exposes composer and workers through TCP and prepares the container to be either booted in podman or in a VM.

This can be used as a development box to test changes, a helper script `bootc-dev` is provided.

### Usage

From the repository root, `./bootc-dev` manages a Podman container named `composer-git` built from `Containerfile.devel`. The container runs privileged with systemd and host networking (so HTTP bridges on 6061–6063 and SSH on 222 match the host).

- **`build`** — Build the image with from `Containerfile.devel`. If `~/.ssh/id_rsa.pub` exists, it is passed as a build secret so root can log in via SSH with your key; otherwise root password `redhat` can be used.
- **`start`** — Start the container in the background (`podman run -d …`) with host network configuration.
- **`stop`** — Stop the container and remove it.
- **`restart`** — Same as stop then start.
- **`remove`** — Remove the container (`podman rm`); stop it first if it is still running.
- **`logs`** — Follow journal lines inside the container; any extra arguments are passed to `journalctl`.
- **`copy`** — On the host, build composer/worker/executor, `scp` it to the bootable container and restart services.
- **`cli`** — Run `composer-cli` inside the container; pass subcommands and flags after `cli` (e.g. `./bootc-dev cli status show`).
- **`ssh`** — Open an SSH session (or run a remote command) as `root@localhost` on port `222`, with host key checks disabled for convenience.

To connect to the container, use `ssh -p 222 root@localhost`.

---

I noticed we have several development setups, I would like to do a cleanup. So who uses what? I will add followup commits to this PR with deleting unused ones.