### PR TITLE
templates/packer: add container registries init script

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/container_registries_login.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/container_registries_login.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+source /tmp/cloud_init_vars
+
+echo "Login to container registries."
+
+CONTAINER_REGISTRIES_LOGIN_ARN=${CONTAINER_REGISTRIES_LOGIN_ARN:-}
+if [[ -z "$CONTAINER_REGISTRIES_LOGIN_ARN" ]]; then
+  echo "CONTAINER_REGISTRIES_LOGIN_ARN not defined, skipping."
+  exit 0
+fi
+
+/usr/local/bin/aws secretsmanager get-secret-value \
+  --endpoint-url "${SECRETS_MANAGER_ENDPOINT_URL}" \
+  --secret-id "${CONTAINER_REGISTRIES_LOGIN_ARN}" | jq -r ".SecretString" > /tmp/container_registries_login.json
+trap "rm -f /tmp/container_registries_login.json" EXIT
+
+for key in $(jq -r 'keys[]' /tmp/container_registries_login.json); do
+    USER=$(jq -r .[\""$key"\"].username /tmp/container_registries_login.json)
+
+    echo "Logging in to container registry $key (username: $USER)."
+
+    PASSWORD=$(jq -r .[\""$key"\"].password /tmp/container_registries_login.json)
+    echo "$PASSWORD" | sudo podman login --username="$USER" --password-stdin "$key"
+done

--- a/templates/packer/ansible/roles/common/files/worker-initialization.service
+++ b/templates/packer/ansible/roles/common/files/worker-initialization.service
@@ -21,6 +21,7 @@ ExecStart=/usr/local/libexec/worker-initialization-scripts/get_gcp_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_koji_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_oci_creds.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/get_ldap_sa_mtls_creds.sh
+ExecStart=/usr/local/libexec/worker-initialization-scripts/container_registries_login.sh
 ExecStart=/usr/local/libexec/worker-initialization-scripts/worker_service.sh
 ExecStopPost=/usr/local/libexec/worker-initialization-scripts/on_exit.sh
 


### PR DESCRIPTION
This script logs into container registries during the worker initialization. The structure of the secret should be:
```
{
  "registry.io": {
    "user": "username",
    "password": "password"
  }
}
```