### PR TITLE
Make bootc container source type configurable (HMS-10262)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,7 @@ API-bootc:
     matrix:
       - RUNNER:
           - aws/centos-stream-9-x86_64
+        BOOTC_USE_REMOTE_CONTAINER_SOURCE: ["true", "false"]
 
 Packer:
   stage: test

--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -170,8 +170,9 @@ func (c *Composer) InitMetricsAPI(prometheus net.Listener) {
 
 func (c *Composer) InitAPI(cert, key string, enableTLS bool, enableMTLS bool, enableJWT bool, l net.Listener) error {
 	config := v2.ServerConfig{
-		JWTEnabled:           c.config.Koji.EnableJWT,
-		TenantProviderFields: c.config.Koji.JWTTenantProviderFields,
+		JWTEnabled:                    c.config.Koji.EnableJWT,
+		TenantProviderFields:          c.config.Koji.JWTTenantProviderFields,
+		BootcUseRemoteContainerSource: c.config.Bootc.UseRemoteContainerSource,
 	}
 
 	// handle experimental image-builder manifest generation option using the

--- a/cmd/osbuild-composer/config.go
+++ b/cmd/osbuild-composer/config.go
@@ -15,6 +15,7 @@ type ComposerConfigFile struct {
 	Koji               KojiAPIConfig     `toml:"koji"`
 	Worker             WorkerAPIConfig   `toml:"worker"`
 	WeldrAPI           WeldrAPIConfig    `toml:"weldr_api"`
+	Bootc              BootcConfig       `toml:"bootc"`
 	DistroAliases      map[string]string `toml:"distro_aliases" env:"DISTRO_ALIASES"`
 	LogLevel           string            `toml:"log_level"`
 	LogFormat          string            `toml:"log_format"`
@@ -68,6 +69,11 @@ type WeldrAPIConfig struct {
 
 type WeldrDistroConfig struct {
 	ImageTypeDenyList []string `toml:"image_type_denylist"`
+}
+
+// BootcConfig holds configuration options specific to bootc composes.
+type BootcConfig struct {
+	UseRemoteContainerSource bool `toml:"use_remote_container_source" env:"BOOTC_USE_REMOTE_CONTAINER_SOURCE"`
 }
 
 // weldrDistrosImageTypeDenyList returns a map of distro-specific Image Type
@@ -168,6 +174,19 @@ func envStrToMap(s string) (map[string]string, error) {
 	return result, nil
 }
 
+// lookupEnvTagValue looks up the value of the env tag in the environment variables
+func lookupEnvTagValue(fieldT reflect.StructField) (string, bool) {
+	key, ok := fieldT.Tag.Lookup("env")
+	if !ok {
+		return "", false
+	}
+	confV, ok := os.LookupEnv(key)
+	if !ok {
+		return "", false
+	}
+	return confV, true
+}
+
 func loadConfigFromEnv(intf interface{}) error {
 	t := reflect.TypeOf(intf).Elem()
 	v := reflect.ValueOf(intf).Elem()
@@ -179,21 +198,13 @@ func loadConfigFromEnv(intf interface{}) error {
 
 		switch kind {
 		case reflect.String:
-			key, ok := fieldT.Tag.Lookup("env")
-			if !ok {
-				continue
-			}
-			confV, ok := os.LookupEnv(key)
+			confV, ok := lookupEnvTagValue(fieldT)
 			if !ok {
 				continue
 			}
 			fieldV.SetString(confV)
 		case reflect.Int:
-			key, ok := fieldT.Tag.Lookup("env")
-			if !ok {
-				continue
-			}
-			confV, ok := os.LookupEnv(key)
+			confV, ok := lookupEnvTagValue(fieldT)
 			if !ok {
 				continue
 			}
@@ -203,23 +214,26 @@ func loadConfigFromEnv(intf interface{}) error {
 			}
 			fieldV.SetInt(value)
 		case reflect.Bool:
-			// no-op
-			continue
+			confV, ok := lookupEnvTagValue(fieldT)
+			if !ok {
+				continue
+			}
+			value, err := strconv.ParseBool(confV)
+			if err != nil {
+				return err
+			}
+			fieldV.SetBool(value)
 		case reflect.Slice:
 			// no-op
 			continue
 		case reflect.Map:
-			key, ok := fieldT.Tag.Lookup("env")
+			confV, ok := lookupEnvTagValue(fieldT)
 			if !ok {
 				continue
 			}
 			// handle only map[string]string
 			if fieldV.Type().Key().Kind() != reflect.String || fieldV.Type().Elem().Kind() != reflect.String {
 				return fmt.Errorf("Unsupported map type for loading from ENV: %s", kind)
-			}
-			confV, ok := os.LookupEnv(key)
-			if !ok {
-				continue
 			}
 			value, err := envStrToMap(confV)
 			if err != nil {

--- a/cmd/osbuild-composer/config_test.go
+++ b/cmd/osbuild-composer/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -78,6 +79,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, expectedDistroAliases, defaultConfig.DistroAliases)
 
 	require.Equal(t, "journal", defaultConfig.LogFormat)
+	require.Equal(t, BootcConfig{}, defaultConfig.Bootc)
 }
 
 func TestConfig(t *testing.T) {
@@ -96,12 +98,6 @@ func TestConfig(t *testing.T) {
 
 	require.Equal(t, "overwrite-me-db", config.Worker.PGDatabase)
 
-	require.NoError(t, os.Setenv("PGDATABASE", "composer-db"))
-	config, err = LoadConfig("testdata/test.toml")
-	require.NoError(t, err)
-	require.NotNil(t, config)
-	require.Equal(t, "composer-db", config.Worker.PGDatabase)
-
 	require.False(t, config.Koji.EnableJWT)
 	require.Equal(t, []string{"https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs"}, config.Koji.JWTKeysURLs)
 	require.Equal(t, "", config.Koji.JWTKeysCA)
@@ -115,6 +111,20 @@ func TestConfig(t *testing.T) {
 		"rhel-9":  "rhel-9.3",
 	}
 	require.Equal(t, expectedDistroAliases, config.DistroAliases)
+	require.True(t, config.Bootc.UseRemoteContainerSource)
+
+	// Test overriding the config file with environment variables
+	require.NoError(t, os.Setenv("PGDATABASE", "composer-db"))
+	// NOTE: use negated config value to ensure that the env variable overrides the config file value
+	require.NoError(t, os.Setenv("BOOTC_USE_REMOTE_CONTAINER_SOURCE", strconv.FormatBool(!config.Bootc.UseRemoteContainerSource)))
+
+	// Reload the config from the file and verify that the env variables take precedence
+	config, err = LoadConfig("testdata/test.toml")
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	require.Equal(t, "composer-db", config.Worker.PGDatabase)
+	require.False(t, config.Bootc.UseRemoteContainerSource)
 }
 
 func TestWeldrDistrosImageTypeDenyList(t *testing.T) {

--- a/cmd/osbuild-composer/testdata/test.toml
+++ b/cmd/osbuild-composer/testdata/test.toml
@@ -22,3 +22,6 @@ image_type_denylist = [ "qcow2" ]
 [distro_aliases]
 rhel-8 = "rhel-8.9"
 rhel-9 = "rhel-9.3"
+
+[bootc]
+use_remote_container_source = true

--- a/internal/cloudapi/v2/bootc_premanifest_test.go
+++ b/internal/cloudapi/v2/bootc_premanifest_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/osbuild/images/pkg/arch"
 	"github.com/osbuild/images/pkg/bib/osinfo"
+	"github.com/osbuild/images/pkg/distro"
 	"github.com/osbuild/images/pkg/manifest"
 	v2 "github.com/osbuild/osbuild-composer/internal/cloudapi/v2"
 	"github.com/osbuild/osbuild-composer/internal/common"
@@ -279,7 +280,7 @@ func TestHandleBootcPreManifest_Errors(t *testing.T) {
 // enqueuePreManifestWithResolvedDep enqueues a bootc info-resolve job,
 // finishes it with a valid result, and enqueues a pre-manifest job that
 // depends on it. Returns the pre-manifest job ID.
-func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec) uuid.UUID {
+func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec, io distro.ImageOptions) uuid.UUID {
 	t.Helper()
 	infoResolveJob := &worker.BootcInfoResolveJob{
 		Specs: specs,
@@ -291,6 +292,7 @@ func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch str
 		ImageType:                  "qcow2",
 		Seed:                       42,
 		BootcInfoResolveDynArgsIdx: common.ToPtr(0),
+		ImageOptions:               io,
 	}
 	preManifestJobID, err := ws.EnqueueBootcPreManifestJob(
 		preManifestJob, []uuid.UUID{infoResolveJobID}, "",
@@ -312,15 +314,21 @@ func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch str
 // assertValidPreManifestResult checks that a BootcPreManifestJobResult
 // completed without error and contains the expected container resolve data
 // for the test fixture container (centos-bootc:stream9 on x86_64).
-func assertValidPreManifestResult(t *testing.T, result worker.BootcPreManifestJobResult, arch string, specs []worker.BootcInfoResolveJobSpec) {
+func assertValidPreManifestResult(t *testing.T, result worker.BootcPreManifestJobResult, arch string, specs []worker.BootcInfoResolveJobSpec, useRemoteContainerSource bool) {
 	t.Helper()
 
 	require.Nil(t, result.JobError, "expected no job error, got: %v", result.JobError)
-
 	assert.Equal(t, arch, result.ContainerResolveJobArgs.Arch)
 	assert.Len(t, result.ContainerResolveJobArgs.PipelineSpecs, 2, "expected 2 pipelines specs")
 	assert.Len(t, result.ContainerResolveJobArgs.PipelineSpecs["image"], 1, "expected 1 container spec in image pipeline")
 	assert.Len(t, result.ContainerResolveJobArgs.PipelineSpecs["build"], 1, "expected 1 container spec in build pipeline")
+
+	// verify that all specs have the appropriate Local setting, based on the useRemoteContainerSource flag
+	for _, pipelineSpecs := range result.ContainerResolveJobArgs.PipelineSpecs {
+		for _, pipelineSpec := range pipelineSpecs {
+			assert.Equal(t, !useRemoteContainerSource, pipelineSpec.Local)
+		}
+	}
 
 	// Verify that all container refs from BootcInfoResolveJobSpec are present
 	// in the container resolve job results for at least one pipeline.
@@ -344,46 +352,68 @@ func assertValidPreManifestResult(t *testing.T, result worker.BootcPreManifestJo
 // dependency, and verify the job finishes successfully. Without going
 // through the loop.
 func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
-	workerServer := newTestWorkerServer(t)
-	specs := []worker.BootcInfoResolveJobSpec{
+	testCases := []struct {
+		name                     string
+		useRemoteContainerSource bool
+	}{
 		{
-			Ref:         "quay.io/centos-bootc/centos-bootc:stream9",
-			ResolveMode: worker.BootcInfoResolveModeFull,
+			name:                     "default/local_container_source",
+			useRemoteContainerSource: false,
+		},
+		{
+			name:                     "remote_container_source",
+			useRemoteContainerSource: true,
 		},
 	}
-	archi := arch.ARCH_X86_64.String()
-	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs)
 
-	// Dequeue the pre-manifest job (it should be pending now)
-	jobID, preManifestToken, _, staticArgs, dynArgs, err := workerServer.RequestJob(
-		context.Background(), "",
-		[]string{worker.JobTypeBootcPreManifest}, []string{""}, uuid.Nil,
-	)
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workerServer := newTestWorkerServer(t)
+			specs := []worker.BootcInfoResolveJobSpec{
+				{
+					Ref:         "quay.io/centos-bootc/centos-bootc:stream9",
+					ResolveMode: worker.BootcInfoResolveModeFull,
+				},
+			}
+			archi := arch.ARCH_X86_64.String()
+			preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{
+				Bootc: &distro.BootcImageOptions{
+					UseRemoteContainerSource: tc.useRemoteContainerSource,
+				},
+			})
 
-	// Call the handler
-	v2.HandleBootcPreManifest(workerServer, jobID, preManifestToken, staticArgs, dynArgs)
+			// Dequeue the pre-manifest job (it should be pending now)
+			jobID, preManifestToken, _, staticArgs, dynArgs, err := workerServer.RequestJob(
+				context.Background(), "",
+				[]string{worker.JobTypeBootcPreManifest}, []string{""}, uuid.Nil,
+			)
+			require.NoError(t, err)
 
-	// Verify the job finished successfully
-	var readResult worker.BootcPreManifestJobResult
-	jobInfo, err := workerServer.BootcPreManifestJobInfo(preManifestJobID, &readResult)
-	require.NoError(t, err)
-	require.NotNil(t, jobInfo)
-	assert.False(t, jobInfo.JobStatus.Finished.IsZero(), "job should be finished")
+			// Call the handler
+			v2.HandleBootcPreManifest(workerServer, jobID, preManifestToken, staticArgs, dynArgs)
 
-	assertValidPreManifestResult(t, readResult, archi, specs)
+			// Verify the job finished successfully
+			var readResult worker.BootcPreManifestJobResult
+			jobInfo, err := workerServer.BootcPreManifestJobInfo(preManifestJobID, &readResult)
+			require.NoError(t, err)
+			require.NotNil(t, jobInfo)
+			assert.False(t, jobInfo.JobStatus.Finished.IsZero(), "job should be finished")
 
-	// Verify ManifestInfo is populated
-	assert.Equal(t, common.BuildVersion(), readResult.ManifestInfo.OSBuildComposerVersion)
-	// OSBuildComposerDeps may be nil in tests. See https://github.com/golang/go/issues/33976
-	if readResult.ManifestInfo.OSBuildComposerDeps != nil {
-		assert.Len(t, readResult.ManifestInfo.OSBuildComposerDeps, 1)
-		assert.Equal(t, "github.com/osbuild/images", readResult.ManifestInfo.OSBuildComposerDeps[0].Path)
-		assert.NotEmpty(t, readResult.ManifestInfo.OSBuildComposerDeps[0].Version)
+			assertValidPreManifestResult(t, readResult, archi, specs, tc.useRemoteContainerSource)
+
+			// Verify ManifestInfo is populated
+			assert.Equal(t, common.BuildVersion(), readResult.ManifestInfo.OSBuildComposerVersion)
+			// OSBuildComposerDeps may be nil in tests. See https://github.com/golang/go/issues/33976
+			if readResult.ManifestInfo.OSBuildComposerDeps != nil {
+				assert.Len(t, readResult.ManifestInfo.OSBuildComposerDeps, 1)
+				assert.Equal(t, "github.com/osbuild/images", readResult.ManifestInfo.OSBuildComposerDeps[0].Path)
+				assert.NotEmpty(t, readResult.ManifestInfo.OSBuildComposerDeps[0].Version)
+			}
+			assert.NotNil(t, readResult.ManifestInfo.PipelineNames)
+			assert.NotEmpty(t, readResult.ManifestInfo.PipelineNames.Build)
+			assert.NotEmpty(t, readResult.ManifestInfo.PipelineNames.Payload)
+		})
 	}
-	assert.NotNil(t, readResult.ManifestInfo.PipelineNames)
-	assert.NotEmpty(t, readResult.ManifestInfo.PipelineNames.Build)
-	assert.NotEmpty(t, readResult.ManifestInfo.PipelineNames.Payload)
 }
 
 // TestBootcPreManifestLoop_PicksUpJob tests the full loop lifecycle:
@@ -405,7 +435,7 @@ func TestBootcPreManifestLoop_PicksUpJob(t *testing.T) {
 	}
 	archi := arch.ARCH_X86_64.String()
 
-	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs)
+	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{})
 
 	// Wait for the loop to pick up and finish the pre-manifest job.
 	// Poll with timeout.
@@ -422,7 +452,7 @@ func TestBootcPreManifestLoop_PicksUpJob(t *testing.T) {
 		var readResult worker.BootcPreManifestJobResult
 		jobInfo, err := workerServer.BootcPreManifestJobInfo(preManifestJobID, &readResult)
 		if err == nil && !jobInfo.JobStatus.Finished.IsZero() {
-			assertValidPreManifestResult(t, readResult, archi, specs)
+			assertValidPreManifestResult(t, readResult, archi, specs, false)
 			return
 		}
 

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -80,6 +80,8 @@ type ServerConfig struct {
 	//
 	//     IMAGE_BUILDER_EXPERIMENTAL="image-builder-manifest-generation"
 	ImageBuilderManifestGeneration bool
+
+	BootcUseRemoteContainerSource bool
 }
 
 func NewServer(workers *worker.Server, distros *distrofactory.Factory, repos *reporegistry.RepoRegistry, config ServerConfig) *Server {
@@ -609,10 +611,9 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 	seed := bigSeed.Int64()
 
 	// Construct ImageOptions once — used by both BootcPreManifest and ManifestByID.
-	// UseRemoteContainerSource: on-prem uses local podman storage (false).
 	imageOptions := distro.ImageOptions{
 		Bootc: &distro.BootcImageOptions{
-			UseRemoteContainerSource: false,
+			UseRemoteContainerSource: s.config.BootcUseRemoteContainerSource,
 		},
 	}
 

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -329,9 +329,10 @@ func mockSearch(t *testing.T, workerServer *worker.Server, wg *sync.WaitGroup, f
 }
 
 type v2ServerOpts struct {
-	enableJWT  bool
-	fail       bool
-	ibManifest bool // use image-builder-manifest job instead of manifest-id-only
+	enableJWT                     bool
+	fail                          bool
+	ibManifest                    bool // use image-builder-manifest job instead of manifest-id-only
+	bootcUseRemoteContainerSource bool
 }
 
 func newV2Server(t *testing.T, dir string, opts *v2ServerOpts) (*v2.Server, *worker.Server, jobqueue.JobQueue, context.CancelFunc) {
@@ -369,6 +370,7 @@ func newV2Server(t *testing.T, dir string, opts *v2ServerOpts) (*v2.Server, *wor
 		JWTEnabled:                     opts.enableJWT,
 		TenantProviderFields:           []string{"rh-org-id", "account_id"},
 		ImageBuilderManifestGeneration: opts.ibManifest,
+		BootcUseRemoteContainerSource:  opts.bootcUseRemoteContainerSource,
 	}
 	v2Server := v2.NewServer(workerServer, distros, repos, config)
 	require.NotNil(t, v2Server)
@@ -3052,123 +3054,149 @@ func TestComposeIBManifest(t *testing.T) {
 }
 
 func TestComposeBootc(t *testing.T) {
-	srv, _, queue, cancel := newV2Server(t, t.TempDir(), nil)
-	defer cancel()
 	baseContainerRef := "registry.org/centos-bootc:tag"
 
-	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
-	{
-		"bootc": {
-                  "reference": "%s"
-                },
-		"image_request":{
-			"architecture": "%s",
-			"repositories": [],
-			"image_type": "guest-image",
-			"upload_options": {}
-		}
-	}`, baseContainerRef, test_distro.TestArch3Name), http.StatusCreated, `
-	{
-		"href": "/api/image-builder-composer/v2/compose",
-		"kind": "ComposeId"
-	}`, "id")
+	testCases := []struct {
+		name                          string
+		bootcUseRemoteContainerSource bool
+	}{
+		{
+			name:                          "default/local",
+			bootcUseRemoteContainerSource: false,
+		},
+		{
+			name:                          "remote_container_source",
+			bootcUseRemoteContainerSource: true,
+		},
+	}
 
-	// The job graph for bootc composes is:
-	//   BootcInfoResolve -> BootcPreManifest -> ContainerResolve -> ManifestByID -> OSBuild
-	// The root job (no dependents) is OSBuild.
-	rootJobs, err := queue.AllRootJobIDs(context.Background())
-	require.NoError(t, err)
-	require.Len(t, rootJobs, 1)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, queue, cancel := newV2Server(t, t.TempDir(), &v2ServerOpts{
+				bootcUseRemoteContainerSource: tc.bootcUseRemoteContainerSource,
+			})
+			defer cancel()
 
-	osbuildJobID := rootJobs[0]
-	osbuildJobType, osbuildArgsJSON, osbuildDeps, _, err := queue.Job(osbuildJobID)
-	require.NoError(t, err)
-	osbuildJobTypeParts := strings.Split(osbuildJobType, ":")
-	require.Equal(t, worker.JobTypeOSBuild, osbuildJobTypeParts[0])
-	require.Equal(t, test_distro.TestArch3Name, osbuildJobTypeParts[1])
+			test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
+			{
+				"bootc": {
+						"reference": "%s"
+						},
+				"image_request":{
+					"architecture": "%s",
+					"repositories": [],
+					"image_type": "guest-image",
+					"upload_options": {}
+				}
+			}`, baseContainerRef, test_distro.TestArch3Name), http.StatusCreated, `
+			{
+				"href": "/api/image-builder-composer/v2/compose",
+				"kind": "ComposeId"
+			}`, "id")
 
-	// Ensure the local target is used
-	var osbuildArgs worker.OSBuildJob
-	require.NoError(t, json.Unmarshal(osbuildArgsJSON, &osbuildArgs))
-	require.Equal(t, target.TargetNameWorkerServer, osbuildArgs.Targets[0].Name)
+			// The job graph for bootc composes is:
+			//   BootcInfoResolve -> BootcPreManifest -> ContainerResolve -> ManifestByID -> OSBuild
+			// The root job (no dependents) is OSBuild.
+			rootJobs, err := queue.AllRootJobIDs(context.Background())
+			require.NoError(t, err)
+			require.Len(t, rootJobs, 1)
 
-	// OSBuild depends on ManifestByID
-	require.Len(t, osbuildDeps, 1)
-	manifestJobID := osbuildDeps[0]
+			osbuildJobID := rootJobs[0]
+			osbuildJobType, osbuildArgsJSON, osbuildDeps, _, err := queue.Job(osbuildJobID)
+			require.NoError(t, err)
+			osbuildJobTypeParts := strings.Split(osbuildJobType, ":")
+			require.Equal(t, worker.JobTypeOSBuild, osbuildJobTypeParts[0])
+			require.Equal(t, test_distro.TestArch3Name, osbuildJobTypeParts[1])
 
-	// NOTE: we do not check the job args here, because ManifestByID job has no static
-	// arguments since it accesses all of its dependencies directly via job IDs.
-	manifestJobType, _, manifestDeps, _, err := queue.Job(manifestJobID)
-	require.NoError(t, err)
-	require.Equal(t, worker.JobTypeManifestIDOnly, manifestJobType)
+			// Ensure the local target is used
+			var osbuildArgs worker.OSBuildJob
+			require.NoError(t, json.Unmarshal(osbuildArgsJSON, &osbuildArgs))
+			require.Equal(t, target.TargetNameWorkerServer, osbuildArgs.Targets[0].Name)
 
-	// ManifestByID depends on ContainerResolve, BootcInfoResolve, and BootcPreManifest (in IDs() order).
-	// No depsolve, no ostree resolve, no build resolve (single ref).
-	require.Len(t, manifestDeps, 3, "ManifestByID should depend on ContainerResolve, BootcInfoResolve, and BootcPreManifest")
-	containerResolveJobID := manifestDeps[0]
-	bootcInfoResolveJobID := manifestDeps[1]
-	bootcPreManifestDepJobID := manifestDeps[2]
+			// OSBuild depends on ManifestByID
+			require.Len(t, osbuildDeps, 1)
+			manifestJobID := osbuildDeps[0]
 
-	containerResolveJobType, containerResolveArgsJSON, containerResolveDeps, _, err := queue.Job(containerResolveJobID)
-	require.NoError(t, err)
-	require.Equal(t, worker.JobTypeContainerResolve, containerResolveJobType)
+			// NOTE: we do not check the job args here, because ManifestByID job has no static
+			// arguments since it accesses all of its dependencies directly via job IDs.
+			manifestJobType, _, manifestDeps, _, err := queue.Job(manifestJobID)
+			require.NoError(t, err)
+			require.Equal(t, worker.JobTypeManifestIDOnly, manifestJobType)
 
-	var containerResolveArgs worker.ContainerResolveJob
-	require.NoError(t, json.Unmarshal(containerResolveArgsJSON, &containerResolveArgs))
-	// Verify the ContainerResolve job static args are empty
-	require.Empty(t, containerResolveArgs.Arch)
-	require.Empty(t, containerResolveArgs.PipelineSpecs)
-	// Verify the ContainerResolve job dynamic args index is set correctly
-	require.NotNil(t, containerResolveArgs.PreManifestDynArgsIdx, "ContainerResolve should have PreManifestDynArgsIdx set")
-	require.Equal(t, 0, *containerResolveArgs.PreManifestDynArgsIdx)
+			// ManifestByID depends on ContainerResolve, BootcInfoResolve, and BootcPreManifest (in IDs() order).
+			// No depsolve, no ostree resolve, no build resolve (single ref).
+			require.Len(t, manifestDeps, 3, "ManifestByID should depend on ContainerResolve, BootcInfoResolve, and BootcPreManifest")
+			containerResolveJobID := manifestDeps[0]
+			bootcInfoResolveJobID := manifestDeps[1]
+			bootcPreManifestDepJobID := manifestDeps[2]
 
-	// ContainerResolve depends on BootcPreManifest
-	require.Len(t, containerResolveDeps, 1)
-	preManifestJobID := containerResolveDeps[0]
+			containerResolveJobType, containerResolveArgsJSON, containerResolveDeps, _, err := queue.Job(containerResolveJobID)
+			require.NoError(t, err)
+			require.Equal(t, worker.JobTypeContainerResolve, containerResolveJobType)
 
-	preManifestJobType, preManifestArgsJSON, preManifestDeps, _, err := queue.Job(preManifestJobID)
-	require.NoError(t, err)
-	require.Equal(t, worker.JobTypeBootcPreManifest, preManifestJobType)
+			var containerResolveArgs worker.ContainerResolveJob
+			require.NoError(t, json.Unmarshal(containerResolveArgsJSON, &containerResolveArgs))
+			// Verify the ContainerResolve job static args are empty
+			require.Empty(t, containerResolveArgs.Arch)
+			require.Empty(t, containerResolveArgs.PipelineSpecs)
+			// Verify the ContainerResolve job dynamic args index is set correctly
+			require.NotNil(t, containerResolveArgs.PreManifestDynArgsIdx, "ContainerResolve should have PreManifestDynArgsIdx set")
+			require.Equal(t, 0, *containerResolveArgs.PreManifestDynArgsIdx)
 
-	var preManifestArgs worker.BootcPreManifestJob
-	require.NoError(t, json.Unmarshal(preManifestArgsJSON, &preManifestArgs))
-	require.Equal(t, "qcow2", preManifestArgs.ImageType)
-	require.NotZero(t, preManifestArgs.Seed, "BootcPreManifest seed should not be zero")
-	// Verify the BootcInfoResolve job ID and index are set correctly
-	require.NotNil(t, preManifestArgs.BootcInfoResolveDynArgsIdx)
-	require.Equal(t, 0, *preManifestArgs.BootcInfoResolveDynArgsIdx)
-	require.Equal(t, 0, preManifestArgs.BaseInfoIdx)
-	// TODO: adjust this once we add support for a separate build container
-	require.Nil(t, preManifestArgs.BuildInfoIdx, "single ref: no build info index")
+			// ContainerResolve depends on BootcPreManifest
+			require.Len(t, containerResolveDeps, 1)
+			preManifestJobID := containerResolveDeps[0]
 
-	// BootcPreManifest depends on BootcInfoResolve
-	require.Len(t, preManifestDeps, 1)
-	preManifestBootcInfoResolveJobID := preManifestDeps[0]
+			preManifestJobType, preManifestArgsJSON, preManifestDeps, _, err := queue.Job(preManifestJobID)
+			require.NoError(t, err)
+			require.Equal(t, worker.JobTypeBootcPreManifest, preManifestJobType)
 
-	bootcInfoResolveJobType, bootcInfoResolveArgsJSON, bootcInfoResolveDeps, _, err := queue.Job(preManifestBootcInfoResolveJobID)
-	require.NoError(t, err)
-	// BootcInfoResolve uses arch suffix
-	bootcInfoResolveTypeParts := strings.Split(bootcInfoResolveJobType, ":")
-	require.Equal(t, worker.JobTypeBootcInfoResolve, bootcInfoResolveTypeParts[0])
-	require.Equal(t, test_distro.TestArch3Name, bootcInfoResolveTypeParts[1])
+			var preManifestArgs worker.BootcPreManifestJob
+			require.NoError(t, json.Unmarshal(preManifestArgsJSON, &preManifestArgs))
+			require.Equal(t, "qcow2", preManifestArgs.ImageType)
+			require.NotZero(t, preManifestArgs.Seed, "BootcPreManifest seed should not be zero")
+			// Verify the BootcInfoResolve job ID and index are set correctly
+			require.NotNil(t, preManifestArgs.BootcInfoResolveDynArgsIdx)
+			require.Equal(t, 0, *preManifestArgs.BootcInfoResolveDynArgsIdx)
+			require.Equal(t, 0, preManifestArgs.BaseInfoIdx)
+			// TODO: adjust this once we add support for a separate build container
+			require.Nil(t, preManifestArgs.BuildInfoIdx, "single ref: no build info index")
 
-	// Verify the BootcInfoResolve job args are set correctly
-	var bootcInfoResolveArgs worker.BootcInfoResolveJob
-	require.NoError(t, json.Unmarshal(bootcInfoResolveArgsJSON, &bootcInfoResolveArgs))
-	require.Len(t, bootcInfoResolveArgs.Specs, 1)
-	require.Equal(t, baseContainerRef, bootcInfoResolveArgs.Specs[0].Ref)
-	require.Equal(t, worker.BootcInfoResolveModeFull, bootcInfoResolveArgs.Specs[0].ResolveMode)
-	// TODO: add check for build container once we add support for it
+			// Verify UseRemoteContainerSource is propagated to BootcPreManifestJob args
+			require.NotNil(t, preManifestArgs.ImageOptions.Bootc)
+			require.Equal(t, tc.bootcUseRemoteContainerSource, preManifestArgs.ImageOptions.Bootc.UseRemoteContainerSource,
+				"BootcPreManifestJob.ImageOptions.Bootc.UseRemoteContainerSource should match server config")
 
-	// BootcInfoResolve has no dependencies
-	require.Empty(t, bootcInfoResolveDeps)
+			// BootcPreManifest depends on BootcInfoResolve
+			require.Len(t, preManifestDeps, 1)
+			preManifestBootcInfoResolveJobID := preManifestDeps[0]
 
-	// The BootcInfoResolve job referenced by BootcPreManifest should be
-	// the same job referenced by ManifestByID dependencies
-	require.Equal(t, bootcInfoResolveJobID, preManifestBootcInfoResolveJobID,
-		"ManifestByID and BootcPreManifest should reference the same BootcInfoResolve job")
+			bootcInfoResolveJobType, bootcInfoResolveArgsJSON, bootcInfoResolveDeps, _, err := queue.Job(preManifestBootcInfoResolveJobID)
+			require.NoError(t, err)
+			// BootcInfoResolve uses arch suffix
+			bootcInfoResolveTypeParts := strings.Split(bootcInfoResolveJobType, ":")
+			require.Equal(t, worker.JobTypeBootcInfoResolve, bootcInfoResolveTypeParts[0])
+			require.Equal(t, test_distro.TestArch3Name, bootcInfoResolveTypeParts[1])
 
-	// ManifestByID should directly depend on BootcPreManifest (third dependency)
-	require.Equal(t, preManifestJobID, bootcPreManifestDepJobID,
-		"ManifestByID should directly depend on BootcPreManifest")
+			// Verify the BootcInfoResolve job args are set correctly
+			var bootcInfoResolveArgs worker.BootcInfoResolveJob
+			require.NoError(t, json.Unmarshal(bootcInfoResolveArgsJSON, &bootcInfoResolveArgs))
+			require.Len(t, bootcInfoResolveArgs.Specs, 1)
+			require.Equal(t, baseContainerRef, bootcInfoResolveArgs.Specs[0].Ref)
+			require.Equal(t, worker.BootcInfoResolveModeFull, bootcInfoResolveArgs.Specs[0].ResolveMode)
+			// TODO: add check for build container once we add support for it
+
+			// BootcInfoResolve has no dependencies
+			require.Empty(t, bootcInfoResolveDeps)
+
+			// The BootcInfoResolve job referenced by BootcPreManifest should be
+			// the same job referenced by ManifestByID dependencies
+			require.Equal(t, bootcInfoResolveJobID, preManifestBootcInfoResolveJobID,
+				"ManifestByID and BootcPreManifest should reference the same BootcInfoResolve job")
+
+			// ManifestByID should directly depend on BootcPreManifest (third dependency)
+			require.Equal(t, preManifestJobID, bootcPreManifestDepJobID,
+				"ManifestByID should directly depend on BootcPreManifest")
+		})
+	}
 }

--- a/templates/openshift/composer.yml
+++ b/templates/openshift/composer.yml
@@ -128,6 +128,8 @@ objects:
             value: ${DISTRO_ALIASES}
           - name: CHANNEL
             value: ${CHANNEL}
+          - name: BOOTC_USE_REMOTE_CONTAINER_SOURCE
+            value: "${BOOTC_USE_REMOTE_CONTAINER_SOURCE}"
           ports:
           - name: composer-api
             protocol: TCP
@@ -350,3 +352,10 @@ parameters:
       Channel where this pod is deployed.
       This is appended to the logs. Usually something like
       "local", "staging" or "production".
+  - name: BOOTC_USE_REMOTE_CONTAINER_SOURCE
+    value: "true"
+    description: >
+      Whether to use remote container source for bootc composes.
+      This is used to control the container source type in the compose manifest.
+      For the service deployment, this should be true, because one can't expect
+      the container to be present in local podman storage.

--- a/test/cases/api-bootc.sh
+++ b/test/cases/api-bootc.sh
@@ -65,6 +65,8 @@ PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PG
     "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
 popd
 
+BOOTC_USE_REMOTE_CONTAINER_SOURCE="${BOOTC_USE_REMOTE_CONTAINER_SOURCE:-false}"
+
 cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
 ignore_missing_repos = true
 log_level = "debug"
@@ -81,6 +83,8 @@ pg_user = "postgres"
 pg_password = "foobar"
 pg_ssl_mode = "disable"
 pg_max_conns = 10
+[bootc]
+use_remote_container_source = ${BOOTC_USE_REMOTE_CONTAINER_SOURCE}
 EOF
 
 sudo systemctl restart osbuild-composer
@@ -164,6 +168,30 @@ function waitForState() {
     export UPLOAD_OPTIONS
 }
 
+# verify the container source type in the compose manifest is correct
+function verifyManifestContainerSourceType() {
+    MANIFESTS=$(curl \
+        --silent \
+        --show-error \
+        --cacert /etc/osbuild-composer/ca-crt.pem \
+        --key /etc/osbuild-composer/client-key.pem \
+        --cert /etc/osbuild-composer/client-crt.pem \
+        "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID/manifests")
+    echo "compose MANIFESTS:"
+    echo "$MANIFESTS"
+    HAS_SKOPEO=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.skopeo")')
+    HAS_LOCAL=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.containers-storage")')
+    echo "has org.osbuild.skopeo: $HAS_SKOPEO"
+    echo "has org.osbuild.containers-storage: $HAS_LOCAL"
+    if [ "$BOOTC_USE_REMOTE_CONTAINER_SOURCE" = "true" ]; then
+        test "$HAS_SKOPEO" = "true"
+        test "$HAS_LOCAL" = "false"
+    else
+        test "$HAS_SKOPEO" = "false"
+        test "$HAS_LOCAL" = "true"
+    fi
+}
+
 WORKDIR=$(mktemp -d)
 REQ="${WORKDIR}/compose_request.json"
 ARCH=$(uname -m)
@@ -197,3 +225,5 @@ curl \
     --cert /etc/osbuild-composer/client-crt.pem \
     "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID"
 test "$UPLOAD_STATUS" = "success"
+
+verifyManifestContainerSourceType


### PR DESCRIPTION
The `enqueueBootcCompose` function hardcodes `UseRemoteContainerSource: false`, which works for on-prem deployments where containers live in local podman storage but will break the service deployment that needs `org.osbuild.skopeo` (remote pull). Add a `[bootc]` config section with a `use_remote_container_source` toggle - settable via TOML or the `BOOTC_USE_REMOTE_CONTAINER_SOURCE` environment variable - and wire it through `ServerConfig` into the compose pipeline so each deployment gets the right container source type.

## Architectural Changes

Follow the existing per-section config pattern (`[koji]`, `[worker]`, `[weldr_api]`) to add a new `[bootc]` TOML section. A per-request API option was considered but deferred - on-prem and service deployments never mix modes today, and a server-side default would still be required, so the simpler approach avoids unnecessary API surface. The env-var support also required teaching `loadConfigFromEnv` to handle `bool` fields, which were previously skipped.

## Key Changes

- Add `BootcConfig` struct with `use_remote_container_source` field, configurable via TOML and env var
- Extend `loadConfigFromEnv` to support `bool` fields with `env` tags (previously a no-op) and extract a `lookupEnvTagValue` helper to reduce duplication
- Add `BootcUseRemoteContainerSource` to `v2.ServerConfig` and replace the hardcoded `false` in `enqueueBootcCompose`
- Set `BOOTC_USE_REMOTE_CONTAINER_SOURCE=true` in the OpenShift deployment template for the service environment
- Extend unit tests (`TestComposeBootc`, `TestHandleBootcPreManifest_HappyPath`) to cover both local and remote container source variants
- Extend `api-bootc.sh` functional test to validate manifest sources and run both variants in CI via a GitLab matrix

## Breaking Changes

This PR is fully backward compatible. The default when the option is omitted is `false`, preserving existing on-prem behavior to use local container sources.

## Testing

Unit tests verify config loading (default value, TOML parsing, and env-var override), propagation of the flag through `ServerConfig` into `BootcPreManifestJob` args, and correct container source `Local` property in the pre-manifest result for both `true` and `false` variants. The `api-bootc.sh` functional test was extended to inspect the compose manifest for the expected source type (`org.osbuild.skopeo` vs `org.osbuild.containers-storage`), and the GitLab CI matrix now exercises both configurations.