### PR TITLE
Allow any valid upload target for bootc composes, not just local (HMS-10507)

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -408,6 +408,38 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		return err
 	}
 
+	// Read targets from BootcPreManifest dynargs if configured
+	if len(jobArgs.Targets) > 0 && jobArgs.PreManifestDynArgsIdx != nil {
+		osbuildJobResult.JobError = clienterrors.New(
+			clienterrors.ErrorParsingJobArgs,
+			"Targets and PreManifestDynArgsIdx cannot be set at the same time", nil)
+		return fmt.Errorf("Targets and PreManifestDynArgsIdx cannot be set at the same time")
+	}
+
+	if len(jobArgs.Targets) == 0 && jobArgs.PreManifestDynArgsIdx != nil {
+		idx := *jobArgs.PreManifestDynArgsIdx
+		if idx < 0 || idx >= job.NDynamicArgs() {
+			osbuildJobResult.JobError = clienterrors.New(
+				clienterrors.ErrorParsingDynamicArgs,
+				fmt.Sprintf("PreManifestDynArgsIdx %d is out of range", idx), nil)
+			return fmt.Errorf("PreManifestDynArgsIdx %d is out of range of %d dynamic args", idx, job.NDynamicArgs())
+		}
+		var preManifestResult worker.BootcPreManifestJobResult
+		if err = job.DynamicArgs(idx, &preManifestResult); err != nil {
+			osbuildJobResult.JobError = clienterrors.New(
+				clienterrors.ErrorParsingDynamicArgs,
+				"Error parsing BootcPreManifest dynamic args", nil)
+			return fmt.Errorf("error parsing BootcPreManifest dynamic args: %v", err)
+		}
+		if preManifestResult.JobError != nil {
+			osbuildJobResult.JobError = clienterrors.New(
+				clienterrors.ErrorJobDependency,
+				"BootcPreManifest job dependency failed", nil)
+			return nil
+		}
+		jobArgs.Targets = preManifestResult.Targets
+	}
+
 	// In case the manifest is empty, try to get it from dynamic args
 	var manifestInfo *worker.ManifestInfo
 	if len(jobArgs.Manifest) == 0 {

--- a/internal/cloudapi/v2/bootc_premanifest_test.go
+++ b/internal/cloudapi/v2/bootc_premanifest_test.go
@@ -20,6 +20,7 @@ import (
 	v2 "github.com/osbuild/osbuild-composer/internal/cloudapi/v2"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/jobqueue/fsjobqueue"
+	"github.com/osbuild/osbuild-composer/internal/target"
 	"github.com/osbuild/osbuild-composer/internal/worker"
 	"github.com/osbuild/osbuild-composer/internal/worker/clienterrors"
 )
@@ -236,6 +237,23 @@ func TestHandleBootcPreManifest_Errors(t *testing.T) {
 			wantErrID:          clienterrors.ErrorManifestGeneration,
 			wantReasonContains: "Error generating bootc pre-manifest: getting image type \"nonexistent-image-type\": invalid image type: nonexistent-image-type",
 		},
+		{
+			name: "invalid_upload_target_options",
+			job: &worker.BootcPreManifestJob{
+				ImageType:                  "qcow2",
+				Seed:                       42,
+				BootcInfoResolveDynArgsIdx: common.ToPtr(0),
+				UploadTargets: []worker.BootcUploadTarget{
+					{Type: "aws.s3", Options: json.RawMessage(`{"region":123}`)},
+				},
+			},
+			dynArgs: func(t *testing.T) []json.RawMessage {
+				t.Helper()
+				return []json.RawMessage{rawValidBaseBootcInfoResult(t)}
+			},
+			wantErrID:          clienterrors.ErrorInvalidTargetConfig,
+			wantReasonContains: "Error constructing upload target",
+		},
 	}
 
 	for _, tt := range tests {
@@ -280,7 +298,7 @@ func TestHandleBootcPreManifest_Errors(t *testing.T) {
 // enqueuePreManifestWithResolvedDep enqueues a bootc info-resolve job,
 // finishes it with a valid result, and enqueues a pre-manifest job that
 // depends on it. Returns the pre-manifest job ID.
-func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec, io distro.ImageOptions) uuid.UUID {
+func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec, io distro.ImageOptions, uploadTargets []worker.BootcUploadTarget) uuid.UUID {
 	t.Helper()
 	infoResolveJob := &worker.BootcInfoResolveJob{
 		Specs: specs,
@@ -293,6 +311,7 @@ func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch str
 		Seed:                       42,
 		BootcInfoResolveDynArgsIdx: common.ToPtr(0),
 		ImageOptions:               io,
+		UploadTargets:              uploadTargets,
 	}
 	preManifestJobID, err := ws.EnqueueBootcPreManifestJob(
 		preManifestJob, []uuid.UUID{infoResolveJobID}, "",
@@ -352,9 +371,16 @@ func assertValidPreManifestResult(t *testing.T, result worker.BootcPreManifestJo
 // dependency, and verify the job finishes successfully. Without going
 // through the loop.
 func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
+	type expectedTarget struct {
+		name   target.TargetName
+		verify func(t *testing.T, tgt *target.Target)
+	}
+
 	testCases := []struct {
 		name                     string
 		useRemoteContainerSource bool
+		uploadTargets            []worker.BootcUploadTarget
+		expectedTargets          []expectedTarget
 	}{
 		{
 			name:                     "default/local_container_source",
@@ -363,6 +389,66 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 		{
 			name:                     "remote_container_source",
 			useRemoteContainerSource: true,
+		},
+		{
+			name:                     "aws_s3_upload_target",
+			useRemoteContainerSource: false,
+			uploadTargets: []worker.BootcUploadTarget{
+				{Type: "aws.s3", Options: json.RawMessage(`{"region":"us-east-1"}`)},
+			},
+			expectedTargets: []expectedTarget{
+				{
+					name: target.TargetNameAWSS3,
+					verify: func(t *testing.T, tgt *target.Target) {
+						opts, ok := tgt.Options.(*target.AWSS3TargetOptions)
+						require.True(t, ok, "expected AWSS3TargetOptions")
+						assert.Equal(t, "us-east-1", opts.Region)
+						assert.False(t, opts.Public)
+						assert.NotEmpty(t, opts.Key)
+					},
+				},
+			},
+		},
+		{
+			name:                     "local_upload_target",
+			useRemoteContainerSource: false,
+			uploadTargets: []worker.BootcUploadTarget{
+				{Type: "local", Options: json.RawMessage(`{}`)},
+			},
+			expectedTargets: []expectedTarget{
+				{
+					name: target.TargetNameWorkerServer,
+					verify: func(t *testing.T, tgt *target.Target) {
+						_, ok := tgt.Options.(*target.WorkerServerTargetOptions)
+						require.True(t, ok, "expected WorkerServerTargetOptions")
+					},
+				},
+			},
+		},
+		{
+			name:                     "multiple_upload_targets",
+			useRemoteContainerSource: false,
+			uploadTargets: []worker.BootcUploadTarget{
+				{Type: "aws.s3", Options: json.RawMessage(`{"region":"eu-west-1"}`)},
+				{Type: "local", Options: json.RawMessage(`{}`)},
+			},
+			expectedTargets: []expectedTarget{
+				{
+					name: target.TargetNameAWSS3,
+					verify: func(t *testing.T, tgt *target.Target) {
+						opts, ok := tgt.Options.(*target.AWSS3TargetOptions)
+						require.True(t, ok, "expected AWSS3TargetOptions")
+						assert.Equal(t, "eu-west-1", opts.Region)
+					},
+				},
+				{
+					name: target.TargetNameWorkerServer,
+					verify: func(t *testing.T, tgt *target.Target) {
+						_, ok := tgt.Options.(*target.WorkerServerTargetOptions)
+						require.True(t, ok, "expected WorkerServerTargetOptions")
+					},
+				},
+			},
 		},
 	}
 
@@ -380,7 +466,7 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 				Bootc: &distro.BootcImageOptions{
 					UseRemoteContainerSource: tc.useRemoteContainerSource,
 				},
-			})
+			}, tc.uploadTargets)
 
 			// Dequeue the pre-manifest job (it should be pending now)
 			jobID, preManifestToken, _, staticArgs, dynArgs, err := workerServer.RequestJob(
@@ -400,6 +486,17 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 			assert.False(t, jobInfo.JobStatus.Finished.IsZero(), "job should be finished")
 
 			assertValidPreManifestResult(t, readResult, archi, specs, tc.useRemoteContainerSource)
+
+			if len(tc.expectedTargets) > 0 {
+				require.Len(t, readResult.Targets, len(tc.expectedTargets), "expected %d targets", len(tc.expectedTargets))
+				for i, et := range tc.expectedTargets {
+					tgt := readResult.Targets[i]
+					assert.Equal(t, et.name, tgt.Name, "target %d name mismatch", i)
+					assert.NotEmpty(t, tgt.OsbuildArtifact.ExportFilename, "target %d ExportFilename should be set", i)
+					assert.NotEmpty(t, tgt.OsbuildArtifact.ExportName, "target %d ExportName should be set", i)
+					et.verify(t, tgt)
+				}
+			}
 
 			// Verify ManifestInfo is populated
 			assert.Equal(t, common.BuildVersion(), readResult.ManifestInfo.OSBuildComposerVersion)
@@ -435,7 +532,7 @@ func TestBootcPreManifestLoop_PicksUpJob(t *testing.T) {
 	}
 	archi := arch.ARCH_X86_64.String()
 
-	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{})
+	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{}, nil)
 
 	// Wait for the loop to pick up and finish the pre-manifest job.
 	// Poll with timeout.

--- a/internal/cloudapi/v2/compose.go
+++ b/internal/cloudapi/v2/compose.go
@@ -1325,7 +1325,7 @@ func (request *ComposeRequest) GetImageRequests(distroFactory *distrofactory.Fac
 			}
 		} else {
 			// Get the target for the selected image type
-			irTargets, err = ir.GetTargets(request, imageType)
+			irTargets, err = ir.GetTargets(imageType)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cloudapi/v2/imagerequest.go
+++ b/internal/cloudapi/v2/imagerequest.go
@@ -82,7 +82,7 @@ func newAWSS3Target(options UploadOptions, imageType distro.ImageType) (*target.
 	return t, nil
 }
 
-func newContainerTarget(options UploadOptions, request *ComposeRequest, imageType distro.ImageType) (*target.Target, error) {
+func newContainerTarget(options UploadOptions, imageType distro.ImageType) (*target.Target, error) {
 	var containerUploadOptions ContainerUploadOptions
 	jsonUploadOptions, err := json.Marshal(options)
 	if err != nil {
@@ -93,11 +93,7 @@ func newContainerTarget(options UploadOptions, request *ComposeRequest, imageTyp
 		return nil, HTTPError(ErrorJSONUnMarshallingError)
 	}
 
-	if request.Distribution == nil {
-		return nil, HTTPError(ErrorDistroMissing)
-	}
-
-	var name = *request.Distribution
+	var name = imageType.Arch().Distro().Name()
 	var tag = uuid.New().String()
 	if containerUploadOptions.Name != nil {
 		name = *containerUploadOptions.Name
@@ -374,7 +370,7 @@ func targetSupportMap() map[UploadTypes]map[ImageTypes]bool {
 
 // GetTargets returns the targets for the ImageRequest. Merges the
 // UploadTargets with the top-level default UploadOptions if specified.
-func (ir *ImageRequest) GetTargets(request *ComposeRequest, imageType distro.ImageType) ([]*target.Target, error) {
+func (ir *ImageRequest) GetTargets(imageType distro.ImageType) ([]*target.Target, error) {
 	tsm := targetSupportMap()
 	targets := make([]*target.Target, 0)
 	if ir.UploadTargets != nil {
@@ -383,7 +379,7 @@ func (ir *ImageRequest) GetTargets(request *ComposeRequest, imageType distro.Ima
 			if !tsm[ut.Type][ir.ImageType] {
 				return nil, HTTPError(ErrorInvalidUploadTarget)
 			}
-			trgt, err := getTarget(ut.Type, ut.UploadOptions, request, imageType)
+			trgt, err := getTarget(ut.Type, ut.UploadOptions, imageType)
 			if err != nil {
 				return nil, err
 			}
@@ -398,7 +394,7 @@ func (ir *ImageRequest) GetTargets(request *ComposeRequest, imageType distro.Ima
 		if err != nil {
 			return nil, err
 		}
-		trgt, err := getTarget(defTargetType, *ir.UploadOptions, request, imageType)
+		trgt, err := getTarget(defTargetType, *ir.UploadOptions, imageType)
 		if err != nil {
 			return nil, err
 		}
@@ -408,7 +404,7 @@ func (ir *ImageRequest) GetTargets(request *ComposeRequest, imageType distro.Ima
 	return targets, nil
 }
 
-func getTarget(targetType UploadTypes, options UploadOptions, request *ComposeRequest, imageType distro.ImageType) (irTarget *target.Target, err error) {
+func getTarget(targetType UploadTypes, options UploadOptions, imageType distro.ImageType) (irTarget *target.Target, err error) {
 	switch targetType {
 	case UploadTypesAws:
 		irTarget, err = newAWSTarget(options, imageType)
@@ -417,7 +413,7 @@ func getTarget(targetType UploadTypes, options UploadOptions, request *ComposeRe
 		irTarget, err = newAWSS3Target(options, imageType)
 
 	case UploadTypesContainer:
-		irTarget, err = newContainerTarget(options, request, imageType)
+		irTarget, err = newContainerTarget(options, imageType)
 
 	case UploadTypesGcp:
 		irTarget, err = newGCPTarget(options, imageType)

--- a/internal/cloudapi/v2/imagerequest_test.go
+++ b/internal/cloudapi/v2/imagerequest_test.go
@@ -63,10 +63,6 @@ func TestGetTargets(t *testing.T) {
 	arch, err := r9.GetArch(arch.ARCH_X86_64.String())
 	at.NoError(err)
 
-	cr := &ComposeRequest{
-		Distribution: common.ToPtr(r9.Name()),
-	}
-
 	it, err := arch.GetImageType("qcow2")
 	at.NoError(err)
 
@@ -264,7 +260,7 @@ func TestGetTargets(t *testing.T) {
 				ir.UploadOptions = &uploadOptions
 			}
 
-			targets, err := ir.GetTargets(cr, it)
+			targets, err := ir.GetTargets(it)
 			if !testCase.fail {
 				at.NoError(err)
 				at.Equal(len(targets), len(testCase.expected))

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -577,28 +577,60 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 		return uuid.Nil, err
 	}
 
-	// Only local targets are supported
-	if ir.UploadTargets != nil {
-		for _, ut := range *ir.UploadTargets {
-			if ut.Type != UploadTypesLocal {
-				return uuid.Nil, HTTPError(ErrorInvalidUploadTarget)
-			}
-		}
-	}
-	tgts := []*target.Target{
-		target.NewWorkerServerTarget(),
-	}
-
 	imageTypeName := imageTypeFromApiImageType(ir.ImageType)
 
-	// TODO: Hardcoding this is obviously a very bad hack, but currently this image type
-	// information isn't retrievable from images without running the bootc container.
-	if imageTypeName == "qcow2" {
-		tgts[0].ImageName = "disk.qcow2"
-		tgts[0].OsbuildArtifact.ExportFilename = "disk.qcow2"
-		tgts[0].OsbuildArtifact.ExportName = "qcow2"
-	} else {
+	// TODO: Only qcow2 (guest-image) is supported for bootc composes for now.
+	if imageTypeName != "qcow2" {
 		return uuid.Nil, HTTPErrorWithDetails(ErrorUnsupportedImageType, nil, "only qcow2 (guest-image) is supported for bootc composes")
+	}
+
+	// Validate and normalize upload targets — consistent with non-bootc flow.
+	// Error if no targets provided.
+	if ir.UploadOptions == nil && (ir.UploadTargets == nil || len(*ir.UploadTargets) == 0) {
+		return uuid.Nil, HTTPError(ErrorJSONUnMarshallingError)
+	}
+
+	tsm := targetSupportMap()
+	var uploadTargetSpecs []worker.BootcUploadTarget
+
+	if ir.UploadTargets != nil {
+		for _, ut := range *ir.UploadTargets {
+			if !tsm[ut.Type][ir.ImageType] {
+				return uuid.Nil, HTTPErrorWithDetails(
+					ErrorInvalidUploadTarget, nil,
+					fmt.Sprintf("invalid upload target type %q for image type %q", ut.Type, ir.ImageType),
+				)
+			}
+			rawOpts, err := json.Marshal(ut.UploadOptions)
+			if err != nil {
+				return uuid.Nil, HTTPErrorWithInternal(ErrorJSONMarshallingError, err)
+			}
+			uploadTargetSpecs = append(uploadTargetSpecs, worker.BootcUploadTarget{
+				Type:    string(ut.Type),
+				Options: rawOpts,
+			})
+		}
+	}
+
+	if ir.UploadOptions != nil {
+		defTargetType, err := getDefaultTarget(ir.ImageType)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		if !tsm[defTargetType][ir.ImageType] {
+			return uuid.Nil, HTTPErrorWithDetails(
+				ErrorInvalidUploadTarget, nil,
+				fmt.Sprintf("invalid default upload target type %q for image type %q", defTargetType, ir.ImageType),
+			)
+		}
+		rawOpts, err := json.Marshal(*ir.UploadOptions)
+		if err != nil {
+			return uuid.Nil, HTTPErrorWithInternal(ErrorJSONMarshallingError, err)
+		}
+		uploadTargetSpecs = append(uploadTargetSpecs, worker.BootcUploadTarget{
+			Type:    string(defTargetType),
+			Options: rawOpts,
+		})
 	}
 
 	// Generate a manifest seed using crypto/rand, same approach as
@@ -646,6 +678,7 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 		Seed:                       seed,
 		BootcInfoResolveDynArgsIdx: common.ToPtr(0), // dynArgs[0] = BootcInfoResolve
 		BaseInfoIdx:                0,               // base container info index within the BootcInfoResolve job result infos slice
+		UploadTargets:              uploadTargetSpecs,
 	}
 	preManifestJobID, err := s.workers.EnqueueBootcPreManifestJob(preManifestArgs, preManifestDeps, channel)
 	if err != nil {
@@ -686,10 +719,12 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 		return uuid.Nil, HTTPErrorWithInternal(ErrorEnqueueingJob, err)
 	}
 
-	// 5. Enqueue OSBuild (worker job, depends on ManifestByID)
+	// 5. Enqueue OSBuild (worker job, depends on ManifestByID and BootcPreManifest)
 	osbuildJobID, err := s.workers.EnqueueOSBuildAsDependency(ir.Architecture, &worker.OSBuildJob{
-		Targets: tgts,
-	}, []uuid.UUID{manifestJobID}, channel)
+		// Targets are empty — filled by worker from BootcPreManifest dynargs.
+		ManifestDynArgsIdx:    common.ToPtr(0), // dynArgs[0] = ManifestByID result
+		PreManifestDynArgsIdx: common.ToPtr(1), // dynArgs[1] = BootcPreManifest result
+	}, []uuid.UUID{manifestJobID, preManifestJobID}, channel)
 	if err != nil {
 		return uuid.Nil, HTTPErrorWithInternal(ErrorEnqueueingJob, err)
 	}

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -1082,7 +1082,7 @@ func handleBootcPreManifest(
 	// containers), so nil is safe here.
 	baseInfoIdx := preManifestArgs.BaseInfoIdx
 	buildInfoIdx := preManifestArgs.BuildInfoIdx
-	manifestSource, _, err := buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, preManifestArgs.ImageType, &preManifestArgs.Blueprint, preManifestArgs.ImageOptions, preManifestArgs.Seed)
+	manifestSource, imgType, err := buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, preManifestArgs.ImageType, &preManifestArgs.Blueprint, preManifestArgs.ImageOptions, preManifestArgs.Seed)
 	if err != nil {
 		preManifestResult.JobError = clienterrors.New(
 			clienterrors.ErrorManifestGeneration,
@@ -1168,5 +1168,39 @@ func handleBootcPreManifest(
 	preManifestResult.ContainerResolveJobArgs = &worker.ContainerResolveJob{
 		Arch:          canonicalArch.String(),
 		PipelineSpecs: pipelineContainerSpecs,
+	}
+
+	// Construct complete upload targets using the image type.
+	// This is the bootc equivalent of getTarget() called at enqueue time
+	// in the non-bootc flow. We do it here because distro.ImageType is
+	// only available after resolving bootc container info.
+	// Target type validation against image type is already done at enqueue
+	// time via targetSupportMap(), so we skip it here and go straight to
+	// target construction.
+	if len(preManifestArgs.UploadTargets) > 0 {
+		targets := make([]*target.Target, 0, len(preManifestArgs.UploadTargets))
+		for _, ut := range preManifestArgs.UploadTargets {
+			targetType := UploadTypes(ut.Type)
+
+			var opts UploadOptions
+			if err := opts.UnmarshalJSON(ut.Options); err != nil {
+				preManifestResult.JobError = clienterrors.New(
+					clienterrors.ErrorInvalidTargetConfig,
+					"Error constructing upload target: "+err.Error(), nil,
+				)
+				return
+			}
+
+			trgt, err := getTarget(targetType, opts, imgType)
+			if err != nil {
+				preManifestResult.JobError = clienterrors.New(
+					clienterrors.ErrorInvalidTargetConfig,
+					"Error constructing upload target: "+err.Error(), nil,
+				)
+				return
+			}
+			targets = append(targets, trgt)
+		}
+		preManifestResult.Targets = targets
 	}
 }

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -505,61 +505,61 @@ func buildBootcManifestSource(
 	bp *blueprint.Blueprint,
 	imageOptions distro.ImageOptions,
 	seed int64,
-) (*manifest.Manifest, error) {
+) (*manifest.Manifest, distro.ImageType, error) {
 
 	if bootcInfoResult.JobError != nil {
-		return nil, fmt.Errorf("bootc info resolve dependency failed: %s", bootcInfoResult.JobError.Reason)
+		return nil, nil, fmt.Errorf("bootc info resolve dependency failed: %s", bootcInfoResult.JobError.Reason)
 	}
 	if len(bootcInfoResult.Infos) == 0 {
-		return nil, fmt.Errorf("bootc info resolve result has no infos")
+		return nil, nil, fmt.Errorf("bootc info resolve result has no infos")
 	}
 
 	if baseInfoIdx < 0 || baseInfoIdx >= len(bootcInfoResult.Infos) {
-		return nil, fmt.Errorf("base info index %d is out of range (resolved %d infos)", baseInfoIdx, len(bootcInfoResult.Infos))
+		return nil, nil, fmt.Errorf("base info index %d is out of range (resolved %d infos)", baseInfoIdx, len(bootcInfoResult.Infos))
 	}
 
 	baseInfo, err := bootcInfoResult.Infos[baseInfoIdx].ToVendor()
 	if err != nil {
-		return nil, fmt.Errorf("converting bootc base info to vendor type: %w", err)
+		return nil, nil, fmt.Errorf("converting bootc base info to vendor type: %w", err)
 	}
 
 	var buildInfo *bootc.Info
 	if buildInfoIdx != nil {
 		if *buildInfoIdx < 0 || *buildInfoIdx >= len(bootcInfoResult.Infos) {
-			return nil, fmt.Errorf("build info index %d is out of range (resolved %d infos)", *buildInfoIdx, len(bootcInfoResult.Infos))
+			return nil, nil, fmt.Errorf("build info index %d is out of range (resolved %d infos)", *buildInfoIdx, len(bootcInfoResult.Infos))
 		}
 		buildInfo, err = bootcInfoResult.Infos[*buildInfoIdx].ToVendor()
 		if err != nil {
-			return nil, fmt.Errorf("converting bootc build info to vendor type: %w", err)
+			return nil, nil, fmt.Errorf("converting bootc build info to vendor type: %w", err)
 		}
 	}
 
 	bootcDistro, err := generic.NewBootc("bootc", baseInfo)
 	if err != nil {
-		return nil, fmt.Errorf("creating bootc distro: %w", err)
+		return nil, nil, fmt.Errorf("creating bootc distro: %w", err)
 	}
 	if buildInfo != nil {
 		if err := bootcDistro.SetBuildContainer(buildInfo); err != nil {
-			return nil, fmt.Errorf("setting build container: %w", err)
+			return nil, nil, fmt.Errorf("setting build container: %w", err)
 		}
 	}
 	canonicalArch, err := arch.FromString(baseInfo.Arch)
 	if err != nil {
-		return nil, fmt.Errorf("invalid arch %q: %w", baseInfo.Arch, err)
+		return nil, nil, fmt.Errorf("invalid arch %q: %w", baseInfo.Arch, err)
 	}
 	archi, err := bootcDistro.GetArch(canonicalArch.String())
 	if err != nil {
-		return nil, fmt.Errorf("getting arch %q: %w", canonicalArch.String(), err)
+		return nil, nil, fmt.Errorf("getting arch %q: %w", canonicalArch.String(), err)
 	}
 	imgType, err := archi.GetImageType(imageTypeName)
 	if err != nil {
-		return nil, fmt.Errorf("getting image type %q: %w", imageTypeName, err)
+		return nil, nil, fmt.Errorf("getting image type %q: %w", imageTypeName, err)
 	}
 	manifestSource, _, err := imgType.Manifest(bp, imageOptions, nil, &seed)
 	if err != nil {
-		return nil, fmt.Errorf("generating manifest: %w", err)
+		return nil, nil, fmt.Errorf("generating manifest: %w", err)
 	}
-	return manifestSource, nil
+	return manifestSource, imgType, nil
 }
 
 func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uuid.UUID, error) {
@@ -704,7 +704,8 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 			return nil, fmt.Errorf("failed to read bootc info resolve job result: %w", err)
 		}
 
-		return buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, imageTypeName, &bp, imageOptions, seed)
+		m, _, err := buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, imageTypeName, &bp, imageOptions, seed)
+		return m, err
 	}
 	s.goroutinesGroup.Add(1)
 	go func() {
@@ -1081,7 +1082,7 @@ func handleBootcPreManifest(
 	// containers), so nil is safe here.
 	baseInfoIdx := preManifestArgs.BaseInfoIdx
 	buildInfoIdx := preManifestArgs.BuildInfoIdx
-	manifestSource, err := buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, preManifestArgs.ImageType, &preManifestArgs.Blueprint, preManifestArgs.ImageOptions, preManifestArgs.Seed)
+	manifestSource, _, err := buildBootcManifestSource(baseInfoIdx, buildInfoIdx, bootcInfoResult, preManifestArgs.ImageType, &preManifestArgs.Blueprint, preManifestArgs.ImageOptions, preManifestArgs.Seed)
 	if err != nil {
 		preManifestResult.JobError = clienterrors.New(
 			clienterrors.ErrorManifestGeneration,

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -3059,14 +3059,73 @@ func TestComposeBootc(t *testing.T) {
 	testCases := []struct {
 		name                          string
 		bootcUseRemoteContainerSource bool
+		uploadJSON                    string   // upload_options or upload_targets JSON fragment
+		expectedStatus                int      // expected HTTP status code
+		expectedBody                  string   // empty = default ComposeId success body
+		expectedUploadTargetTypes     []string // expected BootcUploadTarget.Type values in pre-manifest args
 	}{
 		{
+			// Matches cockpit-image-builder on-prem: explicit local target
 			name:                          "default/local",
 			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"local"},
 		},
 		{
 			name:                          "remote_container_source",
 			bootcUseRemoteContainerSource: true,
+			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"local"},
+		},
+		{
+			// upload_options defaults to aws.s3 via getDefaultTarget
+			name:                          "default_upload_options_aws_s3",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_options": {}`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"aws.s3"},
+		},
+		{
+			name:                          "aws_s3_upload_target",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "aws.s3", "upload_options": {"region": "us-east-1"}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"aws.s3"},
+		},
+		{
+			name:                          "local_upload_target",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"local"},
+		},
+		{
+			name:                          "invalid_azure_upload_target",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "azure", "upload_options": {"tenant_id": "t", "subscription_id": "s", "resource_group": "rg"}}]`,
+			expectedStatus:                http.StatusBadRequest,
+			expectedBody: `{
+				"code": "IMAGE-BUILDER-COMPOSER-38",
+				"details": "invalid upload target type \"azure\" for image type \"guest-image\"",
+				"href": "/api/image-builder-composer/v2/errors/38",
+				"kind": "Error",
+				"reason": "Invalid upload target for image type"
+			}`,
+		},
+		{
+			name:                          "no_upload_target",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    "",
+			expectedStatus:                http.StatusInternalServerError,
+			expectedBody: `{
+				"code": "IMAGE-BUILDER-COMPOSER-1004",
+				"details": "",
+				"href": "/api/image-builder-composer/v2/errors/1004",
+				"kind": "Error",
+				"reason": "Failed to unmarshal struct"
+			}`,
 		},
 	}
 
@@ -3077,7 +3136,13 @@ func TestComposeBootc(t *testing.T) {
 			})
 			defer cancel()
 
-			test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
+			// Build the upload fragment with a leading comma when present.
+			uploadFragment := ""
+			if tc.uploadJSON != "" {
+				uploadFragment = ", " + tc.uploadJSON
+			}
+
+			requestBody := fmt.Sprintf(`
 			{
 				"bootc": {
 						"reference": "%s"
@@ -3085,17 +3150,27 @@ func TestComposeBootc(t *testing.T) {
 				"image_request":{
 					"architecture": "%s",
 					"repositories": [],
-					"image_type": "guest-image",
-					"upload_options": {}
+					"image_type": "guest-image"%s
 				}
-			}`, baseContainerRef, test_distro.TestArch3Name), http.StatusCreated, `
-			{
-				"href": "/api/image-builder-composer/v2/compose",
-				"kind": "ComposeId"
-			}`, "id")
+			}`, baseContainerRef, test_distro.TestArch3Name, uploadFragment)
+
+			expectedBody := tc.expectedBody
+			if expectedBody == "" {
+				expectedBody = `{
+					"href": "/api/image-builder-composer/v2/compose",
+					"kind": "ComposeId"
+				}`
+			}
+
+			test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", requestBody, tc.expectedStatus, expectedBody, "id", "operation_id")
+
+			if tc.expectedStatus != http.StatusCreated {
+				return // error cases don't create jobs
+			}
 
 			// The job graph for bootc composes is:
-			//   BootcInfoResolve -> BootcPreManifest -> ContainerResolve -> ManifestByID -> OSBuild
+			//   BootcInfoResolve -> BootcPreManifest -> ContainerResolve -> ManifestByID ─┐
+			//                            └────────────────────────────────────────────────├─> OSBuild
 			// The root job (no dependents) is OSBuild.
 			rootJobs, err := queue.AllRootJobIDs(context.Background())
 			require.NoError(t, err)
@@ -3108,14 +3183,19 @@ func TestComposeBootc(t *testing.T) {
 			require.Equal(t, worker.JobTypeOSBuild, osbuildJobTypeParts[0])
 			require.Equal(t, test_distro.TestArch3Name, osbuildJobTypeParts[1])
 
-			// Ensure the local target is used
+			// OSBuild job should have empty static targets and PreManifestDynArgsIdx set
 			var osbuildArgs worker.OSBuildJob
 			require.NoError(t, json.Unmarshal(osbuildArgsJSON, &osbuildArgs))
-			require.Equal(t, target.TargetNameWorkerServer, osbuildArgs.Targets[0].Name)
+			require.NotNil(t, osbuildArgs.ManifestDynArgsIdx, "ManifestDynArgsIdx should be set for multi-dep OSBuild")
+			require.Equal(t, 0, *osbuildArgs.ManifestDynArgsIdx)
+			require.Empty(t, osbuildArgs.Targets, "static targets should be empty for bootc composes")
+			require.NotNil(t, osbuildArgs.PreManifestDynArgsIdx, "PreManifestDynArgsIdx should be set")
+			require.Equal(t, 1, *osbuildArgs.PreManifestDynArgsIdx)
 
-			// OSBuild depends on ManifestByID
-			require.Len(t, osbuildDeps, 1)
+			// OSBuild depends on ManifestByID and BootcPreManifest
+			require.Len(t, osbuildDeps, 2, "OSBuild should depend on ManifestByID and BootcPreManifest")
 			manifestJobID := osbuildDeps[0]
+			osbuildPreManifestDepJobID := osbuildDeps[1]
 
 			// NOTE: we do not check the job args here, because ManifestByID job has no static
 			// arguments since it accesses all of its dependencies directly via job IDs.
@@ -3154,6 +3234,15 @@ func TestComposeBootc(t *testing.T) {
 			var preManifestArgs worker.BootcPreManifestJob
 			require.NoError(t, json.Unmarshal(preManifestArgsJSON, &preManifestArgs))
 			require.Equal(t, "qcow2", preManifestArgs.ImageType)
+
+			// Verify upload targets in pre-manifest args
+			require.Len(t, preManifestArgs.UploadTargets, len(tc.expectedUploadTargetTypes),
+				"pre-manifest should have %d upload targets", len(tc.expectedUploadTargetTypes))
+			for i, expectedType := range tc.expectedUploadTargetTypes {
+				require.Equal(t, expectedType, preManifestArgs.UploadTargets[i].Type,
+					"upload target %d type mismatch", i)
+			}
+
 			require.NotZero(t, preManifestArgs.Seed, "BootcPreManifest seed should not be zero")
 			// Verify the BootcInfoResolve job ID and index are set correctly
 			require.NotNil(t, preManifestArgs.BootcInfoResolveDynArgsIdx)
@@ -3193,6 +3282,11 @@ func TestComposeBootc(t *testing.T) {
 			// the same job referenced by ManifestByID dependencies
 			require.Equal(t, bootcInfoResolveJobID, preManifestBootcInfoResolveJobID,
 				"ManifestByID and BootcPreManifest should reference the same BootcInfoResolve job")
+
+			// The OSBuild pre-manifest dep should be the same as
+			// the ManifestByID pre-manifest dep
+			require.Equal(t, bootcPreManifestDepJobID, osbuildPreManifestDepJobID,
+				"OSBuild and ManifestByID should reference the same BootcPreManifest job")
 
 			// ManifestByID should directly depend on BootcPreManifest (third dependency)
 			require.Equal(t, preManifestJobID, bootcPreManifestDepJobID,

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -51,6 +51,10 @@ type OSBuildJob struct {
 	// as part of the depsolve job, so that they can be uploaded to Koji.
 	DepsolveDynArgsIdx *int `json:"depsolve_dyn_args_idx,omitempty"`
 
+	// Index of the BootcPreManifestJobResult in dynamic args, from which
+	// to read complete targets when static Targets is empty.
+	PreManifestDynArgsIdx *int `json:"pre_manifest_dyn_args_idx,omitempty"`
+
 	Targets []*target.Target `json:"targets,omitempty"`
 
 	// Deprecated: PipelineNames should not be set on OSBuildJob args.

--- a/internal/worker/json.go
+++ b/internal/worker/json.go
@@ -1317,6 +1317,13 @@ type BootcInfoResolveJobResult struct {
 	JobResult
 }
 
+// BootcUploadTarget is a serializable representation of an API upload target,
+// usable across packages without depending on the v2 package.
+type BootcUploadTarget struct {
+	Type    string          `json:"type"`
+	Options json.RawMessage `json:"options,omitempty"`
+}
+
 // BootcPreManifestJob is a server-side job that generates a pre-manifest
 // from resolved bootc info. Its result contains the arguments for
 // downstream resolve jobs.
@@ -1335,6 +1342,12 @@ type BootcPreManifestJob struct {
 	// Index of the build container info within BootcInfoResolveJobResult.Infos.
 	// If nil, the base container is used for build as well.
 	BuildInfoIdx *int `json:"build_info_idx,omitempty"`
+
+	// Upload targets to construct in the pre-manifest job.
+	// Each entry is a normalized upload target spec (type + options).
+	// Both explicit UploadTargets and the default UploadOptions from the API
+	// request are merged into this single slice at enqueue time.
+	UploadTargets []BootcUploadTarget `json:"upload_targets,omitempty"`
 }
 
 // BootcPreManifestJobResult holds the result of a BootcPreManifest job,
@@ -1351,6 +1364,10 @@ type BootcPreManifestJobResult struct {
 	// need to be resolved. This information can be used by parent jobs for
 	// detecting version mismatches during manifest serialization.
 	ManifestInfo ManifestInfo `json:"info,omitempty"`
+
+	// Complete upload targets constructed from the upload target specs
+	// using the distro.ImageType available in the pre-manifest job.
+	Targets []*target.Target `json:"targets,omitempty"`
 
 	JobResult
 }

--- a/test/cases/api-bootc.sh
+++ b/test/cases/api-bootc.sh
@@ -205,7 +205,7 @@ cat > "$REQ" << EOF
     "architecture": "$ARCH",
     "image_type": "guest-image",
     "repositories": [],
-    "upload_options": {}
+    "upload_targets": [{"type": "local", "upload_options": {}}]
   }
 }
 EOF

--- a/test/cases/api-bootc.sh
+++ b/test/cases/api-bootc.sh
@@ -192,6 +192,33 @@ function verifyManifestContainerSourceType() {
     fi
 }
 
+function verifyImageDownload() {
+    ARTIFACT_PATH=$(echo "$UPLOAD_OPTIONS" | jq -r '.artifact_path')
+    test -n "$ARTIFACT_PATH"
+    test "$ARTIFACT_PATH" != "null"
+
+    DOWNLOAD_OUTPUT="${WORKDIR}/downloaded-image"
+    HTTPSTATUS=$(curl \
+        --silent \
+        --show-error \
+        --cacert /etc/osbuild-composer/ca-crt.pem \
+        --key /etc/osbuild-composer/client-key.pem \
+        --cert /etc/osbuild-composer/client-crt.pem \
+        --write-out '%{http_code}' \
+        --output "$DOWNLOAD_OUTPUT" \
+        "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID/download")
+    echo "Download HTTP status: $HTTPSTATUS"
+    test "$HTTPSTATUS" = "200"
+    test -s "$DOWNLOAD_OUTPUT"
+
+    # sudo is needed to access the artifact in the worker's private directory
+    ARTIFACT_SIZE=$(sudo stat --format='%s' "$ARTIFACT_PATH")
+    DOWNLOAD_SIZE=$(stat --format='%s' "$DOWNLOAD_OUTPUT")
+    echo "Artifact size: $ARTIFACT_SIZE"
+    echo "Download size: $DOWNLOAD_SIZE"
+    test "$ARTIFACT_SIZE" = "$DOWNLOAD_SIZE"
+}
+
 WORKDIR=$(mktemp -d)
 REQ="${WORKDIR}/compose_request.json"
 ARCH=$(uname -m)
@@ -226,4 +253,5 @@ curl \
     "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID"
 test "$UPLOAD_STATUS" = "success"
 
+verifyImageDownload
 verifyManifestContainerSourceType


### PR DESCRIPTION
Bootc composes hardcoded a local upload target at enqueue time, making them unusable in the hosted service where cloud upload targets (e.g., AWS S3) are required. This PR moves upload target construction into the `BootcPreManifest` server-side job — where the `distro.ImageType` is available after resolving bootc container info — and validates targets against `targetSupportMap()` at enqueue time, consistent with the non-bootc flow. This is a required prerequisite for enabling bootc composes in the service.

While this change technically enables building bootc-based qcow2 images with an AWS S3 upload target, that is not the goal here. The focus is on refactoring the upload target handling while keeping on-prem bootc composes working. An end-to-end test verifying the full service flow will follow as a next step.

## Architectural Changes

Target construction is deferred from enqueue time to the `BootcPreManifest` job because `distro.ImageType` is only available after resolving bootc container info, and the worker must not derive image-type-dependent data (version skew risk). The OSBuild job graph gains a dependency on `BootcPreManifest` and reads targets from dynargs via `PreManifestDynArgsIdx`, following the existing container-resolve pattern.

## Key Changes

- Add `BootcUploadTarget` struct and extend `BootcPreManifestJob`/`Result` to carry target specs and constructed targets across the job boundary
- Construct complete targets in `handleBootcPreManifest` using the same `getTarget()` code path as non-bootc composes
- Add `PreManifestDynArgsIdx` to `OSBuildJob`; worker reads targets from dynargs with mutual-exclusivity guard
- Replace hardcoded local target in `enqueueBootcCompose` with `targetSupportMap()` validation and target normalization
- Remove `*ComposeRequest` parameter from `getTarget()`/`GetTargets()` — derive container image name from `distro.ImageType` instead
- Update `api-bootc.sh` to use explicit `upload_targets` and add image download verification

## Breaking Changes

This PR is fully backward compatible. The `UploadOptions` field continues to work — it is normalized to a default target type at enqueue time, same as non-bootc.

## Testing

- Extended `TestComposeBootc` with table-driven cases: aws.s3 and local via `upload_targets`, default via `upload_options`, invalid target rejection, and missing target rejection
- Verified job graph wiring: OSBuild depends on ManifestByID + BootcPreManifest, static targets empty, dynargs index set
- Extended pre-manifest happy-path tests with aws.s3, local, and multi-target cases asserting target names, artifact metadata, and target-specific options
- Added pre-manifest error case for invalid upload target options JSON
- Updated `api-bootc.sh` to use explicit local target and verify image download