### PR TITLE
templates/packer: set authfile location for container registries

### DIFF
--- a/templates/packer/ansible/roles/common/files/worker-initialization-scripts/container_registries_login.sh
+++ b/templates/packer/ansible/roles/common/files/worker-initialization-scripts/container_registries_login.sh
@@ -22,5 +22,12 @@ for key in $(jq -r 'keys[]' /tmp/container_registries_login.json); do
     echo "Logging in to container registry $key (username: $USER)."
 
     PASSWORD=$(jq -r .[\""$key"\"].password /tmp/container_registries_login.json)
-    echo "$PASSWORD" | sudo podman login --username="$USER" --password-stdin "$key"
+    echo "$PASSWORD" | sudo podman login --username="$USER" --password-stdin --authfile /etc/osbuild-worker/container-registries-auth.json "$key"
 done
+
+sudo mkdir -p /etc/systemd/system/osbuild-remote-worker@.service.d
+sudo tee "/etc/systemd/system/osbuild-remote-worker@.service.d/registry-auth.conf" <<EOF
+[Service]
+Environment="REGISTRY_AUTH_FILE=/etc/osbuild-worker/container-registries-auth.json"
+EOF
+sudo systemctl daemon-reload


### PR DESCRIPTION
The default location in /run/containers/0 is too ephemeral, it disappears after a successful login in the initialization stage. Using a separate authfile in combination with a systemd dropin bypasses this issue.