### PR TITLE
spec: update composer-cli dependency to weldr-client

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -21,7 +21,7 @@ A service for building customized OS artifacts, such as VM images and OSTree
 commits, that uses osbuild under the hood. Besides building images for local
 usage, it can also upload images directly to cloud.
 
-It is compatible with composer-cli and cockpit-composer clients.
+It is compatible with weldr-client and cockpit-composer clients.
 }
 
 Name:           osbuild-composer
@@ -375,7 +375,7 @@ Requires:   %{name}
 %else
 Requires:   %{name} = %{version}-%{release}
 %endif
-Requires:   composer-cli
+Requires:   weldr-client
 Requires:   createrepo_c
 Requires:   xorriso
 Requires:   qemu-kvm-core


### PR DESCRIPTION
This was renamed long ago, and the Obsoletes/Provides for the old name was recently dropped:

https://github.com/osbuild/weldr-client/commit/349392c16fbac610e3cb71b09f5dcdf3929c8b6e