### PR TITLE
test/worker-executor*: add missing '$' when referencing a variable

### DIFF
--- a/test/cases/worker-executor-crash.sh
+++ b/test/cases/worker-executor-crash.sh
@@ -159,7 +159,7 @@ gpgcheck=0
 priority=10
 EOF
 
-ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@EXECUTOR_IP" sudo journalctl -f &
+ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@$EXECUTOR_IP" sudo journalctl -f &
 subprocessPIDs+=( $! )
 
 ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@$EXECUTOR_IP" sudo dnf install -y osbuild-composer osbuild

--- a/test/cases/worker-executor.sh
+++ b/test/cases/worker-executor.sh
@@ -156,7 +156,7 @@ gpgcheck=0
 priority=10
 EOF
 
-ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@EXECUTOR_IP" sudo journalctl -f &
+ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@$EXECUTOR_IP" sudo journalctl -f &
 subprocessPIDs+=( $! )
 
 ssh -oStrictHostKeyChecking=no -i "$KEYPAIR" "fedora@$EXECUTOR_IP" sudo dnf install -y osbuild-composer osbuild


### PR DESCRIPTION
SSIA