### PR TITLE
Add end-to-end functional test for bootc composes in a service deployment (HMS-10008)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -925,6 +925,19 @@ WorkerExecutorFailure:
     RUNNER: aws/fedora-42-x86_64
     IAM_INSTANCE_PROFILE: worker-executor
 
+API-bootc-service:
+  stage: test
+  extends: .terraform
+  timeout: 120m
+  rules:
+    - !reference [.upstream_and_ga_rules_all, rules]
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/api-bootc-service.sh guest-image
+  variables:
+    RUNNER: aws/rhel-10.1-ga-x86_64
+    IAM_INSTANCE_PROFILE: worker-executor
+
 
 CleanStore:
   stage: test

--- a/Schutzfile
+++ b/Schutzfile
@@ -222,6 +222,13 @@
     "dependencies": {
       "osbuild": {
         "commit": "d36f11818f6f7b301ba392c6f7378eb908c1f943"
+      },
+      "bootc": {
+        "guest-image": {
+          "x86_64": {
+            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+          }
+        }
       }
     }
   },

--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -241,6 +241,9 @@ install -m 0755 -vp test/cases/*.sh                                %{buildroot}%
 install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/tests/osbuild-composer/api
 install -m 0755 -vp test/cases/api/*.sh                            %{buildroot}%{_libexecdir}/tests/osbuild-composer/api/
 
+install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/tests/osbuild-composer/api/bootc
+install -m 0755 -vp test/cases/api/bootc/*.sh                      %{buildroot}%{_libexecdir}/tests/osbuild-composer/api/bootc/
+
 install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/tests/osbuild-composer/api/common
 install -m 0755 -vp test/cases/api/common/*.sh                     %{buildroot}%{_libexecdir}/tests/osbuild-composer/api/common/
 

--- a/test/cases/api-bootc-service.sh
+++ b/test/cases/api-bootc-service.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/bash
+
+#
+# End-to-end functional test for bootc composes in a service deployment.
+# Tests the full pipeline: Cloud API + JWT + private registry + AWS EC2
+# executor + cloud upload target + image verification.
+#
+# Usage: api-bootc-service.sh <image-type>
+#   e.g.: api-bootc-service.sh guest-image
+#
+
+set -euo pipefail
+
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+source /usr/libexec/tests/osbuild-composer/api/common/image-types.sh
+source /usr/libexec/tests/osbuild-composer/api/common/bootc.sh
+source /usr/libexec/tests/osbuild-composer/api/common/executor.sh
+
+if (( $# != 1 )); then
+    redprint "Usage: $0 <image-type>"
+    redprint "Supported image types: ${IMAGE_TYPE_GUEST}"
+    exit 1
+fi
+
+IMAGE_TYPE="$1"
+
+# Select handler based on image type
+case "${IMAGE_TYPE}" in
+    "$IMAGE_TYPE_GUEST")
+        source /usr/libexec/tests/osbuild-composer/api/bootc/guest.s3.sh
+        ;;
+    *)
+        redprint "Unknown image type: ${IMAGE_TYPE}"
+        exit 1
+        ;;
+esac
+
+ARTIFACTS="${ARTIFACTS:-/tmp/artifacts}"
+
+# Container image used for cloud provider CLI tools (used by sourced handlers)
+export CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest"
+
+# This test relies on podman-specific behavior (authfile + image exists checks).
+if ! type -p podman 2>/dev/null >&2; then
+    redprint "podman is required for api-bootc-service.sh."
+    exit 2
+fi
+CONTAINER_RUNTIME=podman
+
+#
+# Resolve bootc container ref from Schutzfile
+#
+ARCH=$(uname -m)
+BOOTC_CONTAINER_REF="${BOOTC_CONTAINER_REF_OVERRIDE:-$(jq -r \
+    ".[\"${ID}-${VERSION_ID}\"].dependencies.bootc[\"${IMAGE_TYPE}\"][\"${ARCH}\"].base" \
+    Schutzfile)}"
+
+if [ -z "$BOOTC_CONTAINER_REF" ] || [ "$BOOTC_CONTAINER_REF" = "null" ]; then
+    redprint "No bootc container ref found in Schutzfile for ${ID}-${VERSION_ID} / ${IMAGE_TYPE} / ${ARCH}"
+    exit 1
+fi
+greenprint "Using bootc container ref: ${BOOTC_CONTAINER_REF}"
+
+# Extract registry host from the container ref (everything before the first /)
+REGISTRY_HOST="${BOOTC_CONTAINER_REF%%/*}"
+
+#
+# Verify environment
+#
+greenprint "Verifying environment"
+checkEnv
+
+#
+# Provision the software under test (JWT mode).
+# This sets up certificates, JWT composer/worker configs, mock auth servers,
+# and starts Cloud API + remote worker units.
+#
+section_start "provision" "Provisioning with JWT authentication" true
+/usr/libexec/osbuild-composer-test/provision.sh jwt
+section_end "provision"
+
+#
+# Set up the database queue
+#
+section_start "provision-db" "Provisioning the database" true
+DB_CONTAINER_NAME="osbuild-composer-db"
+sudo "${CONTAINER_RUNTIME}" run -d --name "${DB_CONTAINER_NAME}" \
+    --health-cmd "pg_isready -U postgres -d osbuildcomposer" --health-interval 2s \
+    --health-timeout 2s --health-retries 10 \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=foobar \
+    -e POSTGRES_DB=osbuildcomposer \
+    -p 5432:5432 \
+    --net host \
+    quay.io/osbuild/postgres:13-alpine
+
+sudo "${CONTAINER_RUNTIME}" logs "${DB_CONTAINER_NAME}"
+
+pushd "$(mktemp -d)"
+sudo dnf install -y go
+go mod init temp
+go install github.com/jackc/tern@latest
+PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PGPORT=5432 \
+    "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
+popd
+section_end "provision-db"
+
+#
+# Cleanup handler
+#
+WORKDIR=$(mktemp -d)
+KILL_PIDS=()
+
+function dump_db() {
+    if ! sudo "${CONTAINER_RUNTIME}" inspect --format '{{.State.Running}}' "${DB_CONTAINER_NAME}" 2>/dev/null | grep -q true; then
+        yellowprint "DB container ${DB_CONTAINER_NAME} is not running, skipping dump"
+        return
+    fi
+    sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" \
+        psql -U postgres -d osbuildcomposer -c "SELECT type, args, result FROM jobs" \
+        | sudo tee "${ARTIFACTS}/build-result.txt" > /dev/null
+}
+
+function cleanups() {
+    section_start "cleanup" "Cleaning up" true
+    set +eu
+
+    greenprint "Cleanup: killing background processes"
+    for P in "${KILL_PIDS[@]}"; do
+        sudo pkill -P "$P" 2>/dev/null || true
+    done
+
+    greenprint "Cleanup: handler cleanup (S3)"
+    cleanup
+
+    greenprint "Cleanup: dumping DB"
+    dump_db
+
+    greenprint "Cleanup: stopping DB container"
+    sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
+    sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
+
+    greenprint "Cleanup: removing executor keypair"
+    cleanupExecutor
+
+    greenprint "Cleanup: removing workdir"
+    sudo rm -rf "$WORKDIR"
+
+    greenprint "Cleanup: stopping mock auth servers"
+    /usr/libexec/osbuild-composer-test/run-mock-auth-servers.sh stop
+
+    greenprint "Cleanup: done"
+    set -eu
+    section_end "cleanup"
+}
+trap cleanups EXIT
+
+#
+# Configure composer with JWT + DB + bootc remote container sources.
+# Overwrites the config written by provision.sh to produce a single valid TOML
+# file (duplicate [worker] sections would make the parser reject the file).
+#
+section_start "configure-composer" "Configuring osbuild-composer" true
+sudo tee /etc/osbuild-composer/osbuild-composer.toml > /dev/null <<EOF
+ignore_missing_repos = true
+
+# Despite the name, [koji] configures the Cloud API (osbuild-composer-api.socket, port 443).
+# Without it, defaults (enable_tls=true, enable_mtls=true) would require mTLS on the API.
+[koji]
+enable_tls = false
+enable_mtls = false
+enable_jwt = true
+jwt_keys_urls = ["https://localhost:8082/certs"]
+jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
+jwt_acl_file = ""
+jwt_tenant_provider_fields = ["rh-org-id"]
+
+# [worker] configures the remote worker API (osbuild-remote-worker.socket, port 8700).
+[worker]
+enable_artifacts = false
+enable_tls = true
+enable_mtls = false
+enable_jwt = true
+jwt_keys_urls = ["https://localhost:8082/certs"]
+jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
+jwt_tenant_provider_fields = ["rh-org-id"]
+pg_host = "localhost"
+pg_port = "5432"
+pg_database = "osbuildcomposer"
+pg_user = "postgres"
+pg_password = "foobar"
+pg_ssl_mode = "disable"
+pg_max_conns = 10
+
+[bootc]
+use_remote_container_source = true
+EOF
+
+sudo systemctl restart osbuild-composer
+section_end "configure-composer"
+
+#
+# Configure container registry authentication
+#
+section_start "configure-registry-auth" "Configuring container registry authentication" true
+CONTAINER_AUTH_FILE="/etc/osbuild-worker/containerauth.json"
+sudo "${CONTAINER_RUNTIME}" login \
+    --authfile "${CONTAINER_AUTH_FILE}" \
+    --username "${BOOTC_FOUNDRY_DERIVED_CONTAINERS_REGISTRY_USER}" \
+    --password "${BOOTC_FOUNDRY_DERIVED_CONTAINERS_REGISTRY_PASS}" \
+    "${REGISTRY_HOST}"
+
+# Set REGISTRY_AUTH_FILE for all worker instances via systemd drop-in
+WORKER_DROPIN_DIR="/etc/systemd/system/osbuild-remote-worker@.service.d"
+sudo mkdir -p "${WORKER_DROPIN_DIR}"
+sudo tee "${WORKER_DROPIN_DIR}/registry-auth.conf" > /dev/null <<EOF
+[Service]
+Environment="REGISTRY_AUTH_FILE=${CONTAINER_AUTH_FILE}"
+EOF
+
+section_end "configure-registry-auth"
+
+#
+# Install cloud provider client tools (from handler)
+#
+section_start "install-client" "Installing cloud provider client tools" true
+installClient
+section_end "install-client"
+
+#
+# Configure worker: executor (JWT auth and AWS credentials already configured by provision.sh)
+#
+section_start "configure-worker" "Configuring osbuild-worker" true
+
+# Set up executor keypair. Key name is exported as EXECUTOR_KEY_NAME.
+setupExecutorKeypair
+
+# Append executor configuration to the worker config
+sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null <<EOF
+
+[osbuild_executor]
+type = "aws.ec2"
+key_name = "${EXECUTOR_KEY_NAME}"
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart "osbuild-remote-worker@*"
+
+section_end "configure-worker"
+
+# Tail worker journal for diagnostics
+sudo journalctl -af -n 1 -u "osbuild-remote-worker@*" &
+KILL_PIDS+=("$!")
+
+#
+# Verify openapi endpoint is accessible
+#
+section_start "verify-openapi" "Verifying Cloud API is accessible" true
+TOKEN=$(curl --request POST \
+    --data "grant_type=refresh_token" \
+    --data "refresh_token=$(cat /etc/osbuild-worker/token)" \
+    --header "Content-Type: application/x-www-form-urlencoded" \
+    --silent \
+    --show-error \
+    --fail \
+    localhost:8081/token | jq -r .access_token)
+
+curl \
+    --silent \
+    --show-error \
+    --fail \
+    --header "Authorization: Bearer ${TOKEN}" \
+    http://localhost:443/api/image-builder-composer/v2/openapi | jq .
+section_end "verify-openapi"
+
+#
+# Pre-compose verification: container ref should NOT be in local storage
+#
+section_start "verify-container-ref-pre-compose" "Verifying container ref is NOT in local storage" true
+if sudo podman image exists "${BOOTC_CONTAINER_REF}" 2>/dev/null; then
+    redprint "Container ref ${BOOTC_CONTAINER_REF} already exists in local storage!"
+    exit 1
+fi
+section_end "verify-container-ref-pre-compose"
+
+#
+# Compose execution
+#
+REQUEST_FILE="${WORKDIR}/compose_request.json"
+export REQUEST_FILE WORKDIR ARCH IMAGE_TYPE BOOTC_CONTAINER_REF
+
+greenprint "Creating compose request"
+createReqFile
+
+function sendCompose() {
+    local OUTPUT HTTPSTATUS
+    OUTPUT=$(mktemp)
+    HTTPSTATUS=$(curl \
+        --silent \
+        --show-error \
+        --header "Authorization: Bearer ${TOKEN}" \
+        --header 'Content-Type: application/json' \
+        --request POST \
+        --data @"$1" \
+        --write-out '%{http_code}' \
+        --output "$OUTPUT" \
+        http://localhost:443/api/image-builder-composer/v2/compose)
+
+    if [ "$HTTPSTATUS" != "201" ]; then
+        redprint "Sending compose request failed:"
+        cat "$OUTPUT"
+    fi
+
+    test "$HTTPSTATUS" = "201"
+
+    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
+}
+
+function waitForState() {
+    local DESIRED_STATE="${1:-success}"
+    local MAX_ITERATIONS=120
+    local ITERATIONS=0
+    local OUTPUT COMPOSE_STATUS
+
+    local SECTION_ID
+    SECTION_ID="wait-for-state-$(uuidgen)"
+    section_start "${SECTION_ID}" "Waiting for compose to reach state '${DESIRED_STATE}'" true
+    while [ "$ITERATIONS" -lt "$MAX_ITERATIONS" ]
+    do
+        ITERATIONS=$((ITERATIONS + 1))
+        OUTPUT=$(curl \
+            --silent \
+            --show-error \
+            --fail \
+            --header "Authorization: Bearer ${TOKEN}" \
+            http://localhost:443/api/image-builder-composer/v2/composes/"$COMPOSE_ID")
+
+        COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
+        UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.status')
+        UPLOAD_OPTIONS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.options')
+
+        case "$COMPOSE_STATUS" in
+            "$DESIRED_STATE"|"success")
+                break
+                ;;
+            "pending"|"building"|"uploading"|"registering")
+                ;;
+            "failure")
+                redprint "Image compose failed"
+                echo "API output: $OUTPUT"
+                dump_db
+                exit 1
+                ;;
+            *)
+                redprint "API returned unexpected image_status.status value: '$COMPOSE_STATUS'"
+                echo "API output: $OUTPUT"
+                dump_db
+                exit 1
+                ;;
+        esac
+
+        sleep 30
+    done
+
+    if [ "$ITERATIONS" -ge "$MAX_ITERATIONS" ]; then
+        redprint "Timed out waiting for compose to reach state '${DESIRED_STATE}' after $((MAX_ITERATIONS * 30)) seconds"
+        dump_db
+        exit 1
+    fi
+
+    export UPLOAD_STATUS UPLOAD_OPTIONS
+    section_end "${SECTION_ID}"
+}
+
+function verifyManifestContainerSourceType() {
+    MANIFESTS=$(curl \
+        --silent \
+        --show-error \
+        --fail \
+        --header "Authorization: Bearer ${TOKEN}" \
+        "http://localhost:443/api/image-builder-composer/v2/composes/$COMPOSE_ID/manifests")
+    verifyContainerSourceType "$MANIFESTS" "remote"
+}
+
+greenprint "Sending bootc compose"
+sendCompose "$REQUEST_FILE"
+
+#
+# Wait for the worker to pick up the compose job before looking for the
+# executor instance it creates.
+#
+waitForState "building"
+
+#
+# The worker creates the executor EC2 instance when it picks up the osbuild
+# job from the compose above. Wait for it to appear, then provision and start it.
+#
+section_start "setup-executor" "Setting up executor" true
+waitForExecutorInstance
+verifyExecutorNetworkIsolation
+provisionExecutor
+startExecutor
+section_end "setup-executor"
+
+waitForState "success"
+
+test "$UPLOAD_STATUS" = "success"
+
+#
+# Post-compose verification: container ref should now be in local storage
+#
+section_start "verify-container-ref-post-compose" "Verifying container ref IS in local storage" true
+if ! sudo podman image exists "${BOOTC_CONTAINER_REF}" 2>/dev/null; then
+    redprint "Container ref ${BOOTC_CONTAINER_REF} was NOT pulled to local storage by BootcInfoResolveJob!"
+    exit 1
+fi
+section_end "verify-container-ref-post-compose"
+
+#
+# Verify upload status options (from handler)
+#
+greenprint "Checking upload status options"
+checkUploadStatusOptions
+
+#
+# Verify the container source type in the compose manifest is correct
+#
+section_start "verify-manifest" "Verifying container source type in compose manifest" true
+verifyManifestContainerSourceType
+section_end "verify-manifest"
+
+#
+# Verify the built image (from handler)
+#
+section_start "verify-image" "Verifying built image" true
+verify
+section_end "verify-image"
+
+greenprint "✅ DONE"
+exit 0

--- a/test/cases/api-bootc.sh
+++ b/test/cases/api-bootc.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+source /usr/libexec/tests/osbuild-composer/api/common/bootc.sh
 
 /usr/libexec/osbuild-composer-test/provision.sh
 
@@ -179,16 +180,10 @@ function verifyManifestContainerSourceType() {
         "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID/manifests")
     echo "compose MANIFESTS:"
     echo "$MANIFESTS"
-    HAS_SKOPEO=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.skopeo")')
-    HAS_LOCAL=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.containers-storage")')
-    echo "has org.osbuild.skopeo: $HAS_SKOPEO"
-    echo "has org.osbuild.containers-storage: $HAS_LOCAL"
     if [ "$BOOTC_USE_REMOTE_CONTAINER_SOURCE" = "true" ]; then
-        test "$HAS_SKOPEO" = "true"
-        test "$HAS_LOCAL" = "false"
+        verifyContainerSourceType "$MANIFESTS" "remote"
     else
-        test "$HAS_SKOPEO" = "false"
-        test "$HAS_LOCAL" = "true"
+        verifyContainerSourceType "$MANIFESTS" "local"
     fi
 }
 

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -21,18 +21,7 @@ CLOUD_PROVIDER_OCI="oci"
 #
 # Supported Image type names
 #
-export IMAGE_TYPE_AWS="aws"
-export IMAGE_TYPE_AZURE="azure"
-export IMAGE_TYPE_EDGE_COMMIT="edge-commit"
-export IMAGE_TYPE_EDGE_CONTAINER="edge-container"
-export IMAGE_TYPE_EDGE_INSTALLER="edge-installer"
-export IMAGE_TYPE_GCP="gcp"
-export IMAGE_TYPE_IMAGE_INSTALLER="image-installer"
-export IMAGE_TYPE_GUEST="guest-image"
-export IMAGE_TYPE_OCI="oci"
-export IMAGE_TYPE_VSPHERE="vsphere"
-export IMAGE_TYPE_IOT_COMMIT="iot-commit"
-export IMAGE_TYPE_IOT_BOOTABLE_CONTAINER="iot-bootable-container"
+source /usr/libexec/tests/osbuild-composer/api/common/image-types.sh
 
 if (( $# > 2 )); then
     echo "$0 does not support more than two arguments"

--- a/test/cases/api/bootc/guest.s3.sh
+++ b/test/cases/api/bootc/guest.s3.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+
+# Handler for bootc guest-image compose with aws.s3 upload target.
+# Sources the non-bootc aws.s3 handler to inherit installClient(),
+# checkUploadStatusOptions(), and cleanup(). Overrides checkEnv(),
+# createReqFile(), and verify() for bootc-specific behavior.
+
+source /usr/libexec/tests/osbuild-composer/api/aws.s3.sh
+
+# Override: check env vars needed for bootc S3 compose
+function checkEnv() {
+    printenv AWS_REGION AWS_BUCKET V2_AWS_ACCESS_KEY_ID V2_AWS_SECRET_ACCESS_KEY > /dev/null
+    printenv BOOTC_FOUNDRY_DERIVED_CONTAINERS_REGISTRY_USER BOOTC_FOUNDRY_DERIVED_CONTAINERS_REGISTRY_PASS > /dev/null
+}
+
+# Override: verify the built image without checking for customizations
+# (bootc composes do not include user or package customizations by default)
+function verify() {
+    local S3_URL
+    S3_URL=$(echo "$UPLOAD_OPTIONS" | jq -r '.url')
+    greenprint "Verifying S3 object at ${S3_URL}"
+
+    # Tag the resource as a test file
+    local S3_FILENAME
+    S3_FILENAME=$(echo "import urllib.parse; print(urllib.parse.urlsplit('$S3_URL').path.strip('/'))" | python3 -)
+
+    # tag the object, also verifying that it exists in the bucket as expected
+    $AWS_CMD s3api put-object-tagging \
+        --bucket "${AWS_BUCKET}" \
+        --key "${S3_FILENAME}" \
+        --tagging '{"TagSet": [{ "Key": "gitlab-ci-test", "Value": "true" }]}'
+
+    greenprint "✅ Successfully tagged S3 object"
+
+    # Download the disk image and do a basic format check.
+    # Bootc images lack a traditional /etc/fstab, so osbuild-image-info
+    # cannot parse them.  qemu-img info is enough to confirm the qcow2
+    # is structurally valid.
+    curl --fail "${S3_URL}" --output "${WORKDIR}/disk.qcow2"
+
+    greenprint "Verifying disk image format with qemu-img"
+    qemu-img info "${WORKDIR}/disk.qcow2"
+
+    greenprint "✅ Successfully verified S3 object"
+}
+
+# Override: create bootc-specific compose request
+function createReqFile() {
+    cat > "$REQUEST_FILE" << EOF
+{
+  "bootc": {
+    "reference": "$BOOTC_CONTAINER_REF"
+  },
+  "image_request": {
+    "architecture": "$ARCH",
+    "image_type": "${IMAGE_TYPE}",
+    "repositories": [],
+    "upload_targets": [
+      {
+        "type": "aws.s3",
+        "upload_options": {
+          "region": "${AWS_REGION}"
+        }
+      }
+    ]
+  }
+}
+EOF
+}

--- a/test/cases/api/common/bootc.sh
+++ b/test/cases/api/common/bootc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
+# Verify container source type in compose manifests JSON.
+# Args: $1 = manifests JSON, $2 = expected source ("remote" or "local")
+function verifyContainerSourceType() {
+    local MANIFESTS="$1"
+    local EXPECTED="${2:-remote}"
+
+    local HAS_SKOPEO HAS_LOCAL
+    HAS_SKOPEO=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.skopeo")')
+    HAS_LOCAL=$(echo "$MANIFESTS" | jq -r '.manifests[0].sources | has("org.osbuild.containers-storage")')
+    echo "has org.osbuild.skopeo: $HAS_SKOPEO"
+    echo "has org.osbuild.containers-storage: $HAS_LOCAL"
+
+    case "$EXPECTED" in
+        "remote")
+            test "$HAS_SKOPEO" = "true"
+            test "$HAS_LOCAL" = "false"
+            ;;
+        "local")
+            test "$HAS_SKOPEO" = "false"
+            test "$HAS_LOCAL" = "true"
+            ;;
+        *)
+            redprint "Invalid expected container source type: $EXPECTED, expected 'remote' or 'local'"
+            exit 1
+            ;;
+    esac
+}

--- a/test/cases/api/common/executor.sh
+++ b/test/cases/api/common/executor.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/bash
+
+#
+# This module contains functions for setting up and cleaning up the executor.
+#
+# It expects the following variables to be set by the caller:
+# - CONTAINER_RUNTIME
+# - CONTAINER_IMAGE_CLOUD_TOOLS
+# - AWS_REGION
+# - WORKDIR
+# - ID
+# - VERSION_ID
+# - ARCH
+# - GIT_COMMIT or CI_COMMIT_SHA
+#
+# It exports the following globals:
+# - EXECUTOR_KEYPAIR
+# - EXECUTOR_KEY_NAME
+# - EXECUTOR_SGID
+# - EXECUTOR_IP
+# - KILL_PIDS
+#
+# The intended usage is:
+# - Call setupExecutorKeypair() to set up the executor keypair
+# - Call waitForExecutorInstance() to wait for the executor instance to be ready
+# - Call verifyExecutorNetworkIsolation() to verify the executor's network isolation
+# - Call provisionExecutor() to provision the executor
+# - Call startExecutor() to start the executor
+# - Call cleanupExecutor() to clean up the executor
+#
+
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
+# Default SSH user for EC2 instances based on the OS.
+# The executor AMI matches the test host, so the cloud-init default user
+# follows the same distro convention.
+function _executor_ssh_user() {
+    case "${ID}" in
+        fedora)  echo "fedora" ;;
+        *)       echo "ec2-user" ;;
+    esac
+}
+
+# Full S3 baseurl for a CI RPM repository, matching the path layout used by
+# mockbuild.sh (upload) and deploy.sh (install).  On subscribed RHEL (GA
+# runners) the RPMs are built against CDN content, so the path contains
+# e.g. "rhel-10-cdn" instead of "rhel-10.1".
+# Args: $1 = project name (e.g. "osbuild-composer", "osbuild")
+#       $2 = commit SHA
+function _rpm_repo_baseurl() {
+    local project="$1"
+    local commit="$2"
+    local distro_version="${ID}-${VERSION_ID}"
+    if [[ "$ID" == rhel ]] && sudo subscription-manager status &>/dev/null; then
+        distro_version="rhel-${VERSION_ID%.*}-cdn"
+    fi
+    echo "http://osbuild-composer-repos.s3-website.us-east-2.amazonaws.com/${project}/${distro_version}/${ARCH}/${commit}"
+}
+
+# Build an AWS CLI command that authenticates via the EC2 instance role.
+# Each function uses this as a local AWS_CMD so it never inherits (or
+# overwrites) the caller's AWS_CMD, which may carry explicit IAM credentials
+# targeting a different AWS account.
+function _executor_aws_cmd() {
+    if hash aws 2>/dev/null; then
+        echo "aws --region ${AWS_REGION} --output json --color on"
+    else
+        echo "sudo ${CONTAINER_RUNTIME} run --rm -v ${WORKDIR}:${WORKDIR}:Z ${CONTAINER_IMAGE_CLOUD_TOOLS} aws --region ${AWS_REGION} --output json --color on"
+    fi
+}
+
+# Sets globals: EXECUTOR_KEYPAIR, INSTANCE_ID, EXECUTOR_KEY_NAME
+function setupExecutorKeypair() {
+    local AWS_CMD
+    AWS_CMD=$(_executor_aws_cmd)
+
+    EXECUTOR_KEYPAIR="${WORKDIR}/executor-keypair.pem"
+    INSTANCE_ID=$(curl -Ls http://169.254.169.254/latest/meta-data/instance-id)
+    EXECUTOR_KEY_NAME="key-for-${INSTANCE_ID}-executor"
+
+    greenprint "Creating executor keypair ${EXECUTOR_KEY_NAME} (AWS identity follows)"
+    $AWS_CMD sts get-caller-identity || true
+
+    $AWS_CMD ec2 create-key-pair \
+        --key-name "${EXECUTOR_KEY_NAME}" \
+        --query 'KeyMaterial' \
+        --output text > "$EXECUTOR_KEYPAIR"
+    chmod 400 "$EXECUTOR_KEYPAIR"
+    $AWS_CMD ec2 describe-key-pairs --key-names "${EXECUTOR_KEY_NAME}"
+}
+
+function cleanupExecutorKeypair() {
+    if [ -z "${EXECUTOR_KEY_NAME:-}" ]; then
+        return
+    fi
+
+    local AWS_CMD
+    AWS_CMD=$(_executor_aws_cmd)
+    $AWS_CMD ec2 delete-key-pair --key-name "${EXECUTOR_KEY_NAME}"
+}
+
+# Sets globals: EXECUTOR_IP, EXECUTOR_SGID
+function waitForExecutorInstance() {
+    local AWS_CMD
+    AWS_CMD=$(_executor_aws_cmd)
+
+    local DESCR_INST="${WORKDIR}/descr-inst.json"
+    local RESERVATIONS
+    local i
+
+    EXECUTOR_IP=0
+    for i in {1..60}; do
+        $AWS_CMD ec2 describe-instances \
+            --filter "Name=tag:parent,Values=$INSTANCE_ID" > "$DESCR_INST"
+        RESERVATIONS=$(jq -r '.Reservations | length' "$DESCR_INST")
+        if [ "$RESERVATIONS" -gt 0 ]; then
+            EXECUTOR_IP=$(jq -r '.Reservations[0].Instances[0].PrivateIpAddress' "$DESCR_INST")
+            break
+        fi
+
+        echo "Reservation not ready yet (attempt ${i}/60), waiting..."
+        sleep 60
+    done
+
+    if [ "$EXECUTOR_IP" = 0 ]; then
+        redprint "Unable to find executor host after 60 attempts"
+        exit 1
+    fi
+
+    EXECUTOR_SGID=$(jq -r '.Reservations[0].Instances[0].SecurityGroups[0].GroupId' "$DESCR_INST")
+
+    local RDY=0
+    for i in {0..60}; do
+        if ssh-keyscan "$EXECUTOR_IP" > /dev/null 2>&1; then
+            RDY=1
+            break
+        fi
+        echo "Waiting for SSH on ${EXECUTOR_IP} (attempt ${i}/60)..."
+        sleep 10
+    done
+
+    if [ "$RDY" = 0 ]; then
+        redprint "Unable to reach executor host $EXECUTOR_IP"
+        exit 1
+    fi
+
+    greenprint "Executor instance is ready at $EXECUTOR_IP (SG: $EXECUTOR_SGID)"
+}
+
+# Verify that the executor's security group only allows egress to the worker host.
+# The executor is created with a single egress rule targeting the parent instance.
+function verifyExecutorNetworkIsolation() {
+    local AWS_CMD
+    AWS_CMD=$(_executor_aws_cmd)
+
+    local WORKER_HOST
+    WORKER_HOST=$(curl -Ls http://169.254.169.254/latest/meta-data/local-ipv4)
+
+    local DESCR_SGRULE="${WORKDIR}/descr-sgrule.json"
+    $AWS_CMD ec2 describe-security-group-rules \
+        --filters "Name=group-id,Values=$EXECUTOR_SGID" > "$DESCR_SGRULE"
+
+    local EGRESS_TARGET
+    EGRESS_TARGET=$(jq -r '.SecurityGroupRules[] | select(.IsEgress).CidrIpv4' "$DESCR_SGRULE")
+    if [ "$EGRESS_TARGET" != "$WORKER_HOST/32" ]; then
+        redprint "Executor egress target is $EGRESS_TARGET, expected $WORKER_HOST/32"
+        exit 1
+    fi
+
+    greenprint "Executor network isolation verified: egress only to $WORKER_HOST/32"
+}
+
+function provisionExecutor() {
+    local AWS_CMD
+    AWS_CMD=$(_executor_aws_cmd)
+
+    local GIT_COMMIT="${GIT_COMMIT:-${CI_COMMIT_SHA}}"
+    local OSBUILD_GIT_COMMIT
+    OSBUILD_GIT_COMMIT=$(jq -r '.["'"${ID}-${VERSION_ID}"'"].dependencies.osbuild.commit' Schutzfile)
+
+    local COMPOSER_REPO_URL OSBUILD_REPO_URL
+    COMPOSER_REPO_URL=$(_rpm_repo_baseurl osbuild-composer "$GIT_COMMIT")
+    OSBUILD_REPO_URL=$(_rpm_repo_baseurl osbuild "$OSBUILD_GIT_COMMIT")
+
+    local AUTH_SG="${WORKDIR}/auth-sgrule.json"
+    local DESCR_SGRULE="${WORKDIR}/descr-sgrule.json"
+
+    local SSH_USER
+    SSH_USER=$(_executor_ssh_user)
+
+    greenprint "Temporarily allowing executor internet access for provisioning"
+    $AWS_CMD ec2 authorize-security-group-egress \
+        --group-id "$EXECUTOR_SGID" \
+        --protocol tcp --cidr 0.0.0.0/0 --port 1-65535 > "$AUTH_SG"
+    local SGRULEID
+    SGRULEID=$(jq -r '.SecurityGroupRules[0].SecurityGroupRuleId' "$AUTH_SG")
+
+    greenprint "Provisioning executor as ${SSH_USER}@${EXECUTOR_IP}"
+
+    # shellcheck disable=SC2087
+    ssh -oStrictHostKeyChecking=no -i "$EXECUTOR_KEYPAIR" "${SSH_USER}@${EXECUTOR_IP}" sudo tee "/etc/yum.repos.d/osbuild.repo" <<EOF
+[osbuild-composer]
+name=osbuild-composer
+baseurl=${COMPOSER_REPO_URL}
+enabled=1
+gpgcheck=0
+priority=10
+[osbuild]
+name=osbuild
+baseurl=${OSBUILD_REPO_URL}
+enabled=1
+gpgcheck=0
+priority=10
+EOF
+
+    ssh -oStrictHostKeyChecking=no -i "$EXECUTOR_KEYPAIR" "${SSH_USER}@${EXECUTOR_IP}" \
+        sudo dnf install -y osbuild-composer osbuild
+
+    greenprint "Revoking executor internet access"
+    $AWS_CMD ec2 revoke-security-group-egress \
+        --group-id "$EXECUTOR_SGID" \
+        --security-group-rule-ids "$SGRULEID"
+
+    $AWS_CMD ec2 describe-security-group-rules \
+        --filters "Name=group-id,Values=$EXECUTOR_SGID" > "$DESCR_SGRULE"
+
+    local SGRULES_LENGTH
+    SGRULES_LENGTH=$(jq -r '.SecurityGroupRules | length' "$DESCR_SGRULE")
+    if [ "$SGRULES_LENGTH" != 2 ]; then
+        redprint "Expected exactly 2 security group rules after revoking internet (got $SGRULES_LENGTH)"
+        exit 1
+    fi
+
+    greenprint "Verifying executor network isolation after provisioning"
+    verifyExecutorNetworkIsolation
+
+    greenprint "Opening worker-executor port on firewall"
+    ssh -oStrictHostKeyChecking=no -i "$EXECUTOR_KEYPAIR" "${SSH_USER}@${EXECUTOR_IP}" \
+        sudo firewall-cmd --zone=public --add-port=8001/tcp --permanent || true
+    ssh -oStrictHostKeyChecking=no -i "$EXECUTOR_KEYPAIR" "${SSH_USER}@${EXECUTOR_IP}" \
+        sudo firewall-cmd --reload || true
+}
+
+function startExecutor() {
+    local SSH_USER
+    SSH_USER=$(_executor_ssh_user)
+
+    greenprint "Starting worker executor"
+    ssh -oStrictHostKeyChecking=no -i "$EXECUTOR_KEYPAIR" "${SSH_USER}@${EXECUTOR_IP}" \
+        sudo /usr/libexec/osbuild-composer/osbuild-worker-executor -host 0.0.0.0 &
+
+    # Re-assign to avoid 'unbound variable' error when array is empty under set -u
+    KILL_PIDS=("${KILL_PIDS[@]}")
+    KILL_PIDS+=("$!")
+}
+
+function cleanupExecutor() {
+    cleanupExecutorKeypair
+}

--- a/test/cases/api/common/image-types.sh
+++ b/test/cases/api/common/image-types.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+#
+# Supported image type name constants.
+#
+# Sourced by test entry points (api.sh, api-bootc-service.sh, …) so that
+# handler scripts in api/ and api/bootc/ can reference them freely.
+#
+
+export IMAGE_TYPE_AWS="aws"
+export IMAGE_TYPE_AZURE="azure"
+export IMAGE_TYPE_EDGE_COMMIT="edge-commit"
+export IMAGE_TYPE_EDGE_CONTAINER="edge-container"
+export IMAGE_TYPE_EDGE_INSTALLER="edge-installer"
+export IMAGE_TYPE_GCP="gcp"
+export IMAGE_TYPE_IMAGE_INSTALLER="image-installer"
+export IMAGE_TYPE_GUEST="guest-image"
+export IMAGE_TYPE_OCI="oci"
+export IMAGE_TYPE_VSPHERE="vsphere"
+export IMAGE_TYPE_IOT_COMMIT="iot-commit"
+export IMAGE_TYPE_IOT_BOOTABLE_CONTAINER="iot-bootable-container"

--- a/test/cases/shared_lib.sh
+++ b/test/cases/shared_lib.sh
@@ -45,3 +45,20 @@ function yellowprint {
 function redprint {
     echo -e "\033[1;31m[$(date -Isecond)] ${1}\033[0m" >&2
 }
+
+# Helper for GitLab foldable sections
+function section_start() {
+    local section_id="${1}_$$"
+    local section_title=$2
+    local collapsed=${3:-true}
+    local params=""
+    [ "$collapsed" = "true" ] && params="[collapsed=true]"
+
+    printf "\e[0Ksection_start:%s:%s%s\r\e[0K\e[1;36m%s\e[0m\n" "$(date +%s)" "$section_id" "$params" "$section_title"
+}
+
+# Helper for GitLab foldable sections
+function section_end() {
+    local section_id="${1}_$$"
+    printf "\e[0Ksection_end:%s:%s\r\e[0K\n" "$(date +%s)" "$section_id"
+}


### PR DESCRIPTION
No existing test covers the full production-like bootc compose pipeline: Cloud API with JWT auth, private container registry, AWS EC2 executor, cloud upload target, and image verification — all in one flow. This PR adds `api-bootc-service.sh`, a new test driver that exercises this complete pipeline, along with supporting infrastructure: a reusable executor setup helper, a bootc guest-image handler for S3 uploads, and bootc container ref pinning in the Schutzfile.

## Architectural Changes

- **Handler pattern** matching the existing `api.sh` approach — pluggable image-type verification via sourced scripts in `api/bootc/`. The guest-image handler (`guest.s3.sh`) sources the non-bootc `aws.s3.sh` handler and overrides only `checkEnv()`, `createReqFile()`, and `verify()`, minimizing duplication.
- **Executor setup extracted to shared helper** (`api/common/executor.sh`) — provides `setupExecutorKeypair()`, `waitForExecutorInstance()`, `verifyExecutorNetworkIsolation()`, `provisionExecutor()`, `startExecutor()`, and `cleanupExecutor()` so both this test and `worker-executor.sh` can share provisioning logic eventually (this is out of scope for this PR).
- **Container registry auth via `REGISTRY_AUTH_FILE` systemd drop-in** instead of a `[containers]` config section — simpler and covers all container operations uniformly (BootcInfoResolveJob, ContainerResolveJob, osbuild).
- **Container source type verification extracted** to `api/common/bootc.sh` (`verifyContainerSourceType()`) for reuse across `api-bootc.sh` and the new service test.

## Key Changes

- Add `test/cases/api-bootc-service.sh` — standalone test driver for the full bootc service compose pipeline (JWT, private registry, executor, S3 upload, image verification)
- Add `test/cases/api/bootc/guest.s3.sh` — bootc-specific handler for `guest-image` with `aws.s3` upload target, reusing S3 verification/cleanup from the existing `aws.s3.sh` handler
- Add `test/cases/api/common/executor.sh` — reusable AWS EC2 executor setup/teardown helper extracted from the `worker-executor.sh` pattern
- Add `test/cases/api/common/bootc.sh` — shared `verifyContainerSourceType()` helper, refactored out of `api-bootc.sh`
- Extend `Schutzfile` with `bootc` container ref mappings (structured as image-type → arch → ref-type) for `rhel-10.1`
- Add `API-bootc-service` CI job in `.gitlab-ci.yml` targeting `aws/rhel-10.1-ga-x86_64` with the `worker-executor` IAM profile

## Testing

- New `api-bootc-service.sh` test exercises the full production-like pipeline: JWT-authenticated Cloud API compose with a private bootc container ref, built on an AWS EC2 executor, uploaded to S3, and verified offline with `osbuild-image-info`
- Pre- and post-compose checks validate that the bootc container ref transitions from absent to present in local storage (confirming BootcInfoResolveJob pulled it correctly)
- Executor network isolation is verified — the security group only allows egress to the worker host, with temporary internet access granted only during provisioning and revoked afterward
- Compose manifest is validated to confirm the remote container source (`org.osbuild.skopeo`) is used when `use_remote_container_source = true`