### PR TITLE
SPEC: add explicit Requires on podman for worker subpackage

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -329,6 +329,7 @@ The core osbuild-composer binary. This is suitable both for spawning in containe
 
 %package worker
 Summary:    The worker for osbuild-composer
+Requires:   podman
 Requires:   systemd
 Requires:   qemu-img
 Requires:   osbuild >= %{min_osbuild_version}


### PR DESCRIPTION
The worker handles jobs, such as the BootcInfoResolve, which implicitly depend on the presence of the podman CLI. Let's add an explicit dependency to the worker package, to ensure that podman is present on the system after osbuild-composer-worker package installation.