### PR TITLE
osbuild-composer.spec: fix version in spec file

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -12,7 +12,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        167
+Version:        169
 
 %gometa
 


### PR DESCRIPTION
Somehow the post release version bump never ran after releasing 167. 168 has the wrong version in the spec file. This makes sure the next release runs with 169.