### PR TITLE
Enable all bootc-supported disk image types for bootc composes, not just qcow2 (HMS-10508)

### DIFF
--- a/internal/cloudapi/v2/bootc.go
+++ b/internal/cloudapi/v2/bootc.go
@@ -1,0 +1,76 @@
+package v2
+
+import (
+	"fmt"
+
+	"github.com/osbuild/images/pkg/arch"
+	"github.com/osbuild/images/pkg/bib/osinfo"
+	"github.com/osbuild/images/pkg/bootc"
+	"github.com/osbuild/images/pkg/distro/generic"
+)
+
+// bootcSupportedImageType checks whether the given image type name is supported
+// for bootc composes on the given architecture by constructing a dummy bootc
+// distro and querying its image type registry.
+//
+// NOTE: This constructs a dummy bootc distro with placeholder values solely to
+// query the set of supported image types from the bootc-generic YAML definitions
+// in osbuild/images. The image type names and their availability are determined
+// by the YAML and do not depend on the actual container metadata. The dummy
+// values for Imgref, DefaultRootFs, Size, and OSInfo are required by the
+// NewBootc constructor validation but are not used for image type listing.
+//
+// TODO: Consider adding a dedicated helper to the osbuild/images library
+// (e.g. generic.BootcSupportedImageTypes) that returns the list of supported
+// image type names without requiring a full bootc.Info. This would eliminate
+// the need for dummy values and make the contract less fragile.
+func bootcSupportedImageType(archName string, imageTypeName string) error {
+	// Canonicalize the architecture name (e.g. "amd64" -> "x86_64")
+	// before passing to NewBootc and GetArch.
+	canonicalArch, err := arch.FromString(archName)
+	if err != nil {
+		return HTTPErrorWithDetails(
+			ErrorUnsupportedArchitecture, nil,
+			fmt.Sprintf("unsupported architecture %q for bootc composes", archName),
+		)
+	}
+	canonicalArchName := canonicalArch.String()
+
+	dummyInfo := &bootc.Info{
+		Imgref:        "dummy",
+		Arch:          canonicalArchName,
+		DefaultRootFs: "ext4",
+		Size:          1,
+		OSInfo: &osinfo.Info{
+			OSRelease: osinfo.OSRelease{
+				ID:        "dummy",
+				VersionID: "0",
+			},
+		},
+	}
+
+	bootcDistro, err := generic.NewBootc("bootc", dummyInfo)
+	if err != nil {
+		return HTTPErrorWithDetails(
+			ErrorUnsupportedImageType, nil,
+			fmt.Sprintf("failed to initialize bootc distro for arch %q: %v", canonicalArchName, err),
+		)
+	}
+
+	archi, err := bootcDistro.GetArch(canonicalArchName)
+	if err != nil {
+		return HTTPErrorWithDetails(
+			ErrorUnsupportedArchitecture, nil,
+			fmt.Sprintf("internal error: architecture %q not available in bootc distro after successful construction", canonicalArchName),
+		)
+	}
+
+	if _, err := archi.GetImageType(imageTypeName); err != nil {
+		return HTTPErrorWithDetails(
+			ErrorUnsupportedImageType, nil,
+			fmt.Sprintf("unsupported image type %q for bootc composes on %q", imageTypeName, canonicalArchName),
+		)
+	}
+
+	return nil
+}

--- a/internal/cloudapi/v2/bootc_premanifest_test.go
+++ b/internal/cloudapi/v2/bootc_premanifest_test.go
@@ -298,7 +298,7 @@ func TestHandleBootcPreManifest_Errors(t *testing.T) {
 // enqueuePreManifestWithResolvedDep enqueues a bootc info-resolve job,
 // finishes it with a valid result, and enqueues a pre-manifest job that
 // depends on it. Returns the pre-manifest job ID.
-func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec, io distro.ImageOptions, uploadTargets []worker.BootcUploadTarget) uuid.UUID {
+func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch string, specs []worker.BootcInfoResolveJobSpec, io distro.ImageOptions, uploadTargets []worker.BootcUploadTarget, imageType string) uuid.UUID {
 	t.Helper()
 	infoResolveJob := &worker.BootcInfoResolveJob{
 		Specs: specs,
@@ -307,7 +307,7 @@ func enqueuePreManifestWithResolvedDep(t *testing.T, ws *worker.Server, arch str
 	require.NoError(t, err)
 
 	preManifestJob := &worker.BootcPreManifestJob{
-		ImageType:                  "qcow2",
+		ImageType:                  imageType,
 		Seed:                       42,
 		BootcInfoResolveDynArgsIdx: common.ToPtr(0),
 		ImageOptions:               io,
@@ -378,20 +378,24 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
+		imageType                string // internal image type name (e.g. "qcow2", "ami")
 		useRemoteContainerSource bool
 		uploadTargets            []worker.BootcUploadTarget
 		expectedTargets          []expectedTarget
 	}{
 		{
 			name:                     "default/local_container_source",
+			imageType:                "qcow2",
 			useRemoteContainerSource: false,
 		},
 		{
 			name:                     "remote_container_source",
+			imageType:                "qcow2",
 			useRemoteContainerSource: true,
 		},
 		{
 			name:                     "aws_s3_upload_target",
+			imageType:                "qcow2",
 			useRemoteContainerSource: false,
 			uploadTargets: []worker.BootcUploadTarget{
 				{Type: "aws.s3", Options: json.RawMessage(`{"region":"us-east-1"}`)},
@@ -411,6 +415,7 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 		},
 		{
 			name:                     "local_upload_target",
+			imageType:                "qcow2",
 			useRemoteContainerSource: false,
 			uploadTargets: []worker.BootcUploadTarget{
 				{Type: "local", Options: json.RawMessage(`{}`)},
@@ -427,6 +432,7 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 		},
 		{
 			name:                     "multiple_upload_targets",
+			imageType:                "qcow2",
 			useRemoteContainerSource: false,
 			uploadTargets: []worker.BootcUploadTarget{
 				{Type: "aws.s3", Options: json.RawMessage(`{"region":"eu-west-1"}`)},
@@ -450,6 +456,42 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                     "ami_image_type/aws",
+			imageType:                "ami",
+			useRemoteContainerSource: false,
+			uploadTargets: []worker.BootcUploadTarget{
+				{Type: "aws", Options: json.RawMessage(`{"region":"us-east-1", "share_with_accounts":["1234567890"]}`)},
+			},
+			expectedTargets: []expectedTarget{
+				{name: target.TargetNameAWS, verify: func(t *testing.T, tgt *target.Target) {
+					opts, ok := tgt.Options.(*target.AWSTargetOptions)
+					require.True(t, ok, "expected AWSTargetOptions")
+					assert.Equal(t, "us-east-1", opts.Region)
+					assert.Equal(t, []string{"1234567890"}, opts.ShareWithAccounts)
+				}},
+			},
+		},
+		{
+			name:                     "vhd_image_type/azure",
+			imageType:                "vhd",
+			useRemoteContainerSource: false,
+			uploadTargets: []worker.BootcUploadTarget{
+				{Type: "azure", Options: json.RawMessage(`{"tenant_id":"test-tenant","subscription_id":"test-sub","resource_group":"test-rg"}`)},
+			},
+			expectedTargets: []expectedTarget{
+				{
+					name: target.TargetNameAzureImage,
+					verify: func(t *testing.T, tgt *target.Target) {
+						opts, ok := tgt.Options.(*target.AzureImageTargetOptions)
+						require.True(t, ok, "expected AzureImageTargetOptions")
+						assert.Equal(t, "test-tenant", opts.TenantID)
+						assert.Equal(t, "test-sub", opts.SubscriptionID)
+						assert.Equal(t, "test-rg", opts.ResourceGroup)
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -466,7 +508,7 @@ func TestHandleBootcPreManifest_HappyPath(t *testing.T) {
 				Bootc: &distro.BootcImageOptions{
 					UseRemoteContainerSource: tc.useRemoteContainerSource,
 				},
-			}, tc.uploadTargets)
+			}, tc.uploadTargets, tc.imageType)
 
 			// Dequeue the pre-manifest job (it should be pending now)
 			jobID, preManifestToken, _, staticArgs, dynArgs, err := workerServer.RequestJob(
@@ -532,7 +574,7 @@ func TestBootcPreManifestLoop_PicksUpJob(t *testing.T) {
 	}
 	archi := arch.ARCH_X86_64.String()
 
-	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{}, nil)
+	preManifestJobID := enqueuePreManifestWithResolvedDep(t, workerServer, archi, specs, distro.ImageOptions{}, nil, "qcow2")
 
 	// Wait for the loop to pick up and finish the pre-manifest job.
 	// Poll with timeout.

--- a/internal/cloudapi/v2/bootc_test.go
+++ b/internal/cloudapi/v2/bootc_test.go
@@ -1,0 +1,104 @@
+package v2_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v2 "github.com/osbuild/osbuild-composer/internal/cloudapi/v2"
+)
+
+func TestBootcSupportedImageType(t *testing.T) {
+	tests := []struct {
+		name          string
+		arch          string
+		imageTypeName string
+		expectErrMsg  string
+	}{
+		// Supported: API image types that map to bootc YAML entries
+		{
+			name:          "guest-image on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesGuestImage),
+		},
+		{
+			name:          "aws on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesAws),
+		},
+		{
+			name:          "azure on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesAzure),
+		},
+		{
+			name:          "gcp on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesGcp),
+		},
+		{
+			name:          "vsphere on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesVsphere),
+		},
+		{
+			name:          "vsphere-ova on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesVsphereOva),
+		},
+		{
+			name:          "pxe-tar-xz on x86_64",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesPxeTarXz),
+		},
+		// Supported on aarch64
+		{
+			name:          "guest-image on aarch64",
+			arch:          "aarch64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesGuestImage),
+		},
+		{
+			name:          "aws on aarch64",
+			arch:          "aarch64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesAws),
+		},
+		// Unsupported: internal names not in bootc YAML
+		{
+			name:          "minimal-raw not in bootc YAML",
+			arch:          "x86_64",
+			imageTypeName: v2.ImageTypeFromApiImageType(v2.ImageTypesMinimalRaw),
+			expectErrMsg:  "unsupported image type \"minimal-raw\" for bootc composes on \"x86_64\"",
+		},
+		{
+			name:          "image-installer not in bootc YAML",
+			arch:          "x86_64",
+			imageTypeName: "image-installer",
+			expectErrMsg:  "unsupported image type \"image-installer\" for bootc composes on \"x86_64\"",
+		},
+		{
+			name:          "ec2 (RHUI) not in bootc YAML",
+			arch:          "x86_64",
+			imageTypeName: "ec2",
+			expectErrMsg:  "unsupported image type \"ec2\" for bootc composes on \"x86_64\"",
+		},
+		// Invalid architecture
+		{
+			name:          "invalid arch",
+			arch:          "invalid-arch",
+			imageTypeName: "qcow2",
+			expectErrMsg:  "unsupported architecture \"invalid-arch\" for bootc composes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := v2.BootcSupportedImageType(tc.arch, tc.imageTypeName)
+			if tc.expectErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/cloudapi/v2/export_test.go
+++ b/internal/cloudapi/v2/export_test.go
@@ -22,6 +22,12 @@ func MockSerializeManifestFunc(f func(ctx context.Context, getManifestSource man
 	}
 }
 
+// BootcSupportedImageType exports the bootcSupportedImageType function for testing.
+var BootcSupportedImageType = bootcSupportedImageType
+
+// ImageTypeFromApiImageType exports imageTypeFromApiImageType for testing.
+var ImageTypeFromApiImageType = imageTypeFromApiImageType
+
 // HandleBootcPreManifest exports the handleBootcPreManifest function for testing.
 func HandleBootcPreManifest(workers *worker.Server, jobID uuid.UUID, token uuid.UUID, staticArgs json.RawMessage, dynArgs []json.RawMessage) {
 	handleBootcPreManifest(workers, jobID, token, staticArgs, dynArgs)

--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -579,9 +579,8 @@ func (s *Server) enqueueBootcCompose(request ComposeRequest, channel string) (uu
 
 	imageTypeName := imageTypeFromApiImageType(ir.ImageType)
 
-	// TODO: Only qcow2 (guest-image) is supported for bootc composes for now.
-	if imageTypeName != "qcow2" {
-		return uuid.Nil, HTTPErrorWithDetails(ErrorUnsupportedImageType, nil, "only qcow2 (guest-image) is supported for bootc composes")
+	if err := bootcSupportedImageType(ir.Architecture, imageTypeName); err != nil {
+		return uuid.Nil, err
 	}
 
 	// Validate and normalize upload targets — consistent with non-bootc flow.

--- a/internal/cloudapi/v2/v2_multi_tenancy_test.go
+++ b/internal/cloudapi/v2/v2_multi_tenancy_test.go
@@ -71,18 +71,18 @@ func s3Request() string {
 }
 
 func bootcRequest() string {
-	return fmt.Sprintf(`
+	return `
 		{
 			"bootc": {
 				"reference": "registry.org/centos-bootc:tag"
 			},
 			"image_request": {
-				"architecture": "%s",
+				"architecture": "x86_64",
 				"repositories": [],
 				"image_type": "guest-image",
 				"upload_options": {}
 			}
-		}`, test_distro.TestArch3Name)
+		}`
 }
 
 var reqContextCallCount = 0
@@ -425,7 +425,7 @@ func TestBootcMultitenancyPreManifestProcessed(t *testing.T) {
 	// Finish the BootcInfoResolve job so the BootcPreManifest dependency is met.
 	// Dequeue it using the tenant channel via the worker server directly.
 	_, infoToken, _, _, _, err := workerServer.RequestJob(
-		context.Background(), test_distro.TestArch3Name,
+		context.Background(), "x86_64",
 		[]string{worker.JobTypeBootcInfoResolve}, []string{"org-" + orgID}, uuid.Nil,
 	)
 	require.NoError(t, err)

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -3058,6 +3058,8 @@ func TestComposeBootc(t *testing.T) {
 
 	testCases := []struct {
 		name                          string
+		imageType                     string
+		expectedImageTypeName         string
 		bootcUseRemoteContainerSource bool
 		uploadJSON                    string   // upload_options or upload_targets JSON fragment
 		expectedStatus                int      // expected HTTP status code
@@ -3067,6 +3069,8 @@ func TestComposeBootc(t *testing.T) {
 		{
 			// Matches cockpit-image-builder on-prem: explicit local target
 			name:                          "default/local",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
 			expectedStatus:                http.StatusCreated,
@@ -3074,6 +3078,8 @@ func TestComposeBootc(t *testing.T) {
 		},
 		{
 			name:                          "remote_container_source",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: true,
 			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
 			expectedStatus:                http.StatusCreated,
@@ -3082,6 +3088,8 @@ func TestComposeBootc(t *testing.T) {
 		{
 			// upload_options defaults to aws.s3 via getDefaultTarget
 			name:                          "default_upload_options_aws_s3",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    `"upload_options": {}`,
 			expectedStatus:                http.StatusCreated,
@@ -3089,6 +3097,8 @@ func TestComposeBootc(t *testing.T) {
 		},
 		{
 			name:                          "aws_s3_upload_target",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    `"upload_targets": [{"type": "aws.s3", "upload_options": {"region": "us-east-1"}}]`,
 			expectedStatus:                http.StatusCreated,
@@ -3096,13 +3106,35 @@ func TestComposeBootc(t *testing.T) {
 		},
 		{
 			name:                          "local_upload_target",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    `"upload_targets": [{"type": "local", "upload_options": {}}]`,
 			expectedStatus:                http.StatusCreated,
 			expectedUploadTargetTypes:     []string{"local"},
 		},
 		{
+			name:                          "aws/aws",
+			imageType:                     "aws",
+			expectedImageTypeName:         "ami",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "aws", "upload_options": {"region": "us-east-1", "share_with_accounts": ["1234567890"]}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"aws"},
+		},
+		{
+			name:                          "azure/azure",
+			imageType:                     "azure",
+			expectedImageTypeName:         "vhd",
+			bootcUseRemoteContainerSource: false,
+			uploadJSON:                    `"upload_targets": [{"type": "azure", "upload_options": {"tenant_id": "test-tenant","subscription_id":"test-sub","resource_group":"test-rg"}}]`,
+			expectedStatus:                http.StatusCreated,
+			expectedUploadTargetTypes:     []string{"azure"},
+		},
+		{
 			name:                          "invalid_azure_upload_target",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    `"upload_targets": [{"type": "azure", "upload_options": {"tenant_id": "t", "subscription_id": "s", "resource_group": "rg"}}]`,
 			expectedStatus:                http.StatusBadRequest,
@@ -3116,6 +3148,8 @@ func TestComposeBootc(t *testing.T) {
 		},
 		{
 			name:                          "no_upload_target",
+			imageType:                     "guest-image",
+			expectedImageTypeName:         "qcow2",
 			bootcUseRemoteContainerSource: false,
 			uploadJSON:                    "",
 			expectedStatus:                http.StatusInternalServerError,
@@ -3125,6 +3159,19 @@ func TestComposeBootc(t *testing.T) {
 				"href": "/api/image-builder-composer/v2/errors/1004",
 				"kind": "Error",
 				"reason": "Failed to unmarshal struct"
+			}`,
+		},
+		{
+			name:                  "unsupported_bootc_image_type",
+			imageType:             "minimal-raw",
+			expectedImageTypeName: "minimal-raw",
+			expectedStatus:        http.StatusBadRequest,
+			expectedBody: `{
+				"code": "IMAGE-BUILDER-COMPOSER-6",
+				"details": "unsupported image type \"minimal-raw\" for bootc composes on \"x86_64\"",
+				"href": "/api/image-builder-composer/v2/errors/6",
+				"kind": "Error",
+				"reason": "Unsupported image type"
 			}`,
 		},
 	}
@@ -3148,11 +3195,11 @@ func TestComposeBootc(t *testing.T) {
 						"reference": "%s"
 						},
 				"image_request":{
-					"architecture": "%s",
+					"architecture": "x86_64",
 					"repositories": [],
-					"image_type": "guest-image"%s
+					"image_type": "%s"%s
 				}
-			}`, baseContainerRef, test_distro.TestArch3Name, uploadFragment)
+			}`, baseContainerRef, tc.imageType, uploadFragment)
 
 			expectedBody := tc.expectedBody
 			if expectedBody == "" {
@@ -3181,7 +3228,7 @@ func TestComposeBootc(t *testing.T) {
 			require.NoError(t, err)
 			osbuildJobTypeParts := strings.Split(osbuildJobType, ":")
 			require.Equal(t, worker.JobTypeOSBuild, osbuildJobTypeParts[0])
-			require.Equal(t, test_distro.TestArch3Name, osbuildJobTypeParts[1])
+			require.Equal(t, "x86_64", osbuildJobTypeParts[1])
 
 			// OSBuild job should have empty static targets and PreManifestDynArgsIdx set
 			var osbuildArgs worker.OSBuildJob
@@ -3233,7 +3280,7 @@ func TestComposeBootc(t *testing.T) {
 
 			var preManifestArgs worker.BootcPreManifestJob
 			require.NoError(t, json.Unmarshal(preManifestArgsJSON, &preManifestArgs))
-			require.Equal(t, "qcow2", preManifestArgs.ImageType)
+			require.Equal(t, tc.expectedImageTypeName, preManifestArgs.ImageType)
 
 			// Verify upload targets in pre-manifest args
 			require.Len(t, preManifestArgs.UploadTargets, len(tc.expectedUploadTargetTypes),
@@ -3265,7 +3312,7 @@ func TestComposeBootc(t *testing.T) {
 			// BootcInfoResolve uses arch suffix
 			bootcInfoResolveTypeParts := strings.Split(bootcInfoResolveJobType, ":")
 			require.Equal(t, worker.JobTypeBootcInfoResolve, bootcInfoResolveTypeParts[0])
-			require.Equal(t, test_distro.TestArch3Name, bootcInfoResolveTypeParts[1])
+			require.Equal(t, "x86_64", bootcInfoResolveTypeParts[1])
 
 			// Verify the BootcInfoResolve job args are set correctly
 			var bootcInfoResolveArgs worker.BootcInfoResolveJob

--- a/test/cases/api-bootc.sh
+++ b/test/cases/api-bootc.sh
@@ -223,35 +223,41 @@ WORKDIR=$(mktemp -d)
 REQ="${WORKDIR}/compose_request.json"
 ARCH=$(uname -m)
 
-cat > "$REQ" << EOF
+# Get worker unit file so we can watch the journal.
+WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
+sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
+KILL_PIDS+=("$!")
+
+BOOTC_IMAGE_TYPES=("guest-image" "aws")
+
+for IMAGE_TYPE in "${BOOTC_IMAGE_TYPES[@]}"; do
+    greenprint "Testing bootc compose with image_type=${IMAGE_TYPE}"
+
+    cat > "$REQ" << EOF
 {
   "bootc": {
     "reference": "quay.io/centos-bootc/centos-bootc:stream9"
   },
   "image_request": {
     "architecture": "$ARCH",
-    "image_type": "guest-image",
+    "image_type": "$IMAGE_TYPE",
     "repositories": [],
     "upload_targets": [{"type": "local", "upload_options": {}}]
   }
 }
 EOF
 
-# Get worker unit file so we can watch the journal.
-WORKER_UNIT=$(sudo systemctl list-units | grep -o -E "osbuild.*worker.*\.service")
-sudo journalctl -af -n 1 -u "${WORKER_UNIT}" &
-KILL_PIDS+=("$!")
+    sendCompose "$REQ"
+    waitForState
+    echo "compose status:"
+    curl \
+        --show-error \
+        --cacert /etc/osbuild-composer/ca-crt.pem \
+        --key /etc/osbuild-composer/client-key.pem \
+        --cert /etc/osbuild-composer/client-crt.pem \
+        "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID"
+    test "$UPLOAD_STATUS" = "success"
 
-sendCompose "$REQ"
-waitForState
-echo "compose status:"
-curl \
-    --show-error \
-    --cacert /etc/osbuild-composer/ca-crt.pem \
-    --key /etc/osbuild-composer/client-key.pem \
-    --cert /etc/osbuild-composer/client-crt.pem \
-    "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID"
-test "$UPLOAD_STATUS" = "success"
-
-verifyImageDownload
-verifyManifestContainerSourceType
+    verifyImageDownload
+    verifyManifestContainerSourceType
+done


### PR DESCRIPTION
The bootc compose flow previously rejected every image type except `qcow2` (guest-image), even though the underlying bootc distro already supports several disk formats. This PR replaces the hardcoded check with a dynamic validation helper that queries the bootc distro's image type registry, so any disk image type recognized by the bootc distro is automatically accepted. In practice this unlocks the Cloud API image types that overlap with bootc disk formats: `aws` (ami), `azure` (vhd), `gcp` (gce), `vsphere` (vmdk), `vsphere-ova` (ova), and `pxe-tar-xz` - installer types remain out of scope.

## Architectural Changes

Introduce `bootcSupportedImageType` in a new `bootc.go` file. Rather than maintaining a static allowlist of image types in composer (which would drift from the bootc distro definitions in `osbuild/images`), the helper constructs a lightweight dummy `BootcDistro` via `generic.NewBootc` and probes it for the requested image type. This keeps composer in sync with supported types automatically. A TODO notes that a dedicated upstream helper (e.g. `generic.BootcSupportedImageTypes`) would be cleaner and should be pursued as a follow-up.

## Key Changes

- Add `bootcSupportedImageType` helper that validates image types against the bootc distro at runtime
- Replace the hardcoded `imageTypeName != "qcow2"` guard in `enqueueBootcCompose` with a call to the new helper
- Parameterize `TestComposeBootc` to exercise `aws` (ami) and `vsphere` (vmdk) alongside the existing `guest-image` (qcow2) cases
- Extend pre-manifest happy-path tests with `ami`/AWS and `vhd`/Azure upload target scenarios
- Update the `api-bootc.sh` integration test to loop over `guest-image` and `aws`, verifying the full compose-build-download path for both
- Switch bootc-related tests from `test_distro.TestArch3Name` to literal `"x86_64"` since the bootc flow builds its own distro and needs a real architecture

## Breaking Changes

This PR is fully backward compatible. All previously supported requests (`guest-image`/qcow2) continue to work. Additional image types that were previously rejected with a 400 error are now accepted if supported by the bootc distro.

## Testing

- Added `TestBootcSupportedImageType` covering all expected supported types (guest-image, aws, azure, gcp, vsphere, vsphere-ova, pxe-tar-xz on x86_64; guest-image and aws on aarch64), unsupported types (minimal-raw, image-installer, ec2), and invalid architecture input
- Parameterized `TestComposeBootc` and pre-manifest happy-path tests to verify the full enqueue and manifest-generation flow for non-qcow2 image types with matching upload targets
- Extended the `api-bootc.sh` integration test to compose both `guest-image` and `aws` with local upload targets, providing end-to-end CI coverage for the newly enabled formats