### PR TITLE
Add optional container image cleanup to bootc info resolve job and enable it for the service (HMS-10446)

### DIFF
--- a/cmd/osbuild-worker/config.go
+++ b/cmd/osbuild-worker/config.go
@@ -82,6 +82,14 @@ type repositoryMTLSConfig struct {
 	Proxy          string `toml:"proxy"`
 }
 
+type bootcInfoResolveConfig struct {
+	// NOTE: When enabled, the worker removes container images from local
+	// storage after resolving bootc info. This prevents storage buildup
+	// in SaaS deployments where the worker processes many different
+	// container refs over time.
+	CleanupImages bool `toml:"cleanup_images"`
+}
+
 type workerConfig struct {
 	Composer       *composerConfig             `toml:"composer"`
 	Koji           map[string]kojiServerConfig `toml:"koji"`
@@ -96,8 +104,9 @@ type workerConfig struct {
 	BasePath string `toml:"base_path"`
 	DNFJson  string `toml:"dnf-json"`
 	// default value: &{ Type: host }
-	OSBuildExecutor      *executorConfig       `toml:"osbuild_executor"`
-	RepositoryMTLSConfig *repositoryMTLSConfig `toml:"repository_mtls"`
+	OSBuildExecutor      *executorConfig         `toml:"osbuild_executor"`
+	RepositoryMTLSConfig *repositoryMTLSConfig   `toml:"repository_mtls"`
+	BootcInfoResolve     *bootcInfoResolveConfig `toml:"bootc_info_resolve"`
 	// something like "production" or "staging" to be added to logging
 	DeploymentChannel string `toml:"deployment_channel"`
 	// clean store between runs, this should only be used with workers running on AWS within an ASG

--- a/cmd/osbuild-worker/export_test.go
+++ b/cmd/osbuild-worker/export_test.go
@@ -32,3 +32,13 @@ func MockResolveBootcBuildInfoFunc(mockFunc ResolveBootcInfoFuncType) (restore f
 		resolveBootcBuildInfoFunc = saved
 	}
 }
+
+type RemoveContainerImageFuncType = removeContainerImageFuncType
+
+func MockRemoveContainerImageFunc(mockFunc RemoveContainerImageFuncType) (restore func()) {
+	saved := removeContainerImageFunc
+	removeContainerImageFunc = mockFunc
+	return func() {
+		removeContainerImageFunc = saved
+	}
+}

--- a/cmd/osbuild-worker/jobimpl-bootc-info-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-bootc-info-resolve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os/exec"
 
 	"github.com/sirupsen/logrus"
 
@@ -11,12 +12,25 @@ import (
 )
 
 type resolveBootcInfoFuncType func(ref string) (*bootc.Info, error)
+type removeContainerImageFuncType func(ref string) error
 
 // variables to allow for testing
 var resolveBootcInfoFunc resolveBootcInfoFuncType = bootc.ResolveBootcInfo
 var resolveBootcBuildInfoFunc resolveBootcInfoFuncType = bootc.ResolveBootcBuildInfo
+var removeContainerImageFunc removeContainerImageFuncType = removeContainerImage
 
-type BootcInfoResolveJobImpl struct{}
+func removeContainerImage(ref string) error {
+	cmd := exec.Command("podman", "rmi", ref)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("podman rmi %q: %s: %w", ref, string(output), err)
+	}
+	return nil
+}
+
+type BootcInfoResolveJobImpl struct {
+	CleanupImages bool
+}
 
 func (impl *BootcInfoResolveJobImpl) Run(job worker.Job) error {
 	logWithId := logrus.WithField("jobId", job.Id())
@@ -66,6 +80,15 @@ func (impl *BootcInfoResolveJobImpl) Run(job worker.Job) error {
 			reason := fmt.Sprintf("failed to resolve bootc info for ref %q: %s", spec.Ref, err.Error())
 			result.JobError = clienterrors.New(clienterrors.ErrorBootcInfoResolve, reason, err)
 			return fmt.Errorf("failed to resolve bootc info for ref %q: %s", spec.Ref, err.Error())
+		}
+
+		if impl.CleanupImages {
+			ref := spec.Ref
+			defer func() {
+				if err := removeContainerImageFunc(ref); err != nil {
+					logWithId.Warnf("Failed to cleanup container image %q: %v", ref, err)
+				}
+			}()
 		}
 
 		// Convert vendor type to DTO for the job result

--- a/cmd/osbuild-worker/jobimpl-bootc-info-resolve_test.go
+++ b/cmd/osbuild-worker/jobimpl-bootc-info-resolve_test.go
@@ -70,7 +70,10 @@ func TestBootcInfoResolveJobRun(t *testing.T) {
 		mockResolveFullInfo  main.ResolveBootcInfoFuncType                                                                    // if nil, use the default mock function
 		mockResolveBuildInfo main.ResolveBootcInfoFuncType                                                                    // if nil, use the default mock function
 		mockMockJobFunc      func(t *testing.T, jobType string, rawArgs json.RawMessage, dynamicArgs ...interface{}) *mockJob // if nil, use the default mock job creator
-		wantRunErrSubstr     string                                                                                           // if empty, no error is expected
+		cleanupImages        bool
+		mockRemoveImageFunc  main.RemoveContainerImageFuncType
+		wantCleanedUpRefs    []string
+		wantRunErrSubstr     string // if empty, no error is expected
 		verifyFinishResult   func(t *testing.T, result worker.BootcInfoResolveJobResult)
 	}{
 		{
@@ -194,7 +197,71 @@ func TestBootcInfoResolveJobRun(t *testing.T) {
 			verifyFinishResult: func(t *testing.T, result worker.BootcInfoResolveJobResult) {
 				assert.NotNil(t, result.JobError, "expected job error for unresolvable container")
 				assert.Nil(t, result.Infos)
-
+			},
+		},
+		{
+			name: "cleanup enabled: images are removed after successful resolution",
+			jobArgs: &worker.BootcInfoResolveJob{
+				Specs: []worker.BootcInfoResolveJobSpec{
+					{Ref: "localhost:1/image-a:latest", ResolveMode: worker.BootcInfoResolveModeFull},
+					{Ref: "localhost:1/image-b:latest", ResolveMode: worker.BootcInfoResolveModeBuild},
+				},
+			},
+			cleanupImages: true,
+			wantCleanedUpRefs: []string{
+				"localhost:1/image-b:latest",
+				"localhost:1/image-a:latest",
+			},
+			verifyFinishResult: func(t *testing.T, result worker.BootcInfoResolveJobResult) {
+				assert.Nil(t, result.JobError)
+				assert.Len(t, result.Infos, 2)
+			},
+		},
+		{
+			name: "cleanup enabled: only resolved images are cleaned up on failure",
+			jobArgs: &worker.BootcInfoResolveJob{
+				Specs: []worker.BootcInfoResolveJobSpec{
+					{Ref: "localhost:1/image-a:latest", ResolveMode: worker.BootcInfoResolveModeFull},
+					{Ref: "localhost:1/image-b:latest", ResolveMode: worker.BootcInfoResolveModeBuild},
+				},
+			},
+			cleanupImages: true,
+			mockResolveBuildInfo: func(ref string) (*bootc.Info, error) {
+				return nil, fmt.Errorf("pull failed for ref %s", ref)
+			},
+			wantRunErrSubstr:  "pull failed for ref",
+			wantCleanedUpRefs: []string{"localhost:1/image-a:latest"},
+			verifyFinishResult: func(t *testing.T, result worker.BootcInfoResolveJobResult) {
+				assert.NotNil(t, result.JobError)
+			},
+		},
+		{
+			name: "cleanup disabled: images are NOT removed",
+			jobArgs: &worker.BootcInfoResolveJob{
+				Specs: []worker.BootcInfoResolveJobSpec{
+					{Ref: "localhost:1/image-a:latest", ResolveMode: worker.BootcInfoResolveModeFull},
+				},
+			},
+			cleanupImages:     false,
+			wantCleanedUpRefs: nil,
+			verifyFinishResult: func(t *testing.T, result worker.BootcInfoResolveJobResult) {
+				assert.Nil(t, result.JobError)
+				assert.Len(t, result.Infos, 1)
+			},
+		},
+		{
+			name: "cleanup failure is logged but does not fail the job",
+			jobArgs: &worker.BootcInfoResolveJob{
+				Specs: []worker.BootcInfoResolveJobSpec{
+					{Ref: "localhost:1/image-a:latest", ResolveMode: worker.BootcInfoResolveModeFull},
+				},
+			},
+			cleanupImages:       true,
+			mockRemoveImageFunc: func(ref string) error { return fmt.Errorf("podman rmi failed") },
+			wantCleanedUpRefs:   []string{"localhost:1/image-a:latest"},
+			verifyFinishResult: func(t *testing.T, result worker.BootcInfoResolveJobResult) {
+				assert.Nil(t, result.JobError)
+				assert.Len(t, result.Infos, 1)
 			},
 		},
 	}
@@ -223,7 +290,19 @@ func TestBootcInfoResolveJobRun(t *testing.T) {
 			t.Cleanup(main.MockResolveBootcInfoFunc(tt.mockResolveFullInfo))
 			t.Cleanup(main.MockResolveBootcBuildInfoFunc(tt.mockResolveBuildInfo))
 
-			impl := &main.BootcInfoResolveJobImpl{}
+			var cleanedUpRefs []string
+			removeImageMock := func(ref string) error {
+				cleanedUpRefs = append(cleanedUpRefs, ref)
+				if tt.mockRemoveImageFunc != nil {
+					return tt.mockRemoveImageFunc(ref)
+				}
+				return nil
+			}
+			t.Cleanup(main.MockRemoveContainerImageFunc(removeImageMock))
+
+			impl := &main.BootcInfoResolveJobImpl{
+				CleanupImages: tt.cleanupImages,
+			}
 			runErr := impl.Run(jobMock)
 
 			if tt.wantRunErrSubstr != "" {
@@ -241,6 +320,8 @@ func TestBootcInfoResolveJobRun(t *testing.T) {
 			} else {
 				assert.Nil(t, jobMock.finishResult)
 			}
+
+			assert.Equal(t, tt.wantCleanedUpRefs, cleanedUpRefs)
 		})
 	}
 }

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -526,7 +526,9 @@ var run = func() {
 		worker.JobTypeAWSEC2Share: &AWSEC2ShareJobImpl{
 			AWSCreds: awsCredentials,
 		},
-		worker.JobTypeBootcInfoResolve: &BootcInfoResolveJobImpl{},
+		worker.JobTypeBootcInfoResolve: &BootcInfoResolveJobImpl{
+			CleanupImages: config.BootcInfoResolve != nil && config.BootcInfoResolve.CleanupImages,
+		},
 	}
 
 	acceptedJobTypes := []string{}

--- a/templates/packer/ansible/roles/common/files/osbuild-worker.toml
+++ b/templates/packer/ansible/roles/common/files/osbuild-worker.toml
@@ -1,2 +1,5 @@
 base_path = "/api/image-builder-worker/v1"
 clean_store = true
+
+[bootc_info_resolve]
+cleanup_images = true

--- a/test/cases/api-bootc-service.sh
+++ b/test/cases/api-bootc-service.sh
@@ -242,6 +242,9 @@ sudo tee -a /etc/osbuild-worker/osbuild-worker.toml > /dev/null <<EOF
 [osbuild_executor]
 type = "aws.ec2"
 key_name = "${EXECUTOR_KEY_NAME}"
+
+[bootc_info_resolve]
+cleanup_images = true
 EOF
 
 sudo systemctl daemon-reload
@@ -408,11 +411,11 @@ waitForState "success"
 test "$UPLOAD_STATUS" = "success"
 
 #
-# Post-compose verification: container ref should now be in local storage
+# Post-compose verification: container ref should NOT be in local storage (cleanup enabled)
 #
-section_start "verify-container-ref-post-compose" "Verifying container ref IS in local storage" true
-if ! sudo podman image exists "${BOOTC_CONTAINER_REF}" 2>/dev/null; then
-    redprint "Container ref ${BOOTC_CONTAINER_REF} was NOT pulled to local storage by BootcInfoResolveJob!"
+section_start "verify-container-ref-post-compose" "Verifying container ref is NOT in local storage" true
+if sudo podman image exists "${BOOTC_CONTAINER_REF}" 2>/dev/null; then
+    redprint "Container ref ${BOOTC_CONTAINER_REF} was NOT cleaned up from local storage by BootcInfoResolveJob!"
     exit 1
 fi
 section_end "verify-container-ref-post-compose"


### PR DESCRIPTION
SaaS workers accumulate container images over time as a side effect of resolving bootc container info via `podman run`. These images remain in local storage indefinitely, eventually exhausting disk space on long-lived workers. This PR introduces a config-driven, best-effort cleanup mechanism that removes pulled container images after each BootcInfoResolve job completes, gated behind a new `[bootc_info_resolve]` TOML config section so on-prem behavior is unchanged by default.

## Architectural Changes

- Cleanup uses per-ref `defer` statements inside the resolution loop, ensuring images are removed even on mid-loop errors or panics, with LIFO ordering relative to the existing panic-recovery defer.
- Image removal is best-effort: failures are logged as warnings but never fail the job, since the resolution itself already succeeded.

## Key Changes

- Add `[bootc_info_resolve]` config section with a `cleanup_images` flag (default `false`) to `workerConfig`
- Enable `cleanup_images = true` in the SaaS deployment template (`osbuild-worker.toml`)
- Update the `api-bootc-service` E2E test to enable cleanup and verify images are removed post-compose

## Breaking Changes

This PR is fully backward compatible. The new config section is optional and cleanup defaults to `false`, preserving existing on-prem behavior.

## Testing

- Add four unit test cases covering: cleanup on successful resolution, partial cleanup on mid-loop failure, cleanup disabled (no-op), and cleanup failure being non-fatal to the job
- Update the `api-bootc-service` E2E test to enable cleanup and flip the post-compose assertion from "image exists" to "image does not exist"