### PR TITLE
weldr: Use the job id instead of creating a new one

### DIFF
--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -181,7 +181,6 @@ func main() {
 		[]*target.Target{
 			awsTarget,
 		},
-		id1,
 		weldrtypes.RPMMDPackageListToDepsolvedPackageInfoList(packages),
 	)
 	if err != nil {
@@ -196,7 +195,6 @@ func main() {
 		[]*target.Target{
 			awsTarget,
 		},
-		id2,
 		weldrtypes.RPMMDPackageListToDepsolvedPackageInfoList(packages),
 	)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -367,16 +367,15 @@ func (s *Store) GetAllComposes() map[uuid.UUID]weldrtypes.Compose {
 	return composes
 }
 
-func (s *Store) PushCompose(composeID uuid.UUID,
+func (s *Store) PushCompose(jobID uuid.UUID,
 	manifest manifest.OSBuildManifest,
 	imageType distro.ImageType,
 	bp *blueprint.Blueprint,
 	size uint64,
 	targets []*target.Target,
-	jobId uuid.UUID,
 	packages []weldrtypes.DepsolvedPackageInfo) error {
 
-	if _, exists := s.GetCompose(composeID); exists {
+	if _, exists := s.GetCompose(jobID); exists {
 		panic("a compose with this id already exists")
 	}
 
@@ -386,7 +385,7 @@ func (s *Store) PushCompose(composeID uuid.UUID,
 
 	// FIXME: handle or comment this possible error
 	_ = s.change(func() error {
-		s.composes[composeID] = weldrtypes.Compose{
+		s.composes[jobID] = weldrtypes.Compose{
 			Blueprint: bp,
 			ImageBuild: weldrtypes.ImageBuild{
 				Manifest:   manifest,
@@ -394,7 +393,7 @@ func (s *Store) PushCompose(composeID uuid.UUID,
 				Targets:    targets,
 				JobCreated: time.Now(),
 				Size:       size,
-				JobID:      jobId,
+				JobID:      jobID,
 			},
 			Packages: packages,
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -315,16 +315,16 @@ func (suite *storeTest) TestDeleteBlueprintFromWorkspace() {
 
 func (suite *storeTest) TestPushCompose() {
 	testID := uuid.New()
-	err := suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, uuid.New(), []weldrtypes.DepsolvedPackageInfo{})
+	err := suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, []weldrtypes.DepsolvedPackageInfo{})
 	suite.NoError(err)
 	suite.Panics(func() {
-		err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, uuid.New(), []weldrtypes.DepsolvedPackageInfo{})
+		err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, []*target.Target{suite.myTarget}, []weldrtypes.DepsolvedPackageInfo{})
 	})
 	suite.NoError(err)
 
 	// Test with PackageSets
 	testID = uuid.New()
-	err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, uuid.New(), suite.myPackages)
+	err = suite.myStore.PushCompose(testID, suite.myManifest, suite.myImageType, &suite.myBP, 123, nil, suite.myPackages)
 	suite.NoError(err)
 }
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -2489,8 +2489,6 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
-	composeID := uuid.New()
-
 	var targets []*target.Target
 	// Always instruct the worker to upload the artifact back to the server
 	workerServerTarget := target.NewWorkerServerTarget()
@@ -2650,16 +2648,18 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 		return
 	}
 
+	var jobID uuid.UUID
 	weldrPackages := weldrtypes.RPMMDPackageListToDepsolvedPackageInfoList(packages)
 	if testMode == "1" {
+		jobID = uuid.New()
 		// Create a failed compose
-		err = api.store.PushTestCompose(composeID, mf, imageType, bp, size, targets, false, weldrPackages)
+		err = api.store.PushTestCompose(jobID, mf, imageType, bp, size, targets, false, weldrPackages)
 	} else if testMode == "2" {
+		jobID = uuid.New()
 		// Create a successful compose
-		err = api.store.PushTestCompose(composeID, mf, imageType, bp, size, targets, true, weldrPackages)
+		err = api.store.PushTestCompose(jobID, mf, imageType, bp, size, targets, true, weldrPackages)
 	} else {
-		var jobId uuid.UUID
-		jobId, err = api.workers.EnqueueOSBuild(archName, &worker.OSBuildJob{
+		jobID, err = api.workers.EnqueueOSBuild(archName, &worker.OSBuildJob{
 			Manifest: mf,
 			Targets:  targets,
 			PipelineNames: &worker.PipelineNames{
@@ -2669,7 +2669,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 			ImageBootMode: imageType.BootMode().String(),
 		}, "")
 		if err == nil {
-			err = api.store.PushCompose(composeID, mf, imageType, bp, size, targets, jobId, weldrPackages)
+			err = api.store.PushCompose(jobID, mf, imageType, bp, size, targets, weldrPackages)
 		}
 	}
 
@@ -2686,7 +2686,7 @@ func (api *API) composeHandler(writer http.ResponseWriter, request *http.Request
 	}
 
 	err = json.NewEncoder(writer).Encode(ComposeReply{
-		BuildID:  composeID,
+		BuildID:  jobID,
 		Status:   true,
 		Warnings: warnings,
 	})


### PR DESCRIPTION
When a weldr api compose is started it stores information about the build in the weldr store, using a new UUID that is different than the job id returned by the compose. This leads to weldr-client showing two different UUIDs for the same compose, which is confusing.

This change switches to using the same job id UUID for the weldr store as it uses for the compose job. This will allow weldr-client to associate the information and combine it when displaying the composes.

This will have no impact on any other part of the system. The weldr store is only used by the internal store module and the weldr api.

Related: HMS-10332