### PR TITLE
cicd: exec make build for each bump

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           go_version: "1.24.12"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          exec: ./tools/prepare-source.sh
+          exec2: "make build"
           exec_pr: ./tools/prepare-source.sh
           include: "github.com/osbuild/images github.com/osbuild/blueprint"
           commit_message: "deps: bump osbuild/images dependency"
@@ -34,6 +36,8 @@ jobs:
         with:
           go_version: "1.24.12"
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+          exec: ./tools/prepare-source.sh
+          exec2: "make build"
           exec_pr: ./tools/prepare-source.sh
           exclude: "github.com/osbuild/images,github.com/osbuild/blueprint"
           commit_message: "deps: update dependencies (w/o osbuild/images)"


### PR DESCRIPTION
Gobump currently fails: https://github.com/osbuild/osbuild-composer/actions/workflows/gobump.yml

The reason is incompatibility between OpenAPI libraries: https://github.com/oapi-codegen/oapi-codegen/pull/2295

Symptoms are that the project will not build and this only happens at the very and of the bump process when `prepare-source.sh` is called. Then something fails at this point, gobump just exists and never files a PR.

```
+ go generate ./cmd/... ./internal/... ./pkg/...
# github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen
../../../vendor/github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen/schema.go:909:13: invalid operation: v == element.Ref (mismatched types openapi3.MappingRef and string)
internal/cloudapi/v2/handler.go:1: running "go": exit status 1
# github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen
../../../vendor/github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen/schema.go:909:13: invalid operation: v == element.Ref (mismatched types openapi3.MappingRef and string)
internal/worker/api/api.go:1: running "go": exit status 1
```

This aims to fix or improve this situation. The change will now build the project for each and every bumped direct dependency. This should prevent such situations and automatically exclude the offending library from the update trying 5 times to find latest stable release that was previously working.

I am pushing a branch directly to `osbuild` org so I can trigger this manually and test it.

Edit: Previously this was also parametrization of include/exclude but I dropped this from the PR.