### PR TITLE
cloudapi/v2: add default target for bootc iso

### DIFF
--- a/internal/cloudapi/v2/imagerequest.go
+++ b/internal/cloudapi/v2/imagerequest.go
@@ -249,6 +249,8 @@ func getDefaultTarget(imageType ImageTypes) (UploadTypes, error) {
 		fallthrough
 	case ImageTypesVsphereOva:
 		fallthrough
+	case ImageTypesBootableContainerIso:
+		fallthrough
 	case ImageTypesWsl:
 		return UploadTypesAwsS3, nil
 
@@ -281,7 +283,7 @@ func getDefaultTarget(imageType ImageTypes) (UploadTypes, error) {
 		return UploadTypesOciObjectstorage, nil
 
 	default:
-		return "", HTTPError(ErrorUnsupportedImageType)
+		return "", HTTPErrorWithDetails(ErrorUnsupportedImageType, nil, fmt.Sprintf("image type %s does not have a default target", imageType))
 	}
 }
 

--- a/internal/cloudapi/v2/imagerequest_test.go
+++ b/internal/cloudapi/v2/imagerequest_test.go
@@ -237,6 +237,12 @@ func TestGetTargets(t *testing.T) {
 			includeDefault: false,
 			expected:       []target.TargetName{target.TargetNameWorkerServer},
 		},
+		"bootable-container-iso:default": {
+			imageType:      ImageTypesBootableContainerIso,
+			targets:        nil,
+			includeDefault: true,
+			expected:       []target.TargetName{target.TargetNameAWSS3},
+		},
 	}
 
 	for name := range testCases {

--- a/test/cases/api/bootc/container-iso.s3.sh
+++ b/test/cases/api/bootc/container-iso.s3.sh
@@ -48,14 +48,9 @@ function createReqFile() {
     "architecture": "$ARCH",
     "image_type": "${IMAGE_TYPE}",
     "repositories": [],
-    "upload_targets": [
-      {
-        "type": "aws.s3",
-        "upload_options": {
-          "region": "${AWS_REGION}"
-        }
-      }
-    ]
+    "upload_options": {
+      "region": "${AWS_REGION}"
+    }
   }
 }
 EOF

--- a/test/cases/api/bootc/guest.s3.sh
+++ b/test/cases/api/bootc/guest.s3.sh
@@ -55,14 +55,9 @@ function createReqFile() {
     "architecture": "$ARCH",
     "image_type": "${IMAGE_TYPE}",
     "repositories": [],
-    "upload_targets": [
-      {
-        "type": "aws.s3",
-        "upload_options": {
-          "region": "${AWS_REGION}"
-        }
-      }
-    ]
+    "upload_options": {
+      "region": "${AWS_REGION}"
+    }
   }
 }
 EOF


### PR DESCRIPTION
    The default upload target was missing for the bootable-container-iso
    type. For requests coming from image builder crc, the default target is
    always used. Thus, this resulted in an "unsupported image type" error.
    
    Also add error details to the getDefaultTarget function in case the
    image type is unsupported.
