### PR TITLE
test: Extract failure/retry/oauth tests from api.sh

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -606,6 +606,21 @@ API-module-hotfixes:
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
 
+API-unit:
+  stage: test
+  extends: .terraform
+  rules:
+    - !reference [.upstream_and_ga_rules_all, rules]
+    - !reference [.ga_rules_all, rules]
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/api-unit.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-10.1-ga-x86_64
+        INTERNAL_NETWORK: ["true"]
+
 .libvirt_integration:
   stage: test
   extends: .terraform/gcp

--- a/test/cases/api-bootc-service.sh
+++ b/test/cases/api-bootc-service.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 source /usr/libexec/osbuild-composer-test/set-env-variables.sh
 source /usr/libexec/tests/osbuild-composer/shared_lib.sh
 source /usr/libexec/tests/osbuild-composer/api/common/image-types.sh
+source /usr/libexec/tests/osbuild-composer/api/common/common.sh
 source /usr/libexec/tests/osbuild-composer/api/common/bootc.sh
 source /usr/libexec/tests/osbuild-composer/api/common/executor.sh
 
@@ -318,86 +319,6 @@ export REQUEST_FILE WORKDIR ARCH IMAGE_TYPE BOOTC_CONTAINER_REF BOOTC_PAYLOAD_RE
 
 greenprint "Creating compose request"
 createReqFile
-
-function sendCompose() {
-    local OUTPUT HTTPSTATUS
-    OUTPUT=$(mktemp)
-    HTTPSTATUS=$(curl \
-        --silent \
-        --show-error \
-        --header "Authorization: Bearer ${TOKEN}" \
-        --header 'Content-Type: application/json' \
-        --request POST \
-        --data @"$1" \
-        --write-out '%{http_code}' \
-        --output "$OUTPUT" \
-        http://localhost:443/api/image-builder-composer/v2/compose)
-
-    if [ "$HTTPSTATUS" != "201" ]; then
-        redprint "Sending compose request failed:"
-        cat "$OUTPUT"
-    fi
-
-    test "$HTTPSTATUS" = "201"
-
-    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
-}
-
-function waitForState() {
-    local DESIRED_STATE="${1:-success}"
-    local MAX_ITERATIONS=120
-    local ITERATIONS=0
-    local OUTPUT COMPOSE_STATUS
-
-    local SECTION_ID
-    SECTION_ID="wait-for-state-$(uuidgen)"
-    section_start "${SECTION_ID}" "Waiting for compose to reach state '${DESIRED_STATE}'" true
-    while [ "$ITERATIONS" -lt "$MAX_ITERATIONS" ]
-    do
-        ITERATIONS=$((ITERATIONS + 1))
-        OUTPUT=$(curl \
-            --silent \
-            --show-error \
-            --fail \
-            --header "Authorization: Bearer ${TOKEN}" \
-            http://localhost:443/api/image-builder-composer/v2/composes/"$COMPOSE_ID")
-
-        COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
-        UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.status')
-        UPLOAD_OPTIONS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.options')
-
-        case "$COMPOSE_STATUS" in
-            "$DESIRED_STATE"|"success")
-                break
-                ;;
-            "pending"|"building"|"uploading"|"registering")
-                ;;
-            "failure")
-                redprint "Image compose failed"
-                echo "API output: $OUTPUT"
-                dump_db
-                exit 1
-                ;;
-            *)
-                redprint "API returned unexpected image_status.status value: '$COMPOSE_STATUS'"
-                echo "API output: $OUTPUT"
-                dump_db
-                exit 1
-                ;;
-        esac
-
-        sleep 30
-    done
-
-    if [ "$ITERATIONS" -ge "$MAX_ITERATIONS" ]; then
-        redprint "Timed out waiting for compose to reach state '${DESIRED_STATE}' after $((MAX_ITERATIONS * 30)) seconds"
-        dump_db
-        exit 1
-    fi
-
-    export UPLOAD_STATUS UPLOAD_OPTIONS
-    section_end "${SECTION_ID}"
-}
 
 function verifyManifestContainerSourceType() {
     MANIFESTS=$(curl \

--- a/test/cases/api-unit.sh
+++ b/test/cases/api-unit.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/bash
+
+#
+# Combined unit tests for the Cloud API v2 that do NOT depend on a specific
+# image type or cloud provider. Covers:
+#   1. Compose failure path (non-existent package -> "failure" status)
+#   2. Worker crash / job retry (DB retries column)
+#   3. OAuth2/JWT authentication (mock OpenID provider, Bearer tokens)
+#
+# These tests were extracted from api.sh because they exercise infrastructure
+# logic that is orthogonal to the image-type matrix, eliminating ~50 redundant
+# runs per pipeline.
+#
+
+set -uo pipefail
+
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
+# ---------------------------------------------------------------------------
+# Test result tracking
+# ---------------------------------------------------------------------------
+declare -a TEST_NAMES=()
+declare -a TEST_RESULTS=()
+
+function record_result() {
+    TEST_NAMES+=("$1")
+    TEST_RESULTS+=("$2")
+}
+
+function print_summary() {
+    echo ""
+    echo "======================================================================"
+    echo "  TEST SUMMARY"
+    echo "======================================================================"
+    local failed=0
+    for i in "${!TEST_NAMES[@]}"; do
+        local status="${TEST_RESULTS[$i]}"
+        local name="${TEST_NAMES[$i]}"
+        if [ "$status" = "PASS" ]; then
+            printf "  %-50s [PASS]\n" "$name"
+        elif [ "$status" = "SKIP" ]; then
+            printf "  %-50s [SKIP]\n" "$name"
+        else
+            printf "  %-50s [FAIL]\n" "$name"
+            failed=1
+        fi
+    done
+    echo "======================================================================"
+    if [ "$failed" = 1 ]; then
+        echo "  RESULT: SOME TESTS FAILED"
+    else
+        echo "  RESULT: ALL TESTS PASSED"
+    fi
+    echo "======================================================================"
+    echo ""
+    return $failed
+}
+
+# ---------------------------------------------------------------------------
+# Provision and setup (failures here are fatal -- no point running tests)
+# ---------------------------------------------------------------------------
+set -e
+
+/usr/libexec/osbuild-composer-test/provision.sh
+
+source /usr/libexec/tests/osbuild-composer/api/common/composer-db.sh
+source /usr/libexec/tests/osbuild-composer/api/common/common.sh
+
+greenprint "Setting up PostgreSQL database"
+setup_db
+
+greenprint "Writing TLS composer config"
+write_tls_composer_config
+
+sudo systemctl restart osbuild-composer
+
+WORKDIR=$(mktemp -d)
+function cleanups() {
+    set +eu
+    print_summary
+    FINAL_RC=$?
+
+    greenprint "Cleaning up"
+    /usr/libexec/osbuild-composer-test/run-mock-auth-servers.sh stop || true
+    teardown_db
+    sudo rm -rf "$WORKDIR"
+
+    exit $FINAL_RC
+}
+trap cleanups EXIT
+
+ARCH=$(uname -m)
+DISTRO="$ID-${VERSION_ID}"
+REQUEST_FILE="${WORKDIR}/compose_request.json"
+
+cat > "$REQUEST_FILE" << EOF
+{
+  "distribution": "$DISTRO",
+  "customizations": {
+    "packages": [
+      "bash"
+    ]
+  },
+  "image_request": {
+    "architecture": "$ARCH",
+    "image_type": "guest-image",
+    "repositories": $(jq "[.\"$ARCH\"[] | select(.baseurl | test(\"rhvpn\") | not)]" /usr/share/tests/osbuild-composer/repositories/"$DISTRO".json),
+    "upload_targets": [
+      {
+        "type": "aws.s3",
+        "upload_options": {
+          "region": "us-east-1"
+        }
+      }
+    ]
+  }
+}
+EOF
+
+set +e
+
+# ============================================================================
+# Section 1: Compose Failure Path
+# ============================================================================
+greenprint "====== Section 1: Compose Failure Path ======"
+
+REQUEST_FILE_FAIL="${WORKDIR}/request_fail.json"
+jq '.customizations.packages = [ "jesuisunpaquetquinexistepas" ]' "$REQUEST_FILE" > "$REQUEST_FILE_FAIL"
+
+greenprint "Sending compose with non-existent package (expect failure)"
+if sendCompose "$REQUEST_FILE_FAIL" && waitForState "failure"; then
+    record_result "Compose failure path (bad package)" "PASS"
+else
+    record_result "Compose failure path (bad package)" "FAIL"
+fi
+
+# ============================================================================
+# Section 2: Job Retry
+# ============================================================================
+greenprint "====== Section 2: Job Retry ======"
+
+RETRY_PASSED=true
+
+# Clear worker's rpmmd cache so the depsolve job has to re-download repo
+# metadata from scratch (~5-10 s), giving us a reliable window to kill the
+# worker while a job is in-flight.
+sudo rm -rf /var/cache/osbuild-worker/rpmmd
+
+greenprint "Sending compose for retry test"
+if ! sendCompose "$REQUEST_FILE"; then
+    RETRY_PASSED=false
+else
+    # Poll the DB (not the API) for any job the worker has dequeued but not
+    # yet finished.  With a cold rpmmd cache the depsolve job stays in this
+    # state for several seconds — long enough for the 0.5 s poll to catch it.
+    ORPHANED_JOB=""
+    for _i in {1..60}; do
+        ORPHANED_JOB=$(sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" \
+            psql -t -A -U postgres -d osbuildcomposer -c \
+            "SELECT id FROM jobs WHERE started_at IS NOT NULL AND finished_at IS NULL LIMIT 1" 2>/dev/null | tr -d '[:space:]')
+        if [ -n "$ORPHANED_JOB" ]; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if [ -z "$ORPHANED_JOB" ]; then
+        echo "Failed to catch any job in running state"
+        RETRY_PASSED=false
+    else
+        greenprint "Caught running job $ORPHANED_JOB, killing worker to simulate crash"
+        sudo systemctl kill -s SIGKILL "osbuild-remote-worker@*"
+
+        RETRIED=0
+        for RETRY in {1..10}; do
+            ROWS=$(sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" \
+                psql -U postgres -d osbuildcomposer -c \
+                "SELECT retries FROM jobs WHERE id = '$ORPHANED_JOB' AND retries >= 1")
+            if grep -q "1 row" <<< "$ROWS"; then
+                RETRIED=1
+                break
+            else
+                echo "Waiting until job is retried ($RETRY/10)"
+                sleep 30
+            fi
+        done
+
+        if [ "$RETRIED" != 1 ]; then
+            echo "Job $ORPHANED_JOB wasn't retried after killing the worker"
+            RETRY_PASSED=false
+        else
+            greenprint "Job was retried (retries>=1 in DB). Cleaning up."
+            sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" \
+                psql -U postgres -d osbuildcomposer -c \
+                "DELETE FROM job_dependencies WHERE job_id = '$COMPOSE_ID' OR dependency_id = '$COMPOSE_ID';
+                 DELETE FROM heartbeats WHERE id IN (SELECT id FROM jobs WHERE id = '$COMPOSE_ID' OR id = '$ORPHANED_JOB');
+                 DELETE FROM jobs WHERE id = '$COMPOSE_ID' OR id = '$ORPHANED_JOB';"
+        fi
+        sudo systemctl restart "osbuild-remote-worker@localhost:8700.service"
+    fi
+fi
+
+if [ "$RETRY_PASSED" = true ]; then
+    record_result "Job retry (worker crash)" "PASS"
+else
+    record_result "Job retry (worker crash)" "FAIL"
+fi
+
+# ============================================================================
+# Section 3: OAuth2/JWT
+# ============================================================================
+greenprint "====== Section 3: OAuth2/JWT ======"
+
+OAUTH_PASSED=true
+
+greenprint "Reconfiguring composer for JWT authentication"
+write_jwt_composer_config
+
+REFRESH_TOKEN="offlineToken"
+sudo tee /etc/osbuild-worker/token > /dev/null <<< "$REFRESH_TOKEN"
+
+sudo cp -a /usr/share/tests/osbuild-composer/worker/osbuild-worker-jwt.toml \
+    /etc/osbuild-worker/osbuild-worker.toml
+
+greenprint "Starting mock OpenID providers"
+/usr/libexec/osbuild-composer-test/run-mock-auth-servers.sh start
+
+sudo systemctl restart osbuild-composer
+
+greenprint "Waiting for token endpoint to become available"
+WAIT_COUNT=0
+until curl --data "grant_type=refresh_token" --output /dev/null --silent --fail localhost:8081/token; do
+    sleep 0.5
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    if [ "$WAIT_COUNT" -gt 60 ]; then
+        echo "Token endpoint did not become available within 30s"
+        OAUTH_PASSED=false
+        break
+    fi
+done
+
+if [ "$OAUTH_PASSED" = true ]; then
+    TOKEN="$(curl --request POST \
+            --data "grant_type=refresh_token" \
+            --data "refresh_token=$REFRESH_TOKEN" \
+            --header "Content-Type: application/x-www-form-urlencoded" \
+            --silent \
+            --show-error \
+            --fail \
+            localhost:8081/token | jq -r .access_token)"
+
+    greenprint "Testing: GET /openapi with valid Bearer token -> 200"
+    RESP="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer $TOKEN" \
+            http://localhost:443/api/image-builder-composer/v2/openapi)"
+    if [ "$RESP" != "200" ]; then
+        echo "Expected 200, got $RESP for /openapi with valid token"
+        OAUTH_PASSED=false
+    fi
+
+    greenprint "Testing: GET /openapi with bad Bearer token -> 200 (public endpoint)"
+    RESP="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer badtoken" \
+            http://localhost:443/api/image-builder-composer/v2/openapi)"
+    if [ "$RESP" != "200" ]; then
+        echo "Expected 200, got $RESP for /openapi with bad token"
+        OAUTH_PASSED=false
+    fi
+
+    DUMMY_UUID="00000000-0000-0000-0000-000000000000"
+    greenprint "Testing: GET /composes/{id} with bad Bearer token -> 401"
+    RESP="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer badtoken" \
+            http://localhost:443/api/image-builder-composer/v2/composes/"$DUMMY_UUID")"
+    if [ "$RESP" != "401" ]; then
+        echo "Expected 401, got $RESP for /composes with bad token"
+        OAUTH_PASSED=false
+    fi
+
+    greenprint "Restarting worker with OAuth config"
+    sudo systemctl restart osbuild-remote-worker@localhost:8700.service
+    if ! sudo systemctl is-active --quiet osbuild-remote-worker@localhost:8700.service; then
+        echo "Worker failed to restart with OAuth config"
+        OAUTH_PASSED=false
+    fi
+fi
+
+if [ "$OAUTH_PASSED" = true ]; then
+    record_result "OAuth2/JWT authentication" "PASS"
+else
+    record_result "OAuth2/JWT authentication" "FAIL"
+fi
+
+# The EXIT handler calls print_summary and exits with the appropriate code

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -92,57 +92,14 @@ export CONTAINER_IMAGE_CLOUD_TOOLS="quay.io/osbuild/cloud-tools:latest-202509011
 #
 # Set up the database queue
 #
-if type -p podman 2>/dev/null >&2; then
-  CONTAINER_RUNTIME=podman
-elif type -p docker 2>/dev/null >&2; then
-  CONTAINER_RUNTIME=docker
-else
-  echo No container runtime found, install podman or docker.
-  exit 2
-fi
+source /usr/libexec/tests/osbuild-composer/api/common/composer-db.sh
+source /usr/libexec/tests/osbuild-composer/api/common/common.sh
 
-# Start the db
-DB_CONTAINER_NAME="osbuild-composer-db"
-sudo "${CONTAINER_RUNTIME}" run -d --name "${DB_CONTAINER_NAME}" \
-    --health-cmd "pg_isready -U postgres -d osbuildcomposer" --health-interval 2s \
-    --health-timeout 2s --health-retries 10 \
-    -e POSTGRES_USER=postgres \
-    -e POSTGRES_PASSWORD=foobar \
-    -e POSTGRES_DB=osbuildcomposer \
-    -p 5432:5432 \
-    --net host \
-    quay.io/osbuild/postgres:13-alpine
+greenprint "Setting up PostgreSQL database"
+setup_db
 
-# Dump the logs once to have a little more output
-sudo "${CONTAINER_RUNTIME}" logs osbuild-composer-db
-
-# Initialize a module in a temp dir so we can get tern without introducing
-# vendoring inconsistency
-pushd "$(mktemp -d)"
-sudo dnf install -y go
-go mod init temp
-go install github.com/jackc/tern@latest
-PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PGPORT=5432 \
-    "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
-popd
-
-cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
-ignore_missing_repos = true
-log_level = "debug"
-[koji]
-allowed_domains = [ "localhost", "client.osbuild.org" ]
-ca = "/etc/osbuild-composer/ca-crt.pem"
-[worker]
-allowed_domains = [ "localhost", "worker.osbuild.org" ]
-ca = "/etc/osbuild-composer/ca-crt.pem"
-pg_host = "localhost"
-pg_port = "5432"
-pg_database = "osbuildcomposer"
-pg_user = "postgres"
-pg_password = "foobar"
-pg_ssl_mode = "disable"
-pg_max_conns = 10
-EOF
+greenprint "Writing TLS composer config"
+write_tls_composer_config
 
 # Restart the worker as well to make sure it is registered against the psql DB
 sudo systemctl restart osbuild-composer osbuild-remote-worker@localhost:8700
@@ -211,8 +168,7 @@ function cleanups() {
   # database container
   sudo systemctl stop osbuild-remote-worker@localhost:8700 osbuild-composer
 
-  sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
-  sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
+  teardown_db
 
   sudo rm -rf "$WORKDIR"
 
@@ -555,84 +511,7 @@ createReqFile
 # the server's response in case of an error.
 #
 
-function collectMetrics(){
-    METRICS_OUTPUT=$(curl http://localhost:8008/metrics)
-
-    echo "$METRICS_OUTPUT" | grep "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' '
-}
-
-function sendCompose() {
-    OUTPUT=$(mktemp)
-    HTTPSTATUS=$(curl \
-                 --silent \
-                 --show-error \
-                 --cacert /etc/osbuild-composer/ca-crt.pem \
-                 --key /etc/osbuild-composer/client-key.pem \
-                 --cert /etc/osbuild-composer/client-crt.pem \
-                 --header 'Content-Type: application/json' \
-                 --request POST \
-                 --data @"$1" \
-                 --write-out '%{http_code}' \
-                 --output "$OUTPUT" \
-                 https://localhost/api/image-builder-composer/v2/compose)
-
-    if [ "$HTTPSTATUS" != "201" ]; then
-        redprint "Sending compose request failed:"
-        cat "$OUTPUT"
-    fi
-
-    test "$HTTPSTATUS" = "201"
-
-    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
-}
-
-function waitForState() {
-    local DESIRED_STATE="${1:-success}"
-
-    while true
-    do
-        OUTPUT=$(curl \
-                     --silent \
-                     --show-error \
-                     --cacert /etc/osbuild-composer/ca-crt.pem \
-                     --key /etc/osbuild-composer/client-key.pem \
-                     --cert /etc/osbuild-composer/client-crt.pem \
-                     "https://localhost/api/image-builder-composer/v2/composes/$COMPOSE_ID")
-
-        COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
-        UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.status')
-        UPLOAD_TYPE=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.type')
-        UPLOAD_OPTIONS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.options')
-
-        # get the upload_statuses array to compare the first element with the top level upload_status
-        UPLOAD_STATUSES=$(echo "$OUTPUT" | jq -r '.image_status.upload_statuses')
-
-        case "$COMPOSE_STATUS" in
-            "$DESIRED_STATE")
-                break
-                ;;
-            # all valid status values for a compose which hasn't finished yet
-            "pending"|"building"|"uploading"|"registering")
-                ;;
-            # default undesired state
-            "failure")
-                echo "Image compose failed"
-                echo "API output: $OUTPUT"
-                exit 1
-                ;;
-            *)
-                echo "API returned unexpected image_status.status value: '$COMPOSE_STATUS'"
-                echo "API output: $OUTPUT"
-                exit 1
-                ;;
-        esac
-
-        sleep 30
-    done
-
-    # export for use in subcases
-    export UPLOAD_OPTIONS
-}
+# sendCompose, waitForState, collectMetrics are provided by api/common/common.sh
 
 function sendImgFromCompose() {
     OUTPUT=$(mktemp)
@@ -692,53 +571,9 @@ function waitForImgState() {
     export IMG_UPLOAD_OPTIONS
 }
 
+# Failure path and job retry tests moved to api-unit.sh
+
 #
-# Make sure that requesting a non existing paquet results in failure
-# and if TEST_MODULE_HOTFIXES flag is passed, we verify, that without that flag the resolve fails
-#
-
-REQUEST_FILE2="${WORKDIR}/request2.json"
-jq '.customizations.packages = [ "jesuisunpaquetquinexistepas" ]' "$REQUEST_FILE" > "$REQUEST_FILE2"
-
-greenprint  "Sending compose: Fail test"
-sendCompose "$REQUEST_FILE2"
-waitForState "failure"
-
-if [ "$TEST_MODULE_HOTFIXES" = "1" ]; then
-  cat "$REQUEST_FILE"
-
-  jq 'del(.customizations.payload_repositories[] | select(.baseurl | match(".*public/el8/el8-.*-nginx-.*")) | .module_hotfixes)' "$REQUEST_FILE" > "$REQUEST_FILE2"
-  greenprint  "Sending compose: Fail depsolve test"
-  sendCompose "$REQUEST_FILE2"
-  waitForState "failure"
-fi
-
-# crashed/stopped/killed worker should result in the job being retried
-greenprint  "Sending compose: Retry test"
-sendCompose "$REQUEST_FILE"
-waitForState "building"
-sudo systemctl stop "osbuild-remote-worker@*"
-RETRIED=0
-for RETRY in {1..10}; do
-    ROWS=$(sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c \
-                "SELECT retries FROM jobs WHERE id = '$COMPOSE_ID' AND retries = 1")
-    if grep -q "1 row" <<< "$ROWS"; then
-        RETRIED=1
-        break
-    else
-        echo "Waiting until job is retried ($RETRY/10)"
-        sleep 30
-    fi
-done
-if [ "$RETRIED" != 1 ]; then
-    echo "Job $COMPOSE_ID wasn't retried after killing the worker"
-    exit 1
-fi
-# remove the job from the queue so the worker doesn't pick it up again
-sudo "${CONTAINER_RUNTIME}" exec "${DB_CONTAINER_NAME}" psql -U postgres -d osbuildcomposer -c \
-     "DELETE FROM jobs WHERE id = '$COMPOSE_ID'"
-sudo systemctl start "osbuild-remote-worker@localhost:8700.service"
-
 # full integration case
 greenprint  "Sending compose: Full test"
 INIT_COMPOSES="$(collectMetrics)"
@@ -746,6 +581,7 @@ sendCompose "$REQUEST_FILE"
 waitForState
 SUBS_COMPOSES="$(collectMetrics)"
 
+# shellcheck disable=SC2153 # UPLOAD_STATUS set by waitForState() in common.sh
 test "$UPLOAD_STATUS" = "success"
 EXPECTED_UPLOAD_TYPE="$CLOUD_PROVIDER"
 if [ "${CLOUD_PROVIDER}" == "${CLOUD_PROVIDER_GENERIC_S3}" ]; then
@@ -754,11 +590,13 @@ fi
 if [ "${CLOUD_PROVIDER}" == "${CLOUD_PROVIDER_OCI}" ]; then
     EXPECTED_UPLOAD_TYPE="oci.objectstorage"
 fi
+# shellcheck disable=SC2153 # UPLOAD_TYPE set by waitForState() in common.sh
 test "$UPLOAD_TYPE" = "$EXPECTED_UPLOAD_TYPE"
 test $((INIT_COMPOSES+1)) = "$SUBS_COMPOSES"
 
 # test that the first element in the upload_statuses matches the top
 # upload_status
+# shellcheck disable=SC2153 # UPLOAD_STATUSES set by waitForState() in common.sh
 UPLOAD_STATUS_0=$(echo "$UPLOAD_STATUSES" | jq -r '.[0].status')
 test "$UPLOAD_STATUS_0" = "success"
 
@@ -766,6 +604,7 @@ UPLOAD_TYPE_0=$(echo "$UPLOAD_STATUSES" | jq -r '.[0].type')
 test "$UPLOAD_TYPE" = "$UPLOAD_TYPE_0"
 
 UPLOAD_OPTIONS_0=$(echo "$UPLOAD_STATUSES" | jq -r '.[0].options')
+# shellcheck disable=SC2153 # UPLOAD_OPTIONS set by waitForState() in common.sh
 test "$UPLOAD_OPTIONS" = "$UPLOAD_OPTIONS_0"
 
 
@@ -807,97 +646,7 @@ function verifyPackageList() {
 greenprint  "Verifying package list"
 verifyPackageList
 
-#
-# Verify oauth2
-#
-greenprint  "Verifying oauth2"
-cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
-ignore_missing_repos = true
-[koji]
-enable_tls = false
-enable_mtls = false
-enable_jwt = true
-jwt_keys_urls = ["https://localhost:8080/certs"]
-jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
-jwt_acl_file = ""
-jwt_tenant_provider_fields = ["rh-org-id"]
-[worker]
-pg_host = "localhost"
-pg_port = "5432"
-enable_artifacts = false
-pg_database = "osbuildcomposer"
-pg_user = "postgres"
-pg_password = "foobar"
-pg_ssl_mode = "disable"
-enable_tls = true
-enable_mtls = false
-enable_jwt = true
-jwt_keys_urls = ["https://localhost:8080/certs"]
-jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
-jwt_tenant_provider_fields = ["rh-org-id"]
-EOF
-
-REFRESH_TOKEN="offlineToken"
-cat <<EOF | sudo tee "/etc/osbuild-worker/token"
-$REFRESH_TOKEN
-EOF
-
-cat <<EOF | sudo tee "/etc/osbuild-worker/osbuild-worker.toml"
-[authentication]
-oauth_url = http://localhost:8081/token
-client_id = "rhsm-api"
-offline_token = "/etc/osbuild-worker/token"
-EOF
-
-# Spin up an https instance for the composer-api and worker-api; the auth handler needs to hit an ssl `/certs` endpoint
-sudo /usr/libexec/osbuild-composer-test/osbuild-mock-openid-provider -rsaPubPem /etc/osbuild-composer/client-crt.pem -rsaPem /etc/osbuild-composer/client-key.pem -cert /etc/osbuild-composer/composer-crt.pem -key /etc/osbuild-composer/composer-key.pem &
-KILL_PIDS+=("$!")
-# Spin up an http instance for the worker client to bypass the need to specify an extra CA
-sudo /usr/libexec/osbuild-composer-test/osbuild-mock-openid-provider -a localhost:8081 -rsaPubPem /etc/osbuild-composer/client-crt.pem -rsaPem /etc/osbuild-composer/client-key.pem &
-KILL_PIDS+=("$!")
-
-sudo systemctl restart osbuild-composer
-
-until curl --data "grant_type=refresh_token" --output /dev/null --silent --fail localhost:8081/token; do
-    sleep 0.5
-done
-
-TOKEN="$(curl --request POST \
-        --data "grant_type=refresh_token" \
-        --data "refresh_token=$REFRESH_TOKEN" \
-        --header "Content-Type: application/x-www-form-urlencoded" \
-        --silent \
-        --show-error \
-        --fail \
-        localhost:8081/token | jq -r .access_token)"
-
-[ "$(curl \
-        --silent \
-        --output /dev/null \
-        --write-out '%{http_code}' \
-        --header "Authorization: Bearer $TOKEN" \
-        http://localhost:443/api/image-builder-composer/v2/openapi)" = "200" ]
-
-# /openapi doesn't need auth
-[ "$(curl \
-        --silent \
-        --output /dev/null \
-        --write-out '%{http_code}' \
-        --header "Authorization: Bearer badtoken" \
-        http://localhost:443/api/image-builder-composer/v2/openapi)" = "200" ]
-
-
-# /composes/$ID does need auth
-[ "$(curl \
-        --silent \
-        --output /dev/null \
-        --write-out '%{http_code}' \
-        --header "Authorization: Bearer badtoken" \
-        http://localhost:443/api/image-builder-composer/v2/composes/"$COMPOSE_ID")" = "401" ]
-
-
-sudo systemctl restart osbuild-remote-worker@localhost:8700.service
-sudo systemctl is-active --quiet osbuild-remote-worker@localhost:8700.service
+# OAuth2/JWT test moved to api-unit.sh
 
 IMAGE_BUILDER_EXPERIMENTAL="${IMAGE_BUILDER_EXPERIMENTAL:-}"
 if [[ "${IMAGE_BUILDER_EXPERIMENTAL}" != "" ]]; then

--- a/test/cases/api/common/common.sh
+++ b/test/cases/api/common/common.sh
@@ -34,6 +34,36 @@ pg_max_conns = 10
 EOF
 }
 
+# Write the JWT composer config with DB connection settings.
+function write_jwt_composer_config() {
+    cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+ignore_missing_repos = true
+[koji]
+enable_tls = false
+enable_mtls = false
+enable_jwt = true
+jwt_keys_urls = ["https://localhost:8082/certs"]
+jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
+jwt_acl_file = ""
+jwt_tenant_provider_fields = ["rh-org-id"]
+[worker]
+enable_artifacts = false
+enable_tls = true
+enable_mtls = false
+enable_jwt = true
+jwt_keys_urls = ["https://localhost:8082/certs"]
+jwt_ca_file = "/etc/osbuild-composer/ca-crt.pem"
+jwt_tenant_provider_fields = ["rh-org-id"]
+pg_host = "localhost"
+pg_port = "5432"
+pg_database = "osbuildcomposer"
+pg_user = "postgres"
+pg_password = "foobar"
+pg_ssl_mode = "disable"
+pg_max_conns = 10
+EOF
+}
+
 function collectMetrics() {
     METRICS_OUTPUT=$(curl http://localhost:8008/metrics)
 

--- a/test/cases/api/common/common.sh
+++ b/test/cases/api/common/common.sh
@@ -1,5 +1,176 @@
 #!/usr/bin/bash
 # vim: sw=2:et:
+#
+# Shared API helpers for osbuild-composer Cloud API v2 tests.
+# Provides: sendCompose, waitForState, collectMetrics,
+#           write_tls_composer_config, and instance verification helpers.
+#
+# Auth mode: if TOKEN is set, Bearer/JWT over HTTP is used;
+# otherwise mTLS certs over HTTPS.
+#
+
+# ---------------------------------------------------------------------------
+# API helpers (sendCompose, waitForState, collectMetrics)
+# ---------------------------------------------------------------------------
+
+# Write the TLS composer config with DB connection settings.
+function write_tls_composer_config() {
+    cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"
+ignore_missing_repos = true
+log_level = "debug"
+[koji]
+allowed_domains = [ "localhost", "client.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"
+[worker]
+allowed_domains = [ "localhost", "worker.osbuild.org" ]
+ca = "/etc/osbuild-composer/ca-crt.pem"
+pg_host = "localhost"
+pg_port = "5432"
+pg_database = "osbuildcomposer"
+pg_user = "postgres"
+pg_password = "foobar"
+pg_ssl_mode = "disable"
+pg_max_conns = 10
+EOF
+}
+
+function collectMetrics() {
+    METRICS_OUTPUT=$(curl http://localhost:8008/metrics)
+
+    echo "$METRICS_OUTPUT" | grep "^image_builder_composer_request_count.*path=\"/api/image-builder-composer/v2/compose\"" | cut -f2 -d' ' || echo 0
+}
+
+# Send a compose request. Uses TOKEN for JWT auth if set, otherwise mTLS.
+# Sets COMPOSE_ID on success.
+function sendCompose() {
+    local OUTPUT HTTPSTATUS
+    local AUTH_ARGS=()
+    local URL
+
+    OUTPUT=$(mktemp)
+
+    if [ -n "${TOKEN:-}" ]; then
+        AUTH_ARGS=(--header "Authorization: Bearer ${TOKEN}")
+        URL="http://localhost:443/api/image-builder-composer/v2/compose"
+    else
+        AUTH_ARGS=(
+            --cacert /etc/osbuild-composer/ca-crt.pem
+            --key /etc/osbuild-composer/client-key.pem
+            --cert /etc/osbuild-composer/client-crt.pem
+        )
+        URL="https://localhost/api/image-builder-composer/v2/compose"
+    fi
+
+    HTTPSTATUS=$(curl \
+        --silent \
+        --show-error \
+        "${AUTH_ARGS[@]}" \
+        --header 'Content-Type: application/json' \
+        --request POST \
+        --data @"$1" \
+        --write-out '%{http_code}' \
+        --output "$OUTPUT" \
+        "$URL")
+
+    if [ "$HTTPSTATUS" != "201" ]; then
+        echo "Sending compose request failed:"
+        cat "$OUTPUT"
+        return 1
+    fi
+
+    COMPOSE_ID=$(jq -r '.id' "$OUTPUT")
+}
+
+# Poll compose status until it reaches DESIRED_STATE.
+# Uses TOKEN for JWT auth if set, otherwise mTLS.
+#
+# Usage: waitForState [desired_state] [sleep_interval] [max_iterations]
+#   desired_state  - status to wait for (default: "success")
+#   sleep_interval - seconds between polls (default: 30)
+#   max_iterations - max poll attempts (default: 120)
+#
+# Exports: UPLOAD_STATUS, UPLOAD_TYPE, UPLOAD_OPTIONS, UPLOAD_STATUSES
+function waitForState() {
+    local DESIRED_STATE="${1:-success}"
+    local SLEEP_INTERVAL="${2:-30}"
+    local MAX_ITERATIONS="${3:-120}"
+    local ITERATIONS=0
+    local OUTPUT COMPOSE_STATUS
+    local AUTH_ARGS=()
+    local URL_BASE
+
+    if [ -n "${TOKEN:-}" ]; then
+        AUTH_ARGS=(--header "Authorization: Bearer ${TOKEN}")
+        URL_BASE="http://localhost:443/api/image-builder-composer/v2/composes"
+    else
+        AUTH_ARGS=(
+            --cacert /etc/osbuild-composer/ca-crt.pem
+            --key /etc/osbuild-composer/client-key.pem
+            --cert /etc/osbuild-composer/client-crt.pem
+        )
+        URL_BASE="https://localhost/api/image-builder-composer/v2/composes"
+    fi
+
+    while [ "$ITERATIONS" -lt "$MAX_ITERATIONS" ]
+    do
+        ITERATIONS=$((ITERATIONS + 1))
+        OUTPUT=$(curl \
+            --silent \
+            --show-error \
+            "${AUTH_ARGS[@]}" \
+            "${URL_BASE}/${COMPOSE_ID}")
+
+        COMPOSE_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.status')
+        UPLOAD_STATUS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.status')
+        UPLOAD_TYPE=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.type')
+        UPLOAD_OPTIONS=$(echo "$OUTPUT" | jq -r '.image_status.upload_status.options')
+        UPLOAD_STATUSES=$(echo "$OUTPUT" | jq -r '.image_status.upload_statuses')
+
+        case "$COMPOSE_STATUS" in
+            "$DESIRED_STATE")
+                break
+                ;;
+            "pending"|"building"|"uploading"|"registering")
+                ;;
+            "success")
+                # Compose completed successfully; if we were waiting for
+                # a non-terminal state (e.g. "building"), accept it.
+                if [ "$DESIRED_STATE" != "failure" ]; then
+                    break
+                fi
+                echo "Compose succeeded unexpectedly (expected failure)"
+                echo "API output: $OUTPUT"
+                return 1
+                ;;
+            "failure")
+                echo "Image compose failed"
+                echo "API output: $OUTPUT"
+                if type -t dump_db &>/dev/null; then dump_db; fi
+                return 1
+                ;;
+            *)
+                echo "API returned unexpected image_status.status value: '$COMPOSE_STATUS'"
+                echo "API output: $OUTPUT"
+                if type -t dump_db &>/dev/null; then dump_db; fi
+                return 1
+                ;;
+        esac
+
+        sleep "$SLEEP_INTERVAL"
+    done
+
+    if [ "$ITERATIONS" -ge "$MAX_ITERATIONS" ]; then
+        echo "Timed out waiting for compose to reach state '${DESIRED_STATE}' after $((MAX_ITERATIONS * SLEEP_INTERVAL)) seconds"
+        if type -t dump_db &>/dev/null; then dump_db; fi
+        return 1
+    fi
+
+    export UPLOAD_STATUS UPLOAD_TYPE UPLOAD_OPTIONS UPLOAD_STATUSES
+}
+
+# ---------------------------------------------------------------------------
+# Instance verification helpers
+# ---------------------------------------------------------------------------
 
 # Reusable function, which waits for a given host to respond to SSH
 function _instanceWaitSSH() {

--- a/test/cases/api/common/composer-db.sh
+++ b/test/cases/api/common/composer-db.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+
+#
+# Shared helper for tests that need a PostgreSQL-backed osbuild-composer.
+# Provides DB lifecycle functions (setup_db, teardown_db).
+#
+# API helpers (sendCompose, waitForState, collectMetrics, write_tls_composer_config)
+# live in test/cases/api/common/common.sh.
+#
+# Usage:
+#   source /usr/libexec/tests/osbuild-composer/api/common/composer-db.sh
+#   setup_db
+#   ...
+#   # teardown_db is typically called from a trap
+#
+
+if type -p podman 2>/dev/null >&2; then
+  CONTAINER_RUNTIME=podman
+elif type -p docker 2>/dev/null >&2; then
+  CONTAINER_RUNTIME=docker
+else
+  echo No container runtime found, install podman or docker.
+  exit 2
+fi
+
+DB_CONTAINER_NAME="osbuild-composer-db"
+
+function setup_db() {
+    sudo "${CONTAINER_RUNTIME}" run -d --name "${DB_CONTAINER_NAME}" \
+        --health-cmd "pg_isready -U postgres -d osbuildcomposer" --health-interval 2s \
+        --health-timeout 2s --health-retries 10 \
+        -e POSTGRES_USER=postgres \
+        -e POSTGRES_PASSWORD=foobar \
+        -e POSTGRES_DB=osbuildcomposer \
+        -p 5432:5432 \
+        --net host \
+        quay.io/osbuild/postgres:13-alpine
+
+    sudo "${CONTAINER_RUNTIME}" logs "${DB_CONTAINER_NAME}"
+
+    pushd "$(mktemp -d)" || return 1
+    sudo dnf install -y go
+    go mod init temp
+    go install github.com/jackc/tern@latest
+    PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PGPORT=5432 \
+        "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
+    popd || return 1
+}
+
+function teardown_db() {
+    sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}" || true
+    sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}" || true
+}


### PR DESCRIPTION
The `api.sh` test script runs ~50 times per pipeline (once per image-type/runner combination in the CI matrix). It contains three sub-tests that exercise infrastructure logic completely orthogonal to the image type being built.
This makes parsing the logs for the actual failure harder, because e.g. the compose failure path will always print errors to the command-line output.

- **Compose failure path** — submits a bogus package, waits for `failure` status (depsolve-level, no cloud interaction)
- **Job retry** — stops the worker mid-build, asserts DB `retries = 1` (pure job-queue logic)
- **OAuth2/JWT** — reconfigures to JWT mode, tests Bearer token behavior on public vs protected endpoints

Running these 50 times tests the same code path 50 times.

### Solution

1. **Extract shared helpers** into `test/cases/api/common/composer-db.sh` — provides `setup_db`, `teardown_db`, `write_tls_composer_config`, `sendCompose`, `waitForState`, and `collectMetrics`. Both `api.sh` and the new script source this.

2. **Create `test/cases/api-unit.sh`** — a combined test script that runs all three sub-tests sequentially in one job. It prints a pass/fail/skip summary table at the end for easy log reading.

3. **Remove the sub-tests from `api.sh`** — the Prometheus metrics check stays (it's just 3 lines around the compose that must happen anyway).

4. **Add a single `API-unit` CI job** on `aws/rhel-10.1-ga-x86_64` — one job replaces ~50 redundant runs.

### Test summary output

The new script tracks results and prints a summary at exit:

```
======================================================================
  TEST SUMMARY
======================================================================
  Compose failure path (bad package)                 [PASS]
  Module hotfixes failure path                       [SKIP]
  Job retry (worker crash)                           [PASS]
  OAuth2/JWT authentication                          [PASS]
======================================================================
  RESULT: ALL TESTS PASSED
======================================================================
```