### PR TITLE
Schutzfile: Fix bootc-foundry reference

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -231,7 +231,7 @@
         },
         "bootable-container-iso": {
           "x86_64": {
-            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
+            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
             "payload": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
           }
         }


### PR DESCRIPTION
The minor version was dropped from the container reference.