### PR TITLE
Schutzfile: drop minor versions from bootc-foundry

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -226,13 +226,13 @@
       "bootc": {
         "guest-image": {
           "x86_64": {
-            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
           }
         },
         "bootable-container-iso": {
           "x86_64": {
-            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-installer:latest",
-            "payload": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest"
+            "base": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-installer:latest",
+            "payload": "quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-qcow2:latest"
           }
         }
       }


### PR DESCRIPTION
SSIA

This was deleted last Friday.