### PR TITLE
.tekton/osbuild-composer: add COMMIT as a build argument

### DIFF
--- a/.tekton/osbuild-composer-pull-request.yaml
+++ b/.tekton/osbuild-composer-pull-request.yaml
@@ -201,6 +201,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - COMMIT=$(params.revision)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/.tekton/osbuild-composer-push.yaml
+++ b/.tekton/osbuild-composer-push.yaml
@@ -191,6 +191,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - COMMIT=$(params.revision)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED


### PR DESCRIPTION
In the build-container step, add COMMIT as a build argument. This argument is used to set the build version.

This fixes the 'devel' version in all konflux-built containers.