### PR TITLE
test/cases/api: fix race condition in worker registration

### DIFF
--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -144,7 +144,8 @@ pg_ssl_mode = "disable"
 pg_max_conns = 10
 EOF
 
-sudo systemctl restart osbuild-composer
+# Restart the worker as well to make sure it is registered against the psql DB
+sudo systemctl restart osbuild-composer osbuild-remote-worker@localhost:8700
 
 greenprint "Using Cloud Provider / Target ${CLOUD_PROVIDER} for Image Type ${IMAGE_TYPE}"
 

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -207,6 +207,10 @@ function cleanups() {
   # dump the DB here to ensure that it gets dumped even if the test fails
   dump_db
 
+  # kill osbuild-composer to avoid it crashing when stopping the
+  # database container
+  sudo systemctl stop osbuild-remote-worker@localhost:8700 osbuild-composer
+
   sudo "${CONTAINER_RUNTIME}" kill "${DB_CONTAINER_NAME}"
   sudo "${CONTAINER_RUNTIME}" rm "${DB_CONTAINER_NAME}"
 


### PR DESCRIPTION
This fixes an issue where the worker would register with osbuild-composer before the latter was restarted to switch from jsondb to the psql container as a database. When the worker would then try to pick up a job, it would fail to do so because the worker was not known to composer, because it was registered against jsondb.

Restarting the worker together with composer solves this, as it forces the worker to register again, and this time against the postgres db.