### PR TITLE
gitlab-ci: enable openshift virt tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,23 +435,20 @@ oci.sh:
           - aws/rhel-10.3-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
 
-# NOTE(akoutsou): Infra capacity issue is causing these to fail constantly. We
-# have an open SNOW ticket (UR0159317). Once it's resolved, we can enable the
-# test again.
-# OpenShift_Virtualization:
-#   extends: .integration_rhel
-#   rules:
-#     - !reference [.nightly_rules_x86_64, rules]
-#   variables:
-#     SCRIPT: openshift_virtualization.sh
-#   parallel:
-#     matrix:
-#       - RUNNER:
-#           - aws/rhel-9.8-ga-x86_64
-#           - aws/rhel-9.9-nightly-x86_64
-#           - aws/rhel-10.2-ga-x86_64
-#           - aws/rhel-10.3-nightly-x86_64
-#         INTERNAL_NETWORK: ["true"]
+OpenShift_Virtualization:
+  extends: .integration_rhel
+  rules:
+    - !reference [.nightly_rules_x86_64, rules]
+  variables:
+    SCRIPT: openshift_virtualization.sh
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-9.8-ga-x86_64
+          - aws/rhel-9.9-nightly-x86_64
+          - aws/rhel-10.2-ga-x86_64
+          - aws/rhel-10.3-nightly-x86_64
+        INTERNAL_NETWORK: ["true"]
 
 azure.sh:
   extends: .integration_rhel

--- a/test/cases/openshift_virtualization.sh
+++ b/test/cases/openshift_virtualization.sh
@@ -182,7 +182,13 @@ STORAGE_CLASS="rh-restricted-nfs-economy"
 
 # import the image into a data volume; total quota on the namespace seems to be 500 GiB
 PVC_NAME="image-builder-data-volume-$TEST_ID"
-retry "$VIRTCTL" image-upload --insecure dv "$PVC_NAME" --size=10Gi --storage-class="${STORAGE_CLASS}" --image-path="${IMAGE_FILENAME}"
+retry "$VIRTCTL" image-upload \
+      --insecure dv "$PVC_NAME" \
+      --size=10Gi \
+      --storage-class="${STORAGE_CLASS}" \
+      --image-path="${IMAGE_FILENAME}" \
+      --wait-secs 600 \
+      --retry 10
 # Note: --size=10Gi corresponds to the size of the filesystem inside the image, not the actual size of the qcow2 file
 
 PVC_VOLUME_ID=$($OC_CLI get pvc "$PVC_NAME" -o json | jq -r ".spec.volumeName")


### PR DESCRIPTION
The referenced ticket has been updated saying the quota has been raised.  Let's enable the tests and see how it goes.

This reverts commit 1d3d6343091c3784152736ec7f801b453f94d999.