### PR TITLE
test: make color print functions print all args

### DIFF
--- a/test/cases/shared_lib.sh
+++ b/test/cases/shared_lib.sh
@@ -35,15 +35,15 @@ function get_build_info() {
 
 # Colorful timestamped output.
 function greenprint {
-    echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m" >&2
+    echo -e "\033[1;32m[$(date -Isecond)] $*\033[0m" >&2
 }
 
 function yellowprint {
-    echo -e "\033[1;33m[$(date -Isecond)] ${1}\033[0m" >&2
+    echo -e "\033[1;33m[$(date -Isecond)] $*\033[0m" >&2
 }
 
 function redprint {
-    echo -e "\033[1;31m[$(date -Isecond)] ${1}\033[0m" >&2
+    echo -e "\033[1;31m[$(date -Isecond)] $*\033[0m" >&2
 }
 
 # Helper for GitLab foldable sections


### PR DESCRIPTION
base_tests.sh currently doesn't print a test result report:

```
[2026-05-22T17:29:39+00:00] 😃 Passed tests:
[2026-05-22T17:29:39+00:00] ☹ Failed tests:
```

This is because 4c7b3dd25 changed the report to use the colored print functions instead of plain echo. However, the colored print functions print only the first arg instead of all of them like echo does. Thus, the reporting broke because it passes multiple args to the print functions.

Fix this by changing the color printing functions to print all args, roughly matching echo's behavior.