### PR TITLE
ci_details: Fix repolist

### DIFF
--- a/schutzbot/ci_details.sh
+++ b/schutzbot/ci_details.sh
@@ -34,7 +34,7 @@ EOF
 echo -e "\033[0m"
 
 echo "List of system repositories:"
-sudo yum repolist -v
+sudo dnf repolist
 
 echo "------------------------------------------------------------------------------"
 


### PR DESCRIPTION
yum is now dnf and the repolist command does not have a '-v' option. Use 'dnf repolist' which will list the enabled repos.