### PR TITLE
cicd: configure gobump per-commit

### DIFF
--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -8,36 +8,37 @@ on:  # yamllint disable-line rule:truthy
     - cron: "0 6 * * 1"
 
 jobs:
-  bump-images:
+  update-and-push:
     runs-on: ubuntu-latest
+    container: registry.fedoraproject.org/fedora:43
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - name: Prepare environment and run tests
+        run: |
+          set -xe
+          sudo dnf -y install git gh jq golang skopeo libvirt-devel gpgme-devel btrfs-progs-devel krb5-devel
+          git clone --depth 1 https://github.com/osbuild/osbuild-composer
+          cd osbuild-composer/
+          make build test
 
-      - name: Run gobump-deps action - images
-        uses: lzap/gobump@main
-        with:
-          go_version: "1.25.9"
-          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          exec: ./tools/prepare-source.sh
-          exec2: "make build"
-          exec_pr: ./tools/prepare-source.sh
-          include: "github.com/osbuild/images github.com/osbuild/blueprint"
-          commit_message: "deps: bump osbuild/images dependency"
-
-  bump-deps:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Run gobump-deps action - all other
-        uses: lzap/gobump@main
-        with:
-          go_version: "1.25.9"
-          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          exec: ./tools/prepare-source.sh
-          exec2: "make build"
-          exec_pr: ./tools/prepare-source.sh
-          exclude: "github.com/osbuild/images,github.com/osbuild/blueprint"
-          commit_message: "deps: update dependencies (w/o osbuild/images)"
+      - name: Run gobump and open a PR
+        env:
+          GH_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+        run: |
+          set -xe
+          cd osbuild-composer/
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+          branch="schutz-gobump-$(date -I)"
+          git checkout -b "${branch}"
+          go run github.com/lzap/gobump@latest \
+            -exec "./tools/prepare-source.sh" \
+            -exec "make build test" \
+            -verbose -format markdown | tee "/tmp/github_pr_body.txt"
+          git log --oneline "main..${branch}"
+          git push -f "https://$GH_TOKEN@github.com/schutzbot/osbuild-composer.git" "${branch}"
+          gh pr create \
+            -t "Update dependencies $(date -I)" \
+            -F "/tmp/github_pr_body.txt" \
+            --repo "osbuild/osbuild-composer" \
+            --base "main" \
+            --head "schutzbot:${branch}"

--- a/.github/workflows/gobump.yml
+++ b/.github/workflows/gobump.yml
@@ -34,6 +34,18 @@ jobs:
             -exec "./tools/prepare-source.sh" \
             -exec "make build test" \
             -verbose -format markdown | tee "/tmp/github_pr_body.txt"
+
+          # Check and update spec file version if needed
+          REQUIRED_VERSION=$(cat vendor/github.com/osbuild/images/data/dependencies/osbuild | tr -d '[:space:]')
+          CURRENT_VERSION=$(grep '^%global min_osbuild_version' osbuild-composer.spec | awk '{print $3}')
+          if [ "${CURRENT_VERSION}" != "${REQUIRED_VERSION}" ]; then
+            sed -i "s/^%global min_osbuild_version .*/%global min_osbuild_version ${REQUIRED_VERSION}/" osbuild-composer.spec
+            git add osbuild-composer.spec
+            git commit -m "chore: update spec with new images minimum version"
+          else
+            echo "Spec file version is already up to date (${CURRENT_VERSION})"
+          fi
+
           git log --oneline "main..${branch}"
           git push -f "https://$GH_TOKEN@github.com/schutzbot/osbuild-composer.git" "${branch}"
           gh pr create \


### PR DESCRIPTION
Gobump can now create individual commits while taking advantage of git reset/clean commands for much better consistency. This brings the configuration on par with images project.

Additionally, also bump the images minimum version in SPEC file so updating images works too.

---

For the initial version, I am taking the optimistic approach and running "make build test" for every single dependency bump. If this turns to be too slow so the job expires, then I will update this to just "make build".

Also, the split to images/blueprint vs other deps is no longer necessary because gobump should be much more consistent now. I will run a bump against this branch.

The new action also uses Fedora container so all the required tools are on par with what we use for images, we also need `skopeo` now and this ensures the versions consistency. Fedora 43 has Go 1.25.10 so we can upgrade as well, there is already a PR: https://github.com/osbuild/osbuild-composer/pull/5153

Run: https://github.com/osbuild/osbuild-composer/actions/runs/26571425108
PR: https://github.com/osbuild/osbuild-composer/pull/5166