### PR TITLE
cloudapi/v2: Fix no partition table handling and add aliases to filtering (HMS-10672)

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1625,11 +1625,10 @@ func (h *apiHandlers) GetDistribution(ctx echo.Context, distroName string, param
 			partitionTable, err := imageType.BasePartitionTable()
 			if err != nil {
 				// Ignore errors about missing partition tables - still a valid image type
-				if errors.Is(err, defs.ErrNoPartitionTableForImgType) ||
-					errors.Is(err, defs.ErrNoPartitionTableForArch) {
-					continue
+				if !errors.Is(err, defs.ErrNoPartitionTableForImgType) &&
+					!errors.Is(err, defs.ErrNoPartitionTableForArch) {
+					return HTTPErrorWithInternal(ErrorGettingImageTypes, err)
 				}
-				return HTTPErrorWithInternal(ErrorGettingImageTypes, err)
 			}
 			if partitionTable != nil {
 				basePartTable, err = partitionTableToDisk(partitionTable)

--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -1613,7 +1613,16 @@ func (h *apiHandlers) GetDistribution(ctx echo.Context, distroName string, param
 
 		for _, imageType := range imageTypes {
 			if params.ImageType != nil && !slices.Contains(*params.ImageType, imageType.Name()) {
-				continue
+				aliasMatch := false
+				for _, alias := range imageType.Aliases() {
+					if slices.Contains(*params.ImageType, alias) {
+						aliasMatch = true
+						break
+					}
+				}
+				if !aliasMatch {
+					continue
+				}
 			}
 
 			var isoLabel *string


### PR DESCRIPTION
I've messed this up back in February in the original change [28d3dcb](https://github.com/osbuild/osbuild-composer/commit/28d3dcbde069cd7a88453f09be827d49307bed64). The code was doing the exact opposite of what the comment was suggesting it's supposed to do. When collecting distribution data, there was a bug that ommits image types without partition tables. As a result, the entire image type was dropped (such as WSL) from the distro metadata. Fix this by inverting the logic of error handling.

Also allows for aliases in filtering image types by name. Implementing it here will allow us not use any "translator" in frontend that uses the aliases when picking targets.