### PR TITLE
[rhel-9.8_10.2] Ensure the host executor logs failures in the journal  (RHEL-179244)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -314,6 +314,23 @@ aws_s3.sh:
   variables:
     SCRIPT: aws_s3.sh
 
+WorkerJournal:
+  stage: test
+  extends: .terraform
+  rules:
+    - !reference [.upstream_and_ga_rules_all, rules]
+  script:
+    - schutzbot/deploy.sh
+    - /usr/libexec/tests/osbuild-composer/worker-journal-failures.sh
+  variables:
+  parallel:
+    matrix:
+      - RUNNER:
+          - aws/rhel-9.8-ga-x86_64
+          - aws/rhel-9.8-ga-aarch64
+          - aws/rhel-10.2-ga-x86_64
+          - aws/rhel-10.2-ga-aarch64
+
 finish:
   stage: finish
   dependencies: []

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -240,6 +240,8 @@ func (impl *OSBuildJobImpl) getOCI(tcp oci.ClientParams) (oci.Client, error) {
 
 func validateResult(result *worker.OSBuildJobResult, jobID string) {
 	logWithId := logrus.WithField("jobId", jobID)
+
+	// in case of failures JobError is expected to be set
 	if result.JobError != nil {
 		logWithId.Errorf("osbuild job failed: %s", result.JobError.Reason)
 		if result.JobError.Details != nil {
@@ -247,17 +249,15 @@ func validateResult(result *worker.OSBuildJobResult, jobID string) {
 		}
 		return
 	}
-	// if the job failed, but the JobError is
-	// nil, we still need to handle this as an error
-	if result.OSBuildOutput == nil || !result.OSBuildOutput.Success {
-		reason := "osbuild job was unsuccessful"
-		logWithId.Errorf("osbuild job failed: %s", reason)
+
+	// bug in case JobError is nil and the job is marked as failed
+	if result.OSBuildOutput == nil || !result.OSBuildOutput.Success || !result.Success {
+		reason := "osbuild job failed without errors, this is a bug"
+		logWithId.Error(reason)
 		result.JobError = clienterrors.New(clienterrors.ErrorBuildJob, reason, nil)
 		return
-	} else {
-		logWithId.Infof("osbuild job succeeded")
 	}
-	result.Success = true
+	logWithId.Infof("osbuild job succeeded")
 }
 
 func uploadToS3(a *awscloud.AWS, outputDirectory, exportPath, bucket, key, filename string, public bool) (string, *clienterrors.Error) {
@@ -318,31 +318,27 @@ func (impl *OSBuildJobImpl) getContainerClient(destination string, targetOptions
 	return client, nil
 }
 
-func makeJobErrorFromOsbuildOutput(osbuildOutput *osbuild.Result) *clienterrors.Error {
-	var osbErrors []string
-	if osbuildOutput.Error != nil {
-		osbErrors = append(osbErrors, fmt.Sprintf("osbuild error: %s", string(osbuildOutput.Error)))
-	}
-	if osbuildOutput.Errors != nil {
-		for _, err := range osbuildOutput.Errors {
-			osbErrors = append(osbErrors, fmt.Sprintf("manifest validation error: %v", err))
+func makeJobErrorFromOsbuildOutput(result *osbuild.Result) *clienterrors.Error {
+	var errors []string
+	// validation errors
+	if result.Errors != nil {
+		for _, err := range result.Errors {
+			errors = append(errors, fmt.Sprintf("validation error in %s: %s", strings.Join(err.Path, "."), err.Message))
 		}
 	}
-	var failedStage string
-	for _, pipelineLog := range osbuildOutput.Log {
-		for _, stageResult := range pipelineLog {
-			if !stageResult.Success {
-				failedStage = stageResult.Type
-				break
+	// use top-level error in case it is set, otherwise go digging
+	if result.Error != nil {
+		errors = append(errors, string(result.Error))
+	} else {
+		for _, pipelineLog := range result.Log {
+			for _, stageResult := range pipelineLog {
+				if !stageResult.Success {
+					errors = append(errors, stageResult.Output)
+				}
 			}
 		}
 	}
-
-	reason := "osbuild build failed"
-	if failedStage != "" {
-		reason += fmt.Sprintf(" in stage: %q", failedStage)
-	}
-	return clienterrors.New(clienterrors.ErrorBuildJob, reason, osbErrors)
+	return clienterrors.New(clienterrors.ErrorBuildJob, "build failure", errors)
 }
 
 func (impl *OSBuildJobImpl) Run(job worker.Job) error {

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -539,35 +539,30 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 		Stderr:     os.Stderr,
 		JSONOutput: true,
 	}
+
 	osbuildJobResult.OSBuildOutput, err = executor.RunOSBuild(jobArgs.Manifest, logWithId, job, opts)
-	// First handle the case when "running" osbuild failed
+	// handle the case where something around running osbuild failed (starting, IO errors, etc.)
 	if err != nil {
-		osbuildJobResult.JobError = clienterrors.New(clienterrors.ErrorBuildJob, "osbuild build failed", err.Error())
+		osbuildJobResult.JobError = clienterrors.New(clienterrors.ErrorBuildJob, "running osbuild failed", err.Error())
 		return err
 	}
 
-	// Include pipeline stages output inside the worker's logs.
-	// Order pipelines based on PipelineNames from job
+	// Log all failed stages
 	for _, pipelineName := range osbuildJobResult.PipelineNames.All() {
-		pipelineLog, hasLog := osbuildJobResult.OSBuildOutput.Log[pipelineName]
-		if !hasLog {
-			// no pipeline output
-			continue
-		}
-		for _, stageResult := range pipelineLog {
-			if stageResult.Success {
-				logWithId.Infof("  %s success", stageResult.Type)
-			} else {
-				logWithId.Infof("  %s failure:", stageResult.Type)
-				stageOutput := strings.Split(stageResult.Output, "\n")
-				for _, line := range stageOutput {
-					logWithId.Infof("    %s", line)
+		if pipelineLog, hasLog := osbuildJobResult.OSBuildOutput.Log[pipelineName]; hasLog {
+			for _, stageResult := range pipelineLog {
+				if !stageResult.Success {
+					logWithId.Infof("failure in %s stage (%s pipeline):", stageResult.Type, pipelineName)
+					stageOutput := strings.Split(stageResult.Output, "\n")
+					for _, line := range stageOutput {
+						logWithId.Infof("  %s", line)
+					}
 				}
 			}
 		}
 	}
 
-	// Second handle the case when the build failed, but osbuild finished successfully
+	// handle the case where osbuild failed and returned a valid result
 	if !osbuildJobResult.OSBuildOutput.Success {
 		osbuildJobResult.JobError = makeJobErrorFromOsbuildOutput(osbuildJobResult.OSBuildOutput)
 		return nil

--- a/cmd/osbuild-worker/jobimpl-osbuild_test.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild_test.go
@@ -34,7 +34,7 @@ func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
 					},
 				},
 			},
-			expected: `Code: 10, Reason: osbuild build failed in stage: "bad-stage", Details: []`,
+			expected: `Code: 10, Reason: build failure, Details: [bad-failure]`,
 		},
 		{
 			inputData: &osbuild.Result{
@@ -43,7 +43,7 @@ func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
 					"fake-os": []osbuild.StageResult{},
 				},
 			},
-			expected: `Code: 10, Reason: osbuild build failed, Details: []`,
+			expected: `Code: 10, Reason: build failure, Details: []`,
 		},
 		{
 			inputData: &osbuild.Result{
@@ -53,14 +53,14 @@ func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
 					"fake-os": []osbuild.StageResult{},
 				},
 			},
-			expected: `Code: 10, Reason: osbuild build failed, Details: [osbuild error: some_osbuild_error]`,
+			expected: `Code: 10, Reason: build failure, Details: [some_osbuild_error]`,
 		},
 		{
 			inputData: &osbuild.Result{
 				Errors: []osbuild.ValidationError{
 					{
 						Message: "validation error message",
-						Path:    []string{"error path"},
+						Path:    []string{"the", "error", "path"},
 					},
 				},
 				Success: false,
@@ -68,7 +68,7 @@ func TestMakeJobErrorFromOsbuildOutput(t *testing.T) {
 					"fake-os": []osbuild.StageResult{},
 				},
 			},
-			expected: `Code: 10, Reason: osbuild build failed, Details: [manifest validation error: {validation error message [error path]}]`,
+			expected: `Code: 10, Reason: build failure, Details: [validation error in the.error.path: validation error message]`,
 		},
 	}
 	for _, testData := range tests {

--- a/internal/osbuildexecutor/runner-impl-host.go
+++ b/internal/osbuildexecutor/runner-impl-host.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/sirupsen/logrus"
 
@@ -41,17 +42,25 @@ func (he *hostExecutor) RunOSBuild(manifest []byte, logger logrus.FieldLogger, j
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("error running osbuild: %w", err)
+		// ignore ExitError if output can be decoded correctly (only if running with --json)
+		if _, isExitError := err.(*exec.ExitError); !isExitError || !opts.JSONOutput {
+			return nil, fmt.Errorf("osbuild failed: %w, %s", err, stdoutBuffer.String())
+		}
 	}
 
-	// try to decode the output even though the job could have failed
-	if stdoutBuffer.Len() == 0 {
-		return nil, fmt.Errorf("osbuild did not return any output")
-	}
 	var result osbuild.Result
-	err = json.Unmarshal(stdoutBuffer.Bytes(), &result)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding osbuild output: %w\nraw output:\n%s", err, stdoutBuffer.String())
+	if opts.JSONOutput {
+		// try to decode the output even though the job could have failed
+		if stdoutBuffer.Len() == 0 {
+			return nil, fmt.Errorf("osbuild did not return any output")
+		}
+		decodeErr := json.Unmarshal(stdoutBuffer.Bytes(), &result)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("error decoding osbuild output: %w\nraw output:\n%s", decodeErr, stdoutBuffer.String())
+		}
+	} else {
+		// the command succeeded without json output, just set the result accordingly
+		result.Success = true
 	}
 
 	return &result, nil

--- a/internal/osbuildexecutor/runner-impl-host_test.go
+++ b/internal/osbuildexecutor/runner-impl-host_test.go
@@ -1,0 +1,146 @@
+package osbuildexecutor_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/images/pkg/osbuild"
+
+	"github.com/osbuild/osbuild-composer/internal/osbuildexecutor"
+)
+
+func TestHostRunOSBuild(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	tests := []struct {
+		name    string
+		osbuild string
+		json    bool
+		error   string
+		result  *osbuild.Result
+	}{
+		{
+			name:    "jsonoutput: invalid json results in error with raw output",
+			osbuild: "echo random output",
+			json:    true,
+			error:   "error decoding osbuild output: invalid character 'r' looking for beginning of value\nraw output:\nrandom output\n",
+		},
+		{
+			name: "jsonoutput: invalid json with exit code 1 results in error",
+			osbuild: `echo random output
+exit 1
+`,
+			json:  true,
+			error: "error decoding osbuild output: invalid character 'r' looking for beginning of value\nraw output:\nrandom output\n",
+		},
+		{
+			name: "jsonoutput: exit code 1 still returns valid results",
+			osbuild: `echo '{"success":false,"log":{"pipeline":[{"id":"stage","success":false,"output":"pigeon"}]}}'
+exit 1
+`,
+			json: true,
+			result: &osbuild.Result{
+				Success: false,
+				Log: map[string]osbuild.PipelineResult{
+					"pipeline": {
+						{
+							ID:      "stage",
+							Success: false,
+							Output:  "pigeon",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonoutput: exit code 2 (validation errors) still returns valid results",
+			osbuild: `echo '{"success":false,"errors":[{"message":"pigeon","path":["path","to","pigeon"]}]}'
+exit 1
+`,
+			json: true,
+			result: &osbuild.Result{
+				Success: false,
+				Errors: []osbuild.ValidationError{
+					{
+						Message: "pigeon",
+						Path:    []string{"path", "to", "pigeon"},
+					},
+				},
+			},
+		},
+		{
+			name: "jsonoutput: exit code 2 (validation errors) still returns valid results",
+			osbuild: `echo '{"success":false,"errors":[{"message":"pigeon","path":["path","to","pigeon"]}]}'
+exit 1
+`,
+			json: true,
+			result: &osbuild.Result{
+				Success: false,
+				Errors: []osbuild.ValidationError{
+					{
+						Message: "pigeon",
+						Path:    []string{"path", "to", "pigeon"},
+					},
+				},
+			},
+		},
+		{
+			name: "no json output: valid",
+			osbuild: `echo 'worked'
+exit 0
+`,
+			result: &osbuild.Result{
+				Success: true,
+			},
+			json: false,
+		},
+		{
+			name: "no json output: exit code 1",
+			osbuild: `echo 'some error'
+exit 1
+`,
+			json:  false,
+			error: "osbuild failed: exit status 1, some error\n",
+		},
+		{
+			name: "no json output: exit code 2",
+			osbuild: `echo 'some validation error'
+exit 2
+`,
+			json:  false,
+			error: "osbuild failed: exit status 2, some validation error\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//nolint:gosec
+			err := os.WriteFile(filepath.Join(tmpDir, "osbuild"), []byte(fmt.Sprintf(`#!/bin/sh
+%s
+`, tt.osbuild)), 0700)
+			require.NoError(t, err)
+
+			hostExe := osbuildexecutor.NewHostExecutor()
+			result, err := hostExe.RunOSBuild(nil, logger, nil, &osbuild.OSBuildOptions{
+				JSONOutput: tt.json,
+			})
+			if tt.error != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tt.error, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.result, result)
+		})
+	}
+}

--- a/test/cases/worker-journal-failures.sh
+++ b/test/cases/worker-journal-failures.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+#
+# Test that osbuild failures end up in the journal and log.
+#
+
+set -euo pipefail
+
+source /usr/libexec/osbuild-composer-test/set-env-variables.sh
+source /usr/libexec/tests/osbuild-composer/shared_lib.sh
+
+# Provision the software under test.
+/usr/libexec/osbuild-composer-test/provision.sh none
+
+TEMPDIR=$(mktemp -d)
+BP=${TEMPDIR}/blueprint.toml
+COMPOSE_START=${TEMPDIR}/compose-start.json
+COMPOSE_INFO=${TEMPDIR}/compose-info.json
+
+tee "$BP" > /dev/null << EOF
+name = "bp"
+description = "A base system"
+version = "0.0.1"
+
+[customizations]
+[customizations.services]
+enabled = ["blergh"]
+EOF
+
+sudo composer-cli blueprints push "$BP"
+
+sudo composer-cli --json compose start bp wsl | tee "$COMPOSE_START"
+COMPOSE_ID=$(get_build_info ".build_id" "$COMPOSE_START")
+
+greenprint "⏱ Waiting for compose to finish: ${COMPOSE_ID}"
+while true; do
+    sudo composer-cli --json compose info "${COMPOSE_ID}" | tee "$COMPOSE_INFO" > /dev/null
+    COMPOSE_STATUS=$(get_build_info ".queue_status" "$COMPOSE_INFO")
+
+    # Is the compose finished?
+    if [[ $COMPOSE_STATUS != RUNNING ]] && [[ $COMPOSE_STATUS != WAITING ]]; then
+        break
+    fi
+
+    # Wait 30 seconds and try again.
+    sleep 30
+done
+
+JOURNAL_OUTPUT=${TEMPDIR}/journal
+sudo journalctl -u osbuild-worker@1 --output cat | sudo tee "$JOURNAL_OUTPUT"
+LOG_OUTPUT=${TEMPDIR}/log
+sudo composer-cli compose log "$COMPOSE_ID" | sudo tee "$LOG_OUTPUT"
+
+EXPECTED_OUTPUT=(
+    "Failed to enable unit.*blergh.service does not exist"
+    "Traceback (most recent call last):"
+    "CalledProcessError.*systemctl.*enable.*blergh.*returned non-zero exit status 1."
+)
+for i in "${!EXPECTED_OUTPUT[@]}"; do
+    if ! grep -q "${EXPECTED_OUTPUT[$i]}" "$JOURNAL_OUTPUT"; then
+        redprint "\"${EXPECTED_OUTPUT[$i]}\" not found in journal"
+        exit 1
+    fi
+    if ! grep -q "${EXPECTED_OUTPUT[$i]}" "$LOG_OUTPUT"; then
+        redprint "\"${EXPECTED_OUTPUT[$i]}\" not found in compose log"
+        exit 1
+    fi
+done
+
+# the worker also logs the JobError which includes the entire error in one line as part of the error details
+if ! grep -q "failure details.*Failed to enable unit.*blergh.service does not exist" "$JOURNAL_OUTPUT"; then
+    redprint "failure details not found in journal"
+    exit 1
+fi


### PR DESCRIPTION
This addresses the issue of missing error messages/logs for the host executor. If osbuild returns a valid result, it is interpreted by the worker, which then generates proper job errors, journal messages and compose logs.

The ec2 executor can be addressed separately, it currently always fails with a (go) error (even if osbuild itself returns a valid result), due to the executor writing invalid json and the monitor failing to parse it (https://github.com/osbuild/images/blob/main/pkg/osbuild/monitor.go#L114). It should get a similar treatment.