### PR TITLE
gitlab: run only one test with module_hotfixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -603,13 +603,6 @@ API-module-hotfixes:
           - aws
         RUNNER:
           - aws/rhel-8.10-ga-x86_64
-          - aws/rhel-8.10-ga-aarch64
-        INTERNAL_NETWORK: ["true"]
-        TEST_MODULE_HOTFIXES: [1]
-      - IMAGE_TYPE:
-          - vsphere
-        RUNNER:
-          - aws/rhel-8.10-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
 


### PR DESCRIPTION
The module_hotfixes option is a repository config option that affects the depsolver.  We should really only be testing if it works as expected as part of the depsolve tests in osbuild.  In osbuild-composer (or preferably in images), we should only be testing if the option is propagated to the repository configs that are sent to the depsolver when resolving packages.

Spinning up three runners and building images in each case for this one option is a bit of an overkill.  Until we add some testing to the depsolver, let's at least reduce the number of tests for this to one.