### PR TITLE
[rhel-9.8_10.2] osbuild-composer.spec: set release version to 164.1

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -12,7 +12,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        165
+Version:        164.1
 
 %gometa
 


### PR DESCRIPTION
The branch was forked after the version bump. As this will be a dot-release, revert the bump and set the version to 164.1.