### PR TITLE
[rhel-9.8_10.2] osbuild-composer.spec: bump version to 165.1

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -12,7 +12,7 @@
 
 %global goipath         github.com/osbuild/osbuild-composer
 
-Version:        164.1
+Version:        165.1
 
 %gometa
 


### PR DESCRIPTION
The rhel-9.8_10.2 branch is based off of 165, not 164 as commit d6eaca8e49b47044e46290567802fd94b3c51a4a assumed.