### PR TITLE
packer: Bump AWS instance type to c6*.xlarge

### DIFF
--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -27,7 +27,7 @@ build {
     # arm one: RHEL-10.0.0_HVM-20251030-x86_64-0-Access2-GP3
     source_ami = "ami-0d2cf1078cac15da9"
     ssh_username = "ec2-user"
-    instance_type = "c6a.large"
+    instance_type = "c6i.2xlarge"
     aws_polling {
       delay_seconds = 20
       max_attempts  = 180
@@ -65,7 +65,7 @@ build {
     # RHEL-10.1.0_HVM_GA-20251031-arm64-0-Access2-GP3
     source_ami = "ami-03d9eec0fe95df48d"
     ssh_username = "ec2-user"
-    instance_type = "c6g.large"
+    instance_type = "c6g.2xlarge"
     aws_polling {
       delay_seconds = 20
       max_attempts  = 180
@@ -103,7 +103,7 @@ build {
     # Fedora-Cloud-Base-AmazonEC2.x86_64-42-1.1
     source_ami = "ami-07df3bb06da88a158"
     ssh_username = "fedora"
-    instance_type = "c6a.large"
+    instance_type = "c6i.2xlarge"
 
     # Set a name for the resulting AMI.
     ami_name = "${var.image_name}-fedora-42-x86_64"
@@ -133,7 +133,7 @@ build {
     # Fedora-Cloud-Base-AmazonEC2.aarch64-42-1.1
     source_ami = "ami-045ca5703b2046e49"
     ssh_username = "fedora"
-    instance_type = "c6g.large"
+    instance_type = "c6g.2xlarge"
 
     # Set a name for the resulting AMI.
     ami_name = "${var.image_name}-fedora-42-aarch64"

--- a/templates/packer/worker.pkr.hcl
+++ b/templates/packer/worker.pkr.hcl
@@ -54,7 +54,7 @@ build {
     launch_block_device_mappings {
       delete_on_termination = "true"
       device_name           = "/dev/sda1"
-      volume_size           = 10
+      volume_size           = 30
       volume_type           = "gp3"
     }
   }
@@ -92,7 +92,7 @@ build {
     launch_block_device_mappings {
       delete_on_termination = "true"
       device_name           = "/dev/sda1"
-      volume_size           = 10
+      volume_size           = 30
       volume_type           = "gp3"
     }
   }
@@ -122,7 +122,7 @@ build {
     launch_block_device_mappings {
       delete_on_termination = "true"
       device_name           = "/dev/sda1"
-      volume_size           = 6
+      volume_size           = 30
       volume_type           = "gp3"
     }
   }
@@ -152,7 +152,7 @@ build {
     launch_block_device_mappings {
       delete_on_termination = "true"
       device_name           = "/dev/sda1"
-      volume_size           = 6
+      volume_size           = 30
       volume_type           = "gp3"
     }
   }


### PR DESCRIPTION
We currently see builds slowing down and then stalling until they time out, possibly due to EBS IOPS burst credit exhaustion or memory pressure.