### PR TITLE
gitlab: drop tests running on RHEL 8.10 [HMS-10771]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,14 +117,7 @@ RPM:
           - aws/centos-stream-9-aarch64
           - aws/centos-stream-10-x86_64
           - aws/centos-stream-10-aarch64
-      - RUNNER:
-          - aws/rhel-9.8-ga-x86_64
-          - aws/rhel-9.9-nightly-x86_64
-          - aws/rhel-9.9-nightly-aarch64
-          - aws/rhel-10.1-ga-aarch64
-          - aws/rhel-10.3-nightly-x86_64
-          - aws/rhel-10.3-nightly-aarch64
-        INTERNAL_NETWORK: ["true"]
+      - <<: *RPM_RUNNERS_RHEL
 
 RPM (GA-only):
   stage: rpmbuild

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,6 @@ RPM:
       - RUNNER:
           - aws/fedora-44-x86_64
           - aws/fedora-44-aarch64
-          - aws/rhel-8.10-ga-x86_64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
           - aws/centos-stream-10-x86_64
@@ -137,7 +136,6 @@ RPM (GA-only):
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.10-ga-aarch64
           - aws/rhel-9.7-ga-aarch64
           - aws/rhel-9.8-ga-aarch64
           - aws/rhel-10.2-ga-x86_64
@@ -170,7 +168,7 @@ Container:
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.10-ga-x86_64
+          - aws/rhel-9.8-ga-x86_64
 
 
 API-bootc:
@@ -236,8 +234,6 @@ Base:
       - RUNNER:
           - aws/fedora-44-x86_64
           - aws/fedora-44-aarch64
-          - aws/rhel-8.10-ga-x86_64
-          - aws/rhel-8.10-ga-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
           - aws/centos-stream-10-x86_64
@@ -260,8 +256,6 @@ Base:
           - aws/fedora-44-x86_64
           - aws/fedora-44-aarch64
       - RUNNER:
-          - aws/rhel-8.10-ga-x86_64
-          - aws/rhel-8.10-ga-aarch64
           - aws/centos-stream-9-x86_64
           - aws/centos-stream-9-aarch64
           - aws/centos-stream-10-x86_64
@@ -288,7 +282,7 @@ regression-excluded-dependency:
   extends: .regression
   rules:
     # WHITELIST & BLACKLIST: excluding GA runners from the PR pipeline
-    - if: $RUNNER =~ "/^.*(rhel-8.*|rhel-9.*|centos-stream-*).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
+    - if: $RUNNER =~ "/^.*(rhel-9.*|centos-stream-*).*$/" && $CI_PIPELINE_SOURCE != "schedule" && $RUNNER !~ /[\S]+rhel-[\S]+-(?:(?:ga)|(?:eus))[\S]+/
     - !reference [.nightly_rules_all, rules]
     - !reference [.ga_rules_all, rules]
   variables:
@@ -311,7 +305,7 @@ regression-old-worker-new-composer:
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.10-ga-x86_64
+          - aws/rhel-10.2-ga-x86_64
         INTERNAL_NETWORK: ["true"]
   extends: .regression
   variables:
@@ -353,7 +347,6 @@ regression-insecure-repo:
 
 .rhel_runners: &rhel_runners
     RUNNER:
-      - aws/rhel-8.10-ga-x86_64
       - aws/rhel-9.9-nightly-x86_64
       - aws/rhel-10.2-ga-x86_64
       - aws/rhel-10.3-nightly-x86_64
@@ -560,7 +553,6 @@ API:
           - edge-container
           - oci
         RUNNER:
-          - aws/rhel-8.10-ga-x86_64
           - aws/rhel-9.8-ga-x86_64
           - aws/rhel-9.9-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -583,10 +575,6 @@ API:
         RUNNER:
           - aws/fedora-44-x86_64
           - aws/fedora-44-aarch64
-      - IMAGE_TYPE: ["aws"]
-        RUNNER:
-          - aws/rhel-8.10-ga-aarch64
-        INTERNAL_NETWORK: ["true"]
 
 API (PR):
   stage: test
@@ -619,7 +607,7 @@ API-module-hotfixes:
       - IMAGE_TYPE:
           - aws
         RUNNER:
-          - aws/rhel-8.10-ga-x86_64
+          - aws/rhel-9.8-ga-x86_64
         INTERNAL_NETWORK: ["true"]
         TEST_MODULE_HOTFIXES: [1]
 
@@ -653,7 +641,6 @@ API-unit:
       - RUNNER:
           - rhos-01/fedora-44-x86_64
       - RUNNER:
-          - gcp/rhel-8.10-ga-x86_64
           - gcp/rhel-9.8-ga-x86_64
           - gcp/rhel-9.9-nightly-x86_64
           - gcp/rhel-10.2-ga-x86_64
@@ -679,7 +666,6 @@ weldr-distro-dot-notation+aliases:
   parallel:
     matrix:
       - RUNNER:
-          - aws/rhel-8.8-ga-x86_64
           - aws/rhel-9.8-ga-x86_64
           - aws/rhel-9.9-nightly-x86_64
         INTERNAL_NETWORK: ["true"]
@@ -749,7 +735,7 @@ Multi-tenancy:
     - schutzbot/deploy.sh
     - /usr/libexec/tests/osbuild-composer/multi-tenancy.sh
   variables:
-    RUNNER: aws/rhel-8.10-ga-x86_64
+    RUNNER: aws/rhel-9.8-ga-x86_64
     INTERNAL_NETWORK: "true"
 
 Upgrade:

--- a/cmd/osbuild-composer-cli-tests/main_test.go
+++ b/cmd/osbuild-composer-cli-tests/main_test.go
@@ -139,15 +139,10 @@ func TestBlueprintCommands(t *testing.T) {
 	// blueprints changes is not supported by cloudapi
 	var changesWeldr []weldr.BlueprintsChangesV0Weldr
 	rawReply := runComposerJSON(t, "blueprints", "changes", "empty")
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &changesWeldr)
-		if err != nil {
-			changesWeldr = make([]weldr.BlueprintsChangesV0Weldr, 1)
-			err = json.Unmarshal(rawReply, &changesWeldr[0])
-		}
-	} else {
+	err = json.Unmarshal(rawReply, &changesWeldr)
+	if err != nil {
 		changesWeldr = make([]weldr.BlueprintsChangesV0Weldr, 1)
-		err = json.Unmarshal(rawReply, &changesWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &changesWeldr[0])
 	}
 	require.Nilf(t, err, "Error searching for commits to undo: %v", err)
 	runComposer(t, "blueprints", "undo", "empty", changesWeldr[0].Body.BlueprintsChanges[0].Changes[0].Commit)
@@ -223,16 +218,10 @@ func startCompose(t *testing.T, name, outputType string) uuid.UUID {
 		Body reply `json:"body"`
 	}
 	var replyWeldr []replyWithBody
-	var err error
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &replyWeldr)
-		if err != nil {
-			replyWeldr = make([]replyWithBody, 1)
-			err = json.Unmarshal(rawReply, &replyWeldr[0])
-		}
-	} else {
+	err := json.Unmarshal(rawReply, &replyWeldr)
+	if err != nil {
 		replyWeldr = make([]replyWithBody, 1)
-		err = json.Unmarshal(rawReply, &replyWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &replyWeldr[0])
 	}
 	require.Nilf(t, err, "Unexpected reply: %v", err)
 	require.Truef(t, replyWeldr[0].Body.Status, "Unexpected status %v", replyWeldr[0].Body.Status)
@@ -283,16 +272,10 @@ func deleteCompose(t *testing.T, id uuid.UUID) {
 		Body reply  `json:"body"`
 	}
 	var replyWeldr []replyWithBody
-	var err error
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &replyWeldr)
-		if err != nil {
-			replyWeldr = make([]replyWithBody, 1)
-			err = json.Unmarshal(rawReply, &replyWeldr[0])
-		}
-	} else {
+	err := json.Unmarshal(rawReply, &replyWeldr)
+	if err != nil {
 		replyWeldr = make([]replyWithBody, 1)
-		err = json.Unmarshal(rawReply, &replyWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &replyWeldr[0])
 	}
 	require.Nilf(t, err, "Unexpected reply: %v", err)
 	// NOTE: The response may contain a cloudapi error in the first response
@@ -356,16 +339,10 @@ func getComposeStatus(t *testing.T, uuid uuid.UUID) string {
 		Body reply  `json:"body"`
 	}
 	var replyWeldr []replyWithBody
-	var err error
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &replyWeldr)
-		if err != nil {
-			replyWeldr = make([]replyWithBody, 1)
-			err = json.Unmarshal(rawReply, &replyWeldr[0])
-		}
-	} else {
+	err := json.Unmarshal(rawReply, &replyWeldr)
+	if err != nil {
 		replyWeldr = make([]replyWithBody, 1)
-		err = json.Unmarshal(rawReply, &replyWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &replyWeldr[0])
 	}
 	require.Nilf(t, err, "Unexpected reply: %v", err)
 	// NOTE: The response may contain a cloudapi error in the first response
@@ -419,15 +396,10 @@ func pushBlueprint(t *testing.T, bp *blueprint.Blueprint) {
 		Body reply `json:"body"`
 	}
 	var replyWeldr []replyWithBody
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &replyWeldr)
-		if err != nil {
-			replyWeldr = make([]replyWithBody, 1)
-			err = json.Unmarshal(rawReply, &replyWeldr[0])
-		}
-	} else {
+	err = json.Unmarshal(rawReply, &replyWeldr)
+	if err != nil {
 		replyWeldr = make([]replyWithBody, 1)
-		err = json.Unmarshal(rawReply, &replyWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &replyWeldr[0])
 	}
 	require.Nilf(t, err, "Unexpected reply: %v", err)
 	log.Printf("Mesasge: %v", replyWeldr[0].Body.Status)
@@ -446,16 +418,10 @@ func deleteBlueprint(t *testing.T, bp *blueprint.Blueprint) {
 		Body reply `json:"body"`
 	}
 	var replyWeldr []replyWithBody
-	var err error
-	if isWeldrClientInstalled() {
-		err = json.Unmarshal(rawReply, &replyWeldr)
-		if err != nil {
-			replyWeldr = make([]replyWithBody, 1)
-			err = json.Unmarshal(rawReply, &replyWeldr[0])
-		}
-	} else {
+	err := json.Unmarshal(rawReply, &replyWeldr)
+	if err != nil {
 		replyWeldr = make([]replyWithBody, 1)
-		err = json.Unmarshal(rawReply, &replyWeldr[0].Body)
+		err = json.Unmarshal(rawReply, &replyWeldr[0])
 	}
 	require.Nilf(t, err, "Unexpected reply: %v", err)
 	require.Truef(t, replyWeldr[0].Body.Status, "Unexpected status %v", replyWeldr[0].Body.Status)
@@ -558,15 +524,4 @@ func (d *TemporaryWorkDir) Close(t *testing.T) {
 
 	err = os.RemoveAll(d.Path)
 	require.Nilf(t, err, "os.RemoveAll: %v", err)
-}
-
-// This checks wheter weldr-client is installed or not
-func isWeldrClientInstalled() bool {
-	cmd := exec.Command("rpm", "-q", "weldr-client")
-	err := cmd.Run()
-	if err != nil {
-		return false
-	} else {
-		return true
-	}
 }

--- a/test/cases/shared_lib.sh
+++ b/test/cases/shared_lib.sh
@@ -21,15 +21,13 @@ function nvrGreaterOrEqual {
     false
 }
 
+# Returns the sub-structure or value defined by the filter argument given the
+# path to a file that contains the response from a "compose start" call.
 function get_build_info() {
     local filter="$1"
     local fname="$2"
-    if rpm -q --quiet weldr-client; then
-        filter=".body${filter}"  # oldest structure, pre v35.6
-        if nvrGreaterOrEqual "weldr-client" "35.6" 2> /dev/null; then
-            filter=".[0]${filter}"  # changed to array in v35.6
-        fi
-    fi
+
+    filter=".[0].body${filter}"  # responses are arrays since v35.6
     jq -r "${filter}" "${fname}"
 }
 
@@ -40,17 +38,14 @@ function get_compose_id() {
     get_build_info ".build_id" "${response_file}"
 }
 
-# Return the status of a compose given a compose ID.
-# This function handles response structure differences in various weldr-client
-# / composer-cli versions. The status string also differs for newer (>= v36.0)
-# of the client.
+# Return the status of a compose given a compose ID. This function handles
+# response structure differences in various weldr-client / composer-cli
+# versions. The structure and status string differ for newer (>= v36.0) of the
+# client.
 function get_compose_status() {
     local compose_id="$1"
 
-    local filter=".body.queue_status"  # oldest structure, pre v35.6
-    if nvrGreaterOrEqual "weldr-client" "35.6" 2> /dev/null; then
-        filter=".[0].body.queue_status"  # changed to array in v35.6
-    fi
+    filter=".[0].body.queue_status"  # oldest structure (since v35.6)
 
     if nvrGreaterOrEqual "weldr-client" "36.0" 2> /dev/null; then
         filter='.[].body | select(.kind == "ComposeStatus") | .status'  # changed using cloud API since v36.0


### PR DESCRIPTION
We're never going to release into RHEL 8.10 again, certainly not from th main branch, so testing newer code on RHEL 8.10 makes no sense and only wastes resources.

The "RHEL 8 on 9 (Koji)" test verifies that osbuild-composer can still successfully build RHEL 8 images on a RHEL 9 runner. The gitlab tests in the images repository verify that RHEL 8 images are valid (bootable).