### PR TITLE
spec: drop the tests subpackage from EL11

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -109,7 +109,7 @@ export LDFLAGS="${LDFLAGS} -X 'github.com/osbuild/osbuild-composer/internal/comm
 
 make man
 
-%if %{with tests} || 0%{?rhel}
+%if %{with tests} || (0%{?rhel} && 0%{?rhel} < 11)
 
 # Build test binaries with `go test -c`, so that they can take advantage of
 # golang's testing package. The golang rpm macros don't support building them
@@ -213,7 +213,7 @@ install -m 0755 -vd                                                %{buildroot}%
 install -m 0755 -vd                                                %{buildroot}%{_mandir}/man7
 install -m 0644 -vp docs/*.7                                       %{buildroot}%{_mandir}/man7/
 
-%if %{with tests} || 0%{?rhel}
+%if %{with tests} || (0%{?rhel} && 0%{?rhel} < 11)
 
 install -m 0755 -vd                                                %{buildroot}%{_libexecdir}/osbuild-composer-test
 install -m 0755 -vp _bin/osbuild-composer-cli-tests                %{buildroot}%{_libexecdir}/osbuild-composer-test/
@@ -370,7 +370,7 @@ fi
 # restart all the worker services
 %systemd_postun_with_restart "osbuild-worker@*.service" "osbuild-remote-worker@*.service"
 
-%if %{with tests} || 0%{?rhel}
+%if %{with tests} || (0%{?rhel} && 0%{?rhel} < 11)
 
 %package tests
 Summary:    Integration tests


### PR DESCRIPTION
We don't intend to ship osbuild-composer in EL11. The first step was to remove weldr-client but the tests subpackage is still pulling it as a dep. Let's remove the tests package from osbuild-composer in EL11 to start chipping away the unwanted components from it.

See https://github.com/fedora-eln/content-resolver-input/pull/1606