### PR TITLE
cloudapi: wrap panic recover in manifest job in an error

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -785,7 +785,7 @@ func serializeManifest(ctx context.Context, getManifestSource manifestSourceFunc
 	defer func() {
 		if r := recover(); r != nil {
 			logWithId.Errorf("Recovered from panic in serializeManifest: %v", r)
-			jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, "Error serializing manifest", r)
+			jobResult.JobError = clienterrors.New(clienterrors.ErrorManifestGeneration, "Error serializing manifest", fmt.Sprintf("%v", r))
 		}
 
 		// token == uuid.Nil indicates that no worker even started processing


### PR DESCRIPTION
While the details of clienterrors are of type `interface{}`, if the details are not json serializable, they will be lost.

Serializing the manifest can result in panics, which mostly panic with either a string or an `error`. The latter is not serializable by default. This patch makes sure that the details are serializable by formatting them as a string.

More precise type checking could be done against the return value of
    `recover()`, but since this is a situation where any information is good
    information, regardless of how it is formatted, simply converting it
    into a string should be acceptable.