### PR TITLE
composer: fall back to /etc/yum.repos.d/ when no repo configs are found

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -12,19 +12,25 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	logrus "github.com/sirupsen/logrus"
+	"gopkg.in/ini.v1"
 
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue/dbjobqueue"
 
+	"github.com/osbuild/image-builder/pkg/arch"
 	"github.com/osbuild/image-builder/pkg/depsolvednf"
+	"github.com/osbuild/image-builder/pkg/distro"
 	"github.com/osbuild/image-builder/pkg/distrofactory"
 	"github.com/osbuild/image-builder/pkg/experimentalflags"
 	"github.com/osbuild/image-builder/pkg/reporegistry"
+	"github.com/osbuild/image-builder/pkg/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/auth"
 	"github.com/osbuild/osbuild-composer/internal/cloudapi"
 	v2 "github.com/osbuild/osbuild-composer/internal/cloudapi/v2"
@@ -83,12 +89,18 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 	case nil:
 		// fine
 	case *reporegistry.NoReposLoadedError:
-		if !c.config.IgnoreMissingRepos {
-			return nil, fmt.Errorf("error loading repository definitions: %w", err)
+		// No osbuild-specific repo config files found; try to build the registry
+		// from the system's /etc/yum.repos.d/ so that the host's configured
+		// repositories are used automatically.
+		logrus.Info("No repository config files found in configured paths, falling back to /etc/yum.repos.d/")
+		c.repos, err = repoRegistryFromYumReposD("/etc/yum.repos.d")
+		if err != nil {
+			if !c.config.IgnoreMissingRepos {
+				return nil, fmt.Errorf("error loading repository definitions from /etc/yum.repos.d/: %w", err)
+			}
+			logrus.Infof("Failed to load repositories from /etc/yum.repos.d/: %v", err)
+			logrus.Info("ignore_missing_repos enabled: continuing")
 		}
-		// running without repositories is allowed: log message and continue
-		logrus.Info(err.Error())
-		logrus.Info("ignore_missing_repos enabled: continuing")
 	default:
 		return nil, fmt.Errorf("error loading repository definitions: %w", err)
 	}
@@ -490,4 +502,105 @@ func createTLSConfig(c *connectionConfig) (*tls.Config, error) {
 			return errors.New("domain not in allowlist")
 		},
 	}, nil
+}
+
+// repoRegistryFromYumReposD reads all *.repo files from reposDir (typically
+// /etc/yum.repos.d), converts each enabled section into an rpmmd.RepoConfig,
+// and returns a RepoRegistry keyed to the host distro and architecture.
+// This is used as a fallback when no osbuild-specific JSON/YAML repo config
+// files are found in the configured repository config paths.
+func repoRegistryFromYumReposD(reposDir string) (*reporegistry.RepoRegistry, error) {
+	hostDistroName, err := distro.GetHostDistroName()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect host distro: %w", err)
+	}
+	return repoRegistryFromYumReposDForDistroArch(reposDir, hostDistroName, arch.Current().String())
+}
+
+// repoRegistryFromYumReposDForDistroArch is the testable core of
+// repoRegistryFromYumReposD. It accepts the distro name and architecture
+// explicitly so tests can call it without a real /etc/os-release present.
+func repoRegistryFromYumReposDForDistroArch(reposDir, distroName, hostArch string) (*reporegistry.RepoRegistry, error) {
+	// filepath.Glob returns (nil, nil) for non-existent directories, so a
+	// missing reposDir is handled by the len(repos) == 0 check below.
+	files, err := filepath.Glob(filepath.Join(reposDir, "*.repo"))
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []rpmmd.RepoConfig
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			logrus.Warnf("repoRegistryFromYumReposD: skipping %s: %v", f, err)
+			continue
+		}
+		cfg, err := ini.Load(content)
+		if err != nil {
+			logrus.Warnf("repoRegistryFromYumReposD: failed to parse %s: %v", f, err)
+			continue
+		}
+		for _, section := range cfg.Sections() {
+			if section.Name() == "DEFAULT" {
+				continue
+			}
+			// Skip explicitly disabled repos
+			if enabled, e := section.GetKey("enabled"); e == nil && enabled.String() == "0" {
+				continue
+			}
+			repo := rpmmd.RepoConfig{
+				Id:   section.Name(),
+				Name: section.Name(),
+			}
+			if k, e := section.GetKey("name"); e == nil {
+				repo.Name = k.String()
+			}
+			if k, e := section.GetKey("baseurl"); e == nil {
+				// DNF supports multiple space/newline-separated URLs per section.
+				repo.BaseURLs = strings.Fields(k.String())
+			}
+			if k, e := section.GetKey("metalink"); e == nil {
+				repo.Metalink = k.String()
+			}
+			if k, e := section.GetKey("mirrorlist"); e == nil {
+				repo.MirrorList = k.String()
+			}
+			if k, e := section.GetKey("gpgkey"); e == nil {
+				// DNF supports multiple whitespace-separated keys per section.
+				repo.GPGKeys = strings.Fields(k.String())
+			}
+			if k, e := section.GetKey("gpgcheck"); e == nil {
+				v := k.String() == "1"
+				repo.CheckGPG = &v
+			}
+			if k, e := section.GetKey("sslcacert"); e == nil {
+				repo.SSLCACert = k.String()
+			}
+			if k, e := section.GetKey("sslclientkey"); e == nil {
+				repo.SSLClientKey = k.String()
+			}
+			if k, e := section.GetKey("sslclientcert"); e == nil {
+				repo.SSLClientCert = k.String()
+			}
+			if k, e := section.GetKey("sslverify"); e == nil {
+				ignoreSSL := k.String() == "0"
+				repo.IgnoreSSL = &ignoreSSL
+			}
+			if k, e := section.GetKey("metadata_expire"); e == nil {
+				repo.MetadataExpire = k.String()
+			}
+			repos = append(repos, repo)
+		}
+	}
+
+	if len(repos) == 0 {
+		return nil, fmt.Errorf("no enabled repositories found in %s", reposDir)
+	}
+
+	distrosRepoConfigs := rpmmd.DistrosRepoConfigs{
+		distroName: {
+			hostArch: repos,
+		},
+	}
+	return reporegistry.NewFromDistrosRepoConfigs(distrosRepoConfigs), nil
 }

--- a/cmd/osbuild-composer/composer_test.go
+++ b/cmd/osbuild-composer/composer_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDistro = "rhel-9"
+	testArch   = "x86_64"
+)
+
+// writeRepoFile is a test helper that writes content to <dir>/<name>.
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+}
+
+func TestRepoRegistryFromYumReposD_BasicRepo(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "test.repo", `
+[baseos]
+name = BaseOS
+baseurl = https://example.com/baseos
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslcacert = /etc/rhsm/ca/katello-server-ca.pem
+sslclientkey = /etc/pki/entitlement/key.pem
+sslclientcert = /etc/pki/entitlement/cert.pem
+metadata_expire = 1
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+	require.NotNil(t, rr)
+
+	require.Equal(t, []string{testDistro}, rr.ListDistros())
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "BaseOS", repos[0].Name)
+	assert.Equal(t, []string{"https://example.com/baseos"}, repos[0].BaseURLs)
+	assert.Equal(t, []string{"file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"}, repos[0].GPGKeys)
+	require.NotNil(t, repos[0].CheckGPG)
+	assert.True(t, *repos[0].CheckGPG)
+	assert.Equal(t, "/etc/rhsm/ca/katello-server-ca.pem", repos[0].SSLCACert)
+	assert.Equal(t, "/etc/pki/entitlement/key.pem", repos[0].SSLClientKey)
+	assert.Equal(t, "/etc/pki/entitlement/cert.pem", repos[0].SSLClientCert)
+	assert.Equal(t, "1", repos[0].MetadataExpire)
+}
+
+func TestRepoRegistryFromYumReposD_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "baseos.repo", `
+[baseos]
+name = BaseOS
+baseurl = https://example.com/baseos
+enabled = 1
+gpgcheck = 0
+`)
+	writeRepoFile(t, dir, "appstream.repo", `
+[appstream]
+name = AppStream
+baseurl = https://example.com/appstream
+enabled = 1
+gpgcheck = 0
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+	require.NotNil(t, rr)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	assert.Len(t, repos, 2)
+}
+
+func TestRepoRegistryFromYumReposD_MultipleReposInOneFile(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "redhat.repo", `
+[rhel-baseos]
+name = RHEL BaseOS
+baseurl = https://satellite.example.com/baseos
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[rhel-appstream]
+name = RHEL AppStream
+baseurl = https://satellite.example.com/appstream
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[rhel-crb]
+name = RHEL CRB
+baseurl = https://satellite.example.com/crb
+enabled = 0
+gpgcheck = 1
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	// CRB is disabled, only 2 repos expected.
+	require.Len(t, repos, 2)
+	names := []string{repos[0].Name, repos[1].Name}
+	assert.Contains(t, names, "RHEL BaseOS")
+	assert.Contains(t, names, "RHEL AppStream")
+}
+
+func TestRepoRegistryFromYumReposD_SkipsDisabledRepos(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "mixed.repo", `
+[enabled-repo]
+name = Enabled
+baseurl = https://example.com/enabled
+enabled = 1
+gpgcheck = 0
+
+[disabled-repo]
+name = Disabled
+baseurl = https://example.com/disabled
+enabled = 0
+gpgcheck = 0
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+	require.NotNil(t, rr)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "Enabled", repos[0].Name)
+}
+
+func TestRepoRegistryFromYumReposD_EnabledDefaultsToTrue(t *testing.T) {
+	dir := t.TempDir()
+	// No "enabled" key — should default to included.
+	writeRepoFile(t, dir, "implicit.repo", `
+[implicit-enabled]
+name = Implicit Enabled
+baseurl = https://example.com/implicit
+gpgcheck = 0
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "Implicit Enabled", repos[0].Name)
+}
+
+func TestRepoRegistryFromYumReposD_SSLFieldsMapped(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "rhsm.repo", `
+[myrepo]
+name = My Repo
+baseurl = https://satellite.example.com/content/os
+enabled = 1
+gpgcheck = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify = 0
+sslcacert = /etc/rhsm/ca/katello-server-ca.pem
+sslclientkey = /etc/pki/entitlement/1234-key.pem
+sslclientcert = /etc/pki/entitlement/1234.pem
+metadata_expire = 86400
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	r := repos[0]
+	assert.Equal(t, "/etc/rhsm/ca/katello-server-ca.pem", r.SSLCACert)
+	assert.Equal(t, "/etc/pki/entitlement/1234-key.pem", r.SSLClientKey)
+	assert.Equal(t, "/etc/pki/entitlement/1234.pem", r.SSLClientCert)
+	require.NotNil(t, r.IgnoreSSL)
+	assert.True(t, *r.IgnoreSSL) // sslverify=0 → IgnoreSSL=true
+	assert.Equal(t, "86400", r.MetadataExpire)
+}
+
+func TestRepoRegistryFromYumReposD_IgnoresNonRepoFiles(t *testing.T) {
+	dir := t.TempDir()
+	// .txt file must not be parsed — only *.repo files are picked up.
+	writeRepoFile(t, dir, "README.txt", "this is not a repo file")
+	writeRepoFile(t, dir, "valid.repo", `
+[baseos]
+name = BaseOS
+baseurl = https://example.com/baseos
+enabled = 1
+gpgcheck = 0
+`)
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+	require.NotNil(t, rr)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	assert.Len(t, repos, 1)
+}
+
+func TestRepoRegistryFromYumReposD_AllDisabledReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeRepoFile(t, dir, "all-disabled.repo", `
+[repo-a]
+name = Repo A
+baseurl = https://example.com/a
+enabled = 0
+
+[repo-b]
+name = Repo B
+baseurl = https://example.com/b
+enabled = 0
+`)
+
+	_, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no enabled repositories found")
+}
+
+func TestRepoRegistryFromYumReposD_EmptyDirReturnsError(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no enabled repositories found")
+}
+
+func TestRepoRegistryFromYumReposD_NonExistentDirReturnsError(t *testing.T) {
+	_, err := repoRegistryFromYumReposDForDistroArch("/nonexistent/path/yum.repos.d", testDistro, testArch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no enabled repositories found")
+}
+
+func TestRepoRegistryFromYumReposD_MultiValueGPGKeyAndBaseurl(t *testing.T) {
+	dir := t.TempDir()
+	// DNF allows multiple GPG keys and base URLs via backslash line continuation.
+	// ini.v1 joins continuation lines with a space; strings.Fields then splits them.
+	writeRepoFile(t, dir, "multi.repo", "[multi]\nname = Multi Key Repo\nbaseurl = https://mirror1.example.com/os \\\n https://mirror2.example.com/os\nenabled = 1\ngpgcheck = 1\ngpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-A \\\n file:///etc/pki/rpm-gpg/RPM-GPG-KEY-B\n")
+
+	rr, err := repoRegistryFromYumReposDForDistroArch(dir, testDistro, testArch)
+	require.NoError(t, err)
+
+	repos, err := rr.ReposByArchName(testDistro, testArch, false)
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+	assert.Len(t, repos[0].BaseURLs, 2)
+	assert.Len(t, repos[0].GPGKeys, 2)
+}


### PR DESCRIPTION
When no osbuild-specific JSON/YAML repository config files exist under
/etc/osbuild-composer/repositories or /usr/share/osbuild-composer/repositories,
the composer previously returned a NoReposLoadedError (fatal unless
ignore_missing_repos=true), making it impossible to use on systems whose
only repository definitions live in /etc/yum.repos.d/ — for example,
Satellite-managed RHEL machines using certificate-based subscriptions.

In my opinion, the repositories already configured on the system should be the defaults.
My VMs are all managed by a RedHat satellite and cannot reach this default "cdn..." repositories. However, you can't even remove them from the GUI, which is quite painful. I tried X different hacks to get rid of those "cdn" repos because the image building will not work if there is any unreachable repository in the list (or atleast the short error message that it cannot find the metadata in those repos make me believe that).
I found in the documentation of [weldr](https://github.com/osbuild/weldr-client#package-sources) that it should pick it up from the already configured repositories. I would prefer that generally. 

Two remarks: Instead of just complaining about a feature you don't have I wanted to propose a possible code solution up front. I haven't worked with Go so far so I would really value your input if the code is not up to your standards. I will check again to fix the checks if they break. 

Edit:
<img width="1081" height="651" alt="image" src="https://github.com/user-attachments/assets/985f0be7-a93e-4364-9920-0b14f66d93ad" />
<img width="613" height="194" alt="image" src="https://github.com/user-attachments/assets/82744fd4-3ac6-4122-9168-76a562fefa70" />
My current issue in some screenshots. These default repositories seem to come from `/usr/share/osbuild-composer/repositories/`. If I understood correctly, you should add your own repositories to `/etc/osbuild-composer/repositories`. In that case, the current solution is just broken if you can't reach these defaults.
My current solution is to overwrite the default files with ansible. That also requires restarting the systemd service and generally it seems ugly to me. I'm also open to have other solutions that work but so far I couldn't find any.
Part of the ansible code I currently have to maintain for this:
```
- name: Copy Satellite repository definitions for all RHEL 9 variants
  ansible.builtin.copy:
    src: rhel-9.json
    dest: "/etc/osbuild-composer/repositories/{{ item }}"
    owner: root
    group: root
    mode: "0644"
  loop:
    - rhel-9.json
    - rhel-9.0.json
    - rhel-9.2.json
    - rhel-9.4.json
    - rhel-9.6.json
    - rhel-9.7.json
    - rhel-9.8.json
  notify: Restart osbuild-composer

- name: Flush handlers so composer restarts before we verify sources
  ansible.builtin.meta: flush_handlers

- name: Wait for osbuild-composer to be ready to accept requests
  ansible.builtin.command:
    cmd: composer-cli status show
  register: composer_ready
  until: composer_ready.rc == 0
  retries: 15
  delay: 2
  changed_when: false 
...
```


### Suggested code change:

Add repoRegistryFromYumReposD() which reads all *.repo files from
/etc/yum.repos.d/, parses the standard DNF/yum INI format using
gopkg.in/ini.v1 (already a transitive dependency via the rhsm package),
and returns a RepoRegistry keyed to the auto-detected host distro and arch.
The function:
  - skips sections with enabled=0
  - includes sections with no enabled key (DNF default)
  - maps all relevant fields: baseurl, gpgkey, gpgcheck, metalink,
    mirrorlist, sslcacert, sslclientkey, sslclientcert, sslverify,
    metadata_expire
  - correctly handles multiple whitespace-separated values for baseurl
    and gpgkey (backslash line continuation, joined by ini.v1)

The fallback is inserted into the NoReposLoadedError branch in
NewComposer(). IgnoreMissingRepos still applies if both the JSON/YAML
configs and the yum.repos.d/ fallback yield nothing.