### PR TITLE
worker: preserve container spec ordering after resolution

### DIFF
--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -77,10 +77,11 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 }
 
 // resolveContainers resolves container specs grouped by pipeline name.
+// Each container is resolved individually with Resolve() to preserve
+// positional ordering.
 func resolveContainers(arch, authFilePath string, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
-	// NOTE: container.Resolver.Finish() sorts results by digest, destroying Add() ordering.
-	// Use a separate resolver per pipeline because, positional slicing
-	// across pipelines would not work, due to the sorting by digest.
+	resolver := container.NewResolver(arch)
+	resolver.AuthFilePath = authFilePath
 
 	result := make(map[string][]worker.ContainerSpec, len(pipelineSpecs))
 	for name, specs := range pipelineSpecs {
@@ -88,21 +89,13 @@ func resolveContainers(arch, authFilePath string, pipelineSpecs map[string][]wor
 			continue
 		}
 
-		resolver := container.NewResolver(arch)
-		resolver.AuthFilePath = authFilePath
-
-		for _, s := range specs {
-			resolver.Add(s.ToVendorSourceSpec())
-		}
-
-		resolved, err := resolver.Finish()
-		if err != nil {
-			return nil, fmt.Errorf("Error resolving containers for pipeline %q: %w", name, err)
-		}
-
-		pipelineResult := make([]worker.ContainerSpec, len(resolved))
-		for i, spec := range resolved {
-			pipelineResult[i] = worker.ContainerSpecFromVendorSpec(spec)
+		pipelineResult := make([]worker.ContainerSpec, len(specs))
+		for i, s := range specs {
+			res, err := resolver.Resolve(s.ToVendorSourceSpec())
+			if err != nil {
+				return nil, fmt.Errorf("Error resolving containers for pipeline %q: %w", name, err)
+			}
+			pipelineResult[i] = worker.ContainerSpecFromVendorSpec(res)
 		}
 		result[name] = pipelineResult
 	}

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -66,17 +66,30 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	}
 	logWithId.Infof("Resolving containers (%d specs across %d pipelines)", totalSpecs, len(args.PipelineSpecs))
 
+	resolved, err := resolveContainers(args.Arch, impl.AuthFilePath, args.PipelineSpecs)
+	if err != nil {
+		result.JobError = clienterrors.New(clienterrors.ErrorContainerResolution, err.Error(), nil)
+		return err
+	}
+	result.PipelineSpecs = resolved
+
+	return nil
+}
+
+// resolveContainers resolves container specs grouped by pipeline name.
+func resolveContainers(arch, authFilePath string, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
 	// NOTE: container.Resolver.Finish() sorts results by digest, destroying Add() ordering.
 	// Use a separate resolver per pipeline because, positional slicing
 	// across pipelines would not work, due to the sorting by digest.
-	result.PipelineSpecs = make(map[string][]worker.ContainerSpec, len(args.PipelineSpecs))
-	for name, specs := range args.PipelineSpecs {
+
+	result := make(map[string][]worker.ContainerSpec, len(pipelineSpecs))
+	for name, specs := range pipelineSpecs {
 		if len(specs) == 0 {
 			continue
 		}
 
-		resolver := container.NewResolver(args.Arch)
-		resolver.AuthFilePath = impl.AuthFilePath
+		resolver := container.NewResolver(arch)
+		resolver.AuthFilePath = authFilePath
 
 		for _, s := range specs {
 			resolver.Add(s.ToVendorSourceSpec())
@@ -84,18 +97,16 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 
 		resolved, err := resolver.Finish()
 		if err != nil {
-			result.JobError = clienterrors.New(clienterrors.ErrorContainerResolution, err.Error(), nil)
-			return fmt.Errorf("Error resolving containers for pipeline %q: %v", name, err)
+			return nil, fmt.Errorf("Error resolving containers for pipeline %q: %w", name, err)
 		}
 
 		pipelineResult := make([]worker.ContainerSpec, len(resolved))
 		for i, spec := range resolved {
 			pipelineResult[i] = worker.ContainerSpecFromVendorSpec(spec)
 		}
-		result.PipelineSpecs[name] = pipelineResult
+		result[name] = pipelineResult
 	}
-
-	return nil
+	return result, nil
 }
 
 // readContainerResolveArgsFromDynArgs reads the container resolve args from

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -66,7 +66,10 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	}
 	logWithId.Infof("Resolving containers (%d specs across %d pipelines)", totalSpecs, len(args.PipelineSpecs))
 
-	resolved, err := resolveContainers(args.Arch, impl.AuthFilePath, args.PipelineSpecs)
+	resolver := container.NewResolver(args.Arch)
+	resolver.AuthFilePath = impl.AuthFilePath
+
+	resolved, err := resolveContainers(resolver, args.PipelineSpecs)
 	if err != nil {
 		result.JobError = clienterrors.New(clienterrors.ErrorContainerResolution, err.Error(), nil)
 		return err
@@ -79,10 +82,7 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 // resolveContainers resolves container specs grouped by pipeline name.
 // Each container is resolved individually with Resolve() to preserve
 // positional ordering.
-func resolveContainers(arch, authFilePath string, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
-	resolver := container.NewResolver(arch)
-	resolver.AuthFilePath = authFilePath
-
+func resolveContainers(resolver container.Resolver, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
 	result := make(map[string][]worker.ContainerSpec, len(pipelineSpecs))
 	for name, specs := range pipelineSpecs {
 		if len(specs) == 0 {

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -69,7 +69,7 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	resolver := container.NewResolver(args.Arch)
 	resolver.AuthFilePath = impl.AuthFilePath
 
-	resolved, err := resolveContainers(resolver, args.PipelineSpecs)
+	resolved, err := ResolveContainers(resolver, args.PipelineSpecs)
 	if err != nil {
 		result.JobError = clienterrors.New(clienterrors.ErrorContainerResolution, err.Error(), nil)
 		return err
@@ -79,10 +79,10 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 	return nil
 }
 
-// resolveContainers resolves container specs grouped by pipeline name.
+// ResolveContainers resolves container specs grouped by pipeline name.
 // Each container is resolved individually with Resolve() to preserve
 // positional ordering.
-func resolveContainers(resolver container.Resolver, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
+func ResolveContainers(resolver container.Resolver, pipelineSpecs map[string][]worker.ContainerSpec) (map[string][]worker.ContainerSpec, error) {
 	result := make(map[string][]worker.ContainerSpec, len(pipelineSpecs))
 	for name, specs := range pipelineSpecs {
 		if len(specs) == 0 {

--- a/cmd/osbuild-worker/jobimpl-container-resolve_test.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/osbuild/image-builder/pkg/container"
 	main "github.com/osbuild/osbuild-composer/cmd/osbuild-worker"
 	"github.com/osbuild/osbuild-composer/internal/common"
 	"github.com/osbuild/osbuild-composer/internal/worker"
@@ -283,4 +284,65 @@ func TestContainerResolveJobRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockResolver implements container.Resolver by returning a fixed digest
+// for each source, allowing tests to verify ordering without a registry.
+type mockResolver struct {
+	digests map[string]string
+}
+
+func (m *mockResolver) Add(container.SourceSpec) {}
+
+func (m *mockResolver) Finish() ([]container.Spec, error) {
+	return nil, fmt.Errorf("mockResolver: use Resolve()")
+}
+
+func (m *mockResolver) Resolve(src container.SourceSpec) (container.Spec, error) {
+	digest, ok := m.digests[src.Source]
+	if !ok {
+		return container.Spec{}, fmt.Errorf("unknown source %q", src.Source)
+	}
+	return container.Spec{
+		Source:    src.Source,
+		LocalName: src.Name,
+		Digest:    digest,
+	}, nil
+}
+
+func (m *mockResolver) ResolveAll(sources map[string][]container.SourceSpec) (map[string][]container.Spec, error) {
+	return nil, fmt.Errorf("mockResolver: use Resolve()")
+}
+
+func TestResolveContainersPreservesOrder(t *testing.T) {
+	resolver := &mockResolver{
+		digests: map[string]string{
+			"quay.io/os-tree:latest": "sha256:zzz",
+			"quay.io/payload:latest": "sha256:aaa",
+		},
+	}
+
+	pipelineSpecs := map[string][]worker.ContainerSpec{
+		"os-tree": {
+			{Source: "quay.io/os-tree:latest", Name: "quay.io/os-tree:latest"},
+			{Source: "quay.io/payload:latest", Name: "quay.io/payload:latest"},
+		},
+		"build": {
+			{Source: "quay.io/os-tree:latest", Name: "quay.io/os-tree:latest"},
+		},
+	}
+
+	result, err := main.ResolveContainers(resolver, pipelineSpecs)
+	require.NoError(t, err)
+
+	// os-tree pipeline: order must match input, not digest order
+	require.Len(t, result["os-tree"], 2)
+	assert.Equal(t, "quay.io/os-tree:latest", result["os-tree"][0].Source)
+	assert.Equal(t, "sha256:zzz", result["os-tree"][0].Digest)
+	assert.Equal(t, "quay.io/payload:latest", result["os-tree"][1].Source)
+	assert.Equal(t, "sha256:aaa", result["os-tree"][1].Digest)
+
+	// build pipeline: single entry
+	require.Len(t, result["build"], 1)
+	assert.Equal(t, "quay.io/os-tree:latest", result["build"][0].Source)
 }


### PR DESCRIPTION
container.Resolver.Finish() sorts results by digest so it's not guaranteed that it keeps the input order. However, osbuild-composer mistakenly started relying on keeping the order:

For bootc-generic-iso with an iso_payload_reference, the os-tree pipeline carries two containers. If the payload container's digest sorts before the source container's, they end up in reversed positions, causing the payload to be deployed as the OS tree and vice versa.

Fix this by switching to the new-ish Resolve() method of the resolver that does resolving synchronously. This allows us to neatly condense the 2 loops into 1 while making sure that the order is not changed.

Kudos to @lucasgarfield for discovering the bug, and to @supakeen for finding out that the container refs get somewhere swapped.