### PR TITLE
.tekton: disable git-clone symlink check

### DIFF
--- a/.tekton/osbuild-composer-maintenance-pull-request.yaml
+++ b/.tekton/osbuild-composer-maintenance-pull-request.yaml
@@ -143,6 +143,8 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enableSymlinkCheck
+        value: "false"
       runAfter:
       - init
       taskRef:

--- a/.tekton/osbuild-composer-maintenance-push.yaml
+++ b/.tekton/osbuild-composer-maintenance-push.yaml
@@ -140,6 +140,8 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enableSymlinkCheck
+        value: "false"
       runAfter:
       - init
       taskRef:

--- a/.tekton/osbuild-composer-pull-request.yaml
+++ b/.tekton/osbuild-composer-pull-request.yaml
@@ -144,6 +144,8 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enableSymlinkCheck
+        value: "false"
       runAfter:
       - init
       taskRef:

--- a/.tekton/osbuild-composer-push.yaml
+++ b/.tekton/osbuild-composer-push.yaml
@@ -134,6 +134,8 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: enableSymlinkCheck
+        value: "false"
       runAfter:
       - init
       taskRef:


### PR DESCRIPTION
The git-clone task fails on centos-stream-* symlinks. Set enableSymlinkCheck=false on the clone-repository task in all Konflux pipelines.

We are getting
```
time="2026-08-12T00:35:59Z" level=error msg="Broken symlink found: /var/workdir/source/repositories/centos-stream-10.json"
time="2026-08-12T00:35:59Z" level=error msg="Broken symlink found: /var/workdir/source/repositories/centos-stream-9.json"
```
on #5186, trying to fix it, although there will likely be more failures after we merge this.