### PR TITLE
weldr: remove repository metadata preload

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -158,9 +158,6 @@ func (c *Composer) InitWeldr(weldrListener net.Listener, distrosImageTypeDenylis
 		return err
 	}
 	c.weldrListener = weldrListener
-
-	// Preload the Metadata for all the supported distros
-	c.weldr.PreloadMetadata()
 	return nil
 }
 

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -319,36 +319,6 @@ func (api *API) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	api.router.ServeHTTP(writer, request)
 }
 
-// PreloadMetadata loads the metadata for all supported distros
-// This starts a background depsolve for all known distros in order to preload the
-// metadata.
-func (api *API) PreloadMetadata() {
-	log.Printf("Starting metadata preload goroutines")
-	for _, distro := range api.validDistros(api.hostArch) {
-		go func(distro string) {
-			startTime := time.Now()
-			d := api.getDistro(distro, api.hostArch)
-			if d == nil {
-				log.Printf("GetDistro - unknown distribution: %s", distro)
-				return
-			}
-
-			repos, err := api.allRepositories(distro, api.hostArch)
-			if err != nil {
-				log.Printf("Error getting repositories for distro %s: %s", distro, err)
-				return
-			}
-
-			solver := api.getSolver(d.ModulePlatformID(), d.Releasever(), api.hostArch, d.Name())
-			_, err = solver.Depsolve([]rpmmd.PackageSet{{Include: []string{"filesystem"}, Repositories: repos}}, sbom.StandardTypeNone)
-			if err != nil {
-				log.Printf("Problem preloading distro metadata for %s: %s", distro, err)
-			}
-			log.Printf("Finished preload of %s in %v", distro, time.Since(startTime))
-		}(distro)
-	}
-}
-
 type composeStatus struct {
 	State    ComposeState
 	Queued   time.Time


### PR DESCRIPTION
The metadata preload was done so that the repository metadata caches are ready and hot for when the first request comes in.  However, in cases where a lot of distro repositories are configured (such as when running on a newer distro that supports building all older ones, or when testing), preloading metadata from multiple distros can take very long and is mostly useless.

This is the cause of a lot of delays in starting up osbuild-composer in testing.  For example, the first depsolve tests take over 10 minutes to complete in CI because of this.

The original intent of the preloading was not bad.  The idea was that between when osbuild-composer starts and the first compose (or depsolve) is requested, it would have enough time to download the repo metadata and be ready to start building without blocking on the first request by the user.  But I think in some cases this causes more issues than it solves.

HMS-10800

This issue was also noted as a potential issue in disconnected or firewalled environments, which might raise concerns about software needlessly "phoning home" on startup.

RHEL-10640