### PR TITLE
Add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# **Reporting a Security Vulnerability or Incident**
+
+Please do not report security vulnerabilities or security incidents via public channels (such as GitHub Issues or Pull Requests, GitLab Merge Requests). To ensure coordinated disclosure, submit your findings via email to: [osbuilders@redhat.com](mailto:osbuilders@redhat.com)
+
+## **Submission Guidelines**
+
+To help us triage and resolve the issue efficiently, please include the following in your report:
+
+- **Title**: A concise, descriptive summary of the issue.
+- **Reporter Details**: Your name/handle and affiliation.
+- **Technical Description**: Detailed information regarding the vulnerability.
+- **Affected Versions**: The specific version(s) or range(s) of software tested.
+- **Reproduction Steps**: A minimal, functional example to reproduce the issue.
+- **Impact Assessment**: Potential exploit scenarios and perceived severity. (optional)
+- **Suggested Fix**: Any proposed patches or mitigations (optional).
+- **Disclosure Status**: Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
+
+## **Response Timeline**
+
+We aim to provide an initial acknowledgement of your report within 3 days.
+
+Our goal is to assess the report, coordinate fix and disclosure as quickly as possible. All confirmed security vulnerabilities and incidents will be addressed according to severity level and impact on the project.
+
+## **Contact Information**
+
+Direct all security questions and vulnerability reports to:
+
+- **Email**: [osbuilders@redhat.com](mailto:osbuilders@redhat.com)
+
+## **Security Policy**
+
+You can find the project's general vulnerability management and incident response policy at [osbuild.org/docs/security/index](https://osbuild.org/docs/security/index/).
+
+## **Supported Versions**
+
+We regularly perform patch releases for the supported latest version https://github.com/osbuild/osbuild-composer/releases, which contains fixes for relevant security vulnerabilities and important bugs. Prior releases might receive critical security fixes on a best-effort basis. However, we cannot guarantee that security fixes will get back-ported to these unsupported versions, unless stated otherwise in our support matrix https://osbuild.org/docs/on-premises/overview/release-overview/.
+
+## **EU Cyber Resilience Act — Open Source Steward Statement**
+
+This project is stewarded by **Red Hat, Inc.**, an open source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)
+
+Refer to [Red Hat's security practices and vulnerability management policy](https://access.redhat.com/security/) for detailed information.


### PR DESCRIPTION
Add guidelines for security vulnerability and incident reporting.  This is based on the template provided by Red Hat [1].  The company's CRA guidelines are also linked from the referenced ticket and are publicly available [2].

[1] https://github.com/RedHatProductSecurity/CRA/blob/main/Templates/Security_MD_template.md
[2] https://access.redhat.com/sites/hub/files/2026-06/EU%20Cyber%20Resilience%20Act%20Stewardship%20Guidelines%20for%20Red%20Hat%20Supported%20Open%20Source%20Projects_0.pdf

HMS-10902