### PR TITLE
test/cases: remove enabled services in test case

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -133,9 +133,6 @@ name = "bash"
 
 [[packages]]
 name = "cloud-init"
-
-[customizations.services]
-enabled = ["sshd", "cloud-init", "cloud-init-local", "cloud-config", "cloud-final"]
 EOF
 
 # Make sure the specified storage account exists

--- a/test/cases/openshift_virtualization.sh
+++ b/test/cases/openshift_virtualization.sh
@@ -99,9 +99,6 @@ name = "bash"
 [[packages]]
 name = "cloud-init"
 
-[customizations.services]
-enabled = ["sshd", "cloud-init", "cloud-init-local", "cloud-config", "cloud-final"]
-
 [[customizations.user]]
 name = "admin"
 description = "admin"


### PR DESCRIPTION
Test cases for azure and openshift virtualization use enabled services: sshd, cloud-init, cloud-init-llocal, cloud-config and cloud-final. These should be enabled by defaut, so there is no need to add these manually to the blueprint.