### PR TITLE
schutzbot/mockbuild: build CI RPMs with nocheck

### DIFF
--- a/schutzbot/mockbuild.sh
+++ b/schutzbot/mockbuild.sh
@@ -181,6 +181,7 @@ mock -r "$MOCK_CONFIG" \
     --define "commit ${COMMIT}" \
     --config-opts=cleanup_on_failure=False \
     --config-opts=cleanup_on_success=True \
+    --nocheck \
     --with=tests \
     ${RELAX_REQUIRES:+"$RELAX_REQUIRES"} \
     --resultdir "$REPO_DIR" \


### PR DESCRIPTION
In CI we build RPMs first for each distro we're going to test and then each job installs those RPMs to run the tests.  Running the tests on rpm build as well is redundant and makes the build take a very long time.

Building RPMs with 'nocheck' will speed up the RPM step of each pipeline, speeding up the whole GitLab CI workflow, with no test coverage reduction.