### PR TITLE
cloudapi/v2: apply user AWS tags when registering AMIs

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/osbuild/image-builder/pkg/arch"
+	ibawscloud "github.com/osbuild/image-builder/pkg/cloud/awscloud"
 	"github.com/osbuild/image-builder/pkg/cloud/azure"
 	"github.com/osbuild/image-builder/pkg/cloud/gcp"
 	"github.com/osbuild/image-builder/pkg/container"
@@ -739,7 +740,12 @@ func (impl *OSBuildJobImpl) Run(job worker.Job) error {
 				}
 			}
 
-			ami, _, err := a.Register(jobTarget.ImageName, bucket, targetOptions.Key, nil, targetOptions.ShareWithAccounts, arch.Current(), bootMode, nil)
+			var tags []ibawscloud.AWSTag
+			for _, tag := range targetOptions.Tags {
+				tags = append(tags, ibawscloud.AWSTag{Name: tag.Key, Value: tag.Value})
+			}
+
+			ami, _, err := a.Register(jobTarget.ImageName, bucket, targetOptions.Key, tags, targetOptions.ShareWithAccounts, arch.Current(), bootMode, nil)
 			if err != nil {
 				targetResult.TargetError = clienterrors.New(clienterrors.ErrorImportingImage, err.Error(), nil)
 				break

--- a/internal/cloud/awscloud/maintenance.go
+++ b/internal/cloud/awscloud/maintenance.go
@@ -10,9 +10,9 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
-// For service maintenance images are discovered by the "Name:composer-api-*" tag filter. Currently
-// all image names in the service are generated, so they're guaranteed to be unique as well. If
-// users are ever allowed to name their images, an extra tag should be added.
+// For service maintenance images are discovered by the "composer-api" tag.
+// User-chosen AMI names are stored in the Name tag; composer-api remains the
+// stable identifier for cleanup.
 func (a *AWS) DescribeImagesByTag(tagKey, tagValue string) ([]ec2types.Image, error) {
 	imgs, err := a.ec2.DescribeImages(
 		context.Background(),

--- a/internal/cloudapi/v2/imagerequest.go
+++ b/internal/cloudapi/v2/imagerequest.go
@@ -42,11 +42,22 @@ func newAWSTarget(options UploadOptions, imageType distro.ImageType) (*target.Ta
 		amiBootMode = common.ToPtr(string(ec2types.BootModeValuesLegacyBios))
 	}
 
+	var tags []target.AWSTag
+	if awsUploadOptions.Tags != nil {
+		for _, tag := range *awsUploadOptions.Tags {
+			tags = append(tags, target.AWSTag{Key: tag.Key, Value: tag.Value})
+		}
+	}
+	// Keep a stable composer-api tag so maintenance can find images even when
+	// snapshot_name / AMI Name is a user-chosen value.
+	tags = append(tags, target.AWSTag{Key: "composer-api", Value: key})
+
 	t := target.NewAWSTarget(&target.AWSTargetOptions{
 		Region:            awsUploadOptions.Region,
 		Key:               key,
 		ShareWithAccounts: awsUploadOptions.ShareWithAccounts,
 		BootMode:          amiBootMode,
+		Tags:              tags,
 	})
 	if awsUploadOptions.SnapshotName != nil {
 		t.ImageName = *awsUploadOptions.SnapshotName

--- a/internal/cloudapi/v2/imagerequest_test.go
+++ b/internal/cloudapi/v2/imagerequest_test.go
@@ -279,3 +279,38 @@ func TestGetTargets(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSTargetPreservesSnapshotNameAndTags(t *testing.T) {
+	r9 := distrofactory.NewDefault().GetDistro("rhel-9.3")
+	require.NotNil(t, r9)
+	archObj, err := r9.GetArch(arch.ARCH_X86_64.String())
+	require.NoError(t, err)
+	amiType, err := archObj.GetImageType("ami")
+	require.NoError(t, err)
+
+	var uploadOptions UploadOptions
+	require.NoError(t, uploadOptions.FromAWSEC2UploadOptions(AWSEC2UploadOptions{
+		Region:            "us-east-1",
+		ShareWithAccounts: []string{"123456789012"},
+		SnapshotName:      common.ToPtr("preferred-ami-name"),
+		Tags: &[]AWSTag{
+			{Key: "environment", Value: "production"},
+		},
+	}))
+
+	ir := ImageRequest{
+		Architecture:  arch.ARCH_X86_64.String(),
+		ImageType:     ImageTypesAws,
+		UploadOptions: &uploadOptions,
+	}
+	targets, err := ir.GetTargets(amiType)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "preferred-ami-name", targets[0].ImageName)
+	awsOpts, ok := targets[0].Options.(*target.AWSTargetOptions)
+	require.True(t, ok)
+	require.Equal(t, []target.AWSTag{
+		{Key: "environment", Value: "production"},
+		{Key: "composer-api", Value: awsOpts.Key},
+	}, awsOpts.Tags)
+}

--- a/internal/cloudapi/v2/openapi.v2.gen.go
+++ b/internal/cloudapi/v2/openapi.v2.gen.go
@@ -500,9 +500,16 @@ type AWSEC2CloneCompose struct {
 
 // AWSEC2UploadOptions defines model for AWSEC2UploadOptions.
 type AWSEC2UploadOptions struct {
-	Region            string   `json:"region"`
-	ShareWithAccounts []string `json:"share_with_accounts"`
-	SnapshotName      *string  `json:"snapshot_name,omitempty"`
+	Region            string    `json:"region"`
+	ShareWithAccounts []string  `json:"share_with_accounts"`
+	SnapshotName      *string   `json:"snapshot_name,omitempty"`
+	Tags              *[]AWSTag `json:"tags,omitempty"`
+}
+
+// AWSTag defines model for AWSTag.
+type AWSTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // AWSEC2UploadStatus defines model for AWSEC2UploadStatus.

--- a/internal/cloudapi/v2/openapi.v2.yml
+++ b/internal/cloudapi/v2/openapi.v2.yml
@@ -1796,6 +1796,24 @@ components:
           example: ['123456789012']
           items:
             type: string
+        tags:
+          type: array
+          description: Optional tags applied to the AMI and snapshot.
+          items:
+            $ref: '#/components/schemas/AWSTag'
+    AWSTag:
+      type: object
+      additionalProperties: false
+      required:
+        - key
+        - value
+      properties:
+        key:
+          type: string
+          example: 'environment'
+        value:
+          type: string
+          example: 'production'
     AWSS3UploadOptions:
       type: object
       additionalProperties: false

--- a/internal/target/aws_target.go
+++ b/internal/target/aws_target.go
@@ -13,6 +13,7 @@ type AWSTargetOptions struct {
 	Bucket            string   `json:"bucket"`
 	Key               string   `json:"key"`
 	ShareWithAccounts []string `json:"shareWithAccounts"`
+	Tags              []AWSTag `json:"tags,omitempty"`
 
 	// Boot mode of the AMI (optional)
 	// Supported values:
@@ -22,6 +23,12 @@ type AWSTargetOptions struct {
 	// If not provided, then the Boot mode will be determined by the default
 	// boot mode of the instance provisioned from the AMI.
 	BootMode *string `json:"bootMode,omitempty"`
+}
+
+// AWSTag is a key/value pair applied to the AMI and snapshot.
+type AWSTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 func (AWSTargetOptions) isTargetOptions() {}


### PR DESCRIPTION
## Remarks

When Image Builder publishes an AMI, callers can already choose the AMI name (`snapshot_name`), but any tags they send are dropped at registration. Composer only applied its own internal tags, so hosted Image Builder could not honor customer tagging on upload.

This PR threads optional user tags into `Register` so they land on the AMI and snapshot, and still sets `composer-api=<key>` so maintenance can find the image after the name is no longer composer-generated.

That is the composer half of [RHEL-123580](https://issues.redhat.com/browse/RHEL-123580), a customer-reported request open since **23 October 2025** (~10 months). Until this ships, users have to tag AMIs after the compose finishes. It should merge **before** [image-builder-crc#1883](https://github.com/osbuild/image-builder-crc/pull/1883); CRC sending `tags` against current composer OpenAPI will fail validation.

## Summary
- Accept optional AWS tags on `AWSEC2UploadOptions` and pass them through the AWS target into `Register`.
- Keep a `composer-api` tag so service maintenance can still find images when `snapshot_name` / AMI Name is user-chosen.

Related: https://issues.redhat.com/browse/RHEL-123580

## Test plan
- [ ] `TestAWSTargetPreservesSnapshotNameAndTags` passes
- [ ] AWS compose with `snapshot_name` and `tags` registers the AMI with those tags

[RHEL-123580]: https://redhat.atlassian.net/browse/RHEL-123580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ